### PR TITLE
Fixing bug in BlendTreeNodeConstant

### DIFF
--- a/AssetRipperCore/Classes/AnimatorController/Constants/BlendTreeNodeConstant.cs
+++ b/AssetRipperCore/Classes/AnimatorController/Constants/BlendTreeNodeConstant.cs
@@ -117,7 +117,7 @@ namespace AssetRipper.Core.Classes.AnimatorController.Constants
 		{
 			if (HasBlendData(version))
 			{
-				if (BlendType != BlendTreeType.Simple1D)
+				if (BlendType != BlendTreeType.Simple1D && BlendType != BlendTreeType.Direct)
 				{
 					return Blend2dData.Instance.m_ChildPositionArray[index];
 				}


### PR DESCRIPTION
BlendTrees of type Direct don't have 2D Position.