### PR TITLE
Fix for ComputeShader yaml export

### DIFF
--- a/AssetRipperCore/Classes/ComputeShader/ComputeBufferCounter.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeBufferCounter.cs
@@ -1,0 +1,27 @@
+﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+
+namespace AssetRipper.Core.Classes.ComputeShader
+{
+	public sealed class ComputeBufferCounter : IAssetReadable, IYAMLExportable
+	{
+		public void Read(AssetReader reader)
+		{
+			Bindpoint = reader.ReadInt32();
+			Offset = reader.ReadInt32();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("bindpoint", Bindpoint);
+			node.Add("offset", Offset);
+			return node;
+		}
+
+		public int Bindpoint { get; set; }
+
+		public int Offset { get; set; }
+	}
+}

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShader.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShader.cs
@@ -1,9 +1,11 @@
-﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Classes.Shader;
+using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
 using AssetRipper.Core.Parser.Asset;
 using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.Project;
 using AssetRipper.Core.YAML;
+using System.Collections.Generic;
 
 namespace AssetRipper.Core.Classes.ComputeShader
 {
@@ -11,29 +13,85 @@ namespace AssetRipper.Core.Classes.ComputeShader
 	{
 		public ComputeShader(AssetInfo assetInfo) : base(assetInfo) { }
 
-		public override string ExportExtension => AssetExtension;
-
 		public static int ToSerializedVersion(UnityVersion version)
 		{
 			return 1;
 		}
 
+		public static bool HasComputeShaderVariant(UnityVersion version) => version.IsGreaterEqual(5, 0, 0, UnityVersionType.Final, 4);
+		public static bool HasEditorOnlyVariant(UnityVersion version) => version.IsGreaterEqual(2017, 2, 0, UnityVersionType.Beta, 2) && version.IsLess(2021, 2, 0, UnityVersionType.Alpha, 19);
+		public static bool EditorOnlyVariantNewName(UnityVersion version) => version.IsGreaterEqual(2018, 1, 0, UnityVersionType.Beta, 11);
+		public static bool HasComputeShaderPlatformVariant(UnityVersion version) => version.IsGreaterEqual(2020, 1, 0, UnityVersionType.Alpha, 9);
+		public static bool HasComputeShaderCompilationContext(UnityVersion version) => version.IsGreaterEqual(2020, 1, 0, UnityVersionType.Alpha, 17);
+		public static bool HasPreprocessorOverride(UnityVersion version) => version.IsGreaterEqual(2020, 2, 0, UnityVersionType.Alpha, 7);
+
 		public override void Read(AssetReader reader)
 		{
-			Name = reader.ReadString();
-			Variants = reader.ReadAssetArray<ComputeShaderVariant>();
+			base.Read(reader);
+
+			if (HasComputeShaderPlatformVariant(reader.Version))
+			{
+				PlatformVariants = reader.ReadAssetArray<ComputeShaderPlatformVariant>();
+			}
+			else if (HasComputeShaderVariant(reader.Version))
+			{
+				Variants = reader.ReadAssetArray<ComputeShaderVariant>();
+			}
+			else
+			{
+				Kernels = reader.ReadAssetArray<ComputeShaderKernel>();
+			}
+
 			reader.AlignStream();
 		}
 
 		protected override YAMLMappingNode ExportYAMLRoot(IExportContainer container)
 		{
-			YAMLMappingNode node = new YAMLMappingNode();
-			node.AddSerializedVersion(ToSerializedVersion(container.ExportVersion));
-			node.Add("m_Name", Name);
-			node.Add("variants", Variants.ExportYAML(container));
+			YAMLMappingNode node = base.ExportYAMLRoot(container);
+			if (HasComputeShaderPlatformVariant(container.Version))
+			{
+				node.Add("variants", PlatformVariants.ExportYAML(container));
+			}
+			else if (HasComputeShaderVariant(container.Version))
+			{
+				node.Add("variants", Variants.ExportYAML(container));
+			}
+			else
+			{
+				node.Add("kernels", Kernels.ExportYAML(container));
+			}
+			//Editor-Only
+			if (HasComputeShaderCompilationContext(container.Version))
+			{
+				node.Add("m_CompilationContext", new ComputeShaderCompilationContext().ExportYAML(container));
+			}
+			node.Add("errors" , (new HashSet<ShaderError>()).ExportYAML(container));
+			if (HasPreprocessorOverride(container.Version))
+			{
+				node.Add("m_PreprocessorOverride", default(int));
+			}
+			if (HasEditorOnlyVariant(container.Version))
+			{
+				node.Add(EditorOnlyVariantNewName(container.Version) ? "m_HasEditorOnlyVariant" : "m_hasEditorOnlyVariant", false);
+			}
+
+
 			return node;
 		}
 
+		/// <summary>
+		/// Greater or equal to 5.0.0f4 and less than 2020.1.0a9
+		/// </summary>
 		public ComputeShaderVariant[] Variants { get; set; }
+
+		/// <summary>
+		/// Greater or equal to 2020.1.0a9
+		/// </summary>
+		public ComputeShaderPlatformVariant[] PlatformVariants { get; set; }
+
+		/// <summary>
+		/// Less than 5.0.0f4
+		/// </summary>
+		public ComputeShaderKernel[] Kernels { get; set; }
 	}
 }

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShaderBuiltinSampler.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShaderBuiltinSampler.cs
@@ -1,26 +1,38 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.Project;
 using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.ComputeShader
 {
-	public sealed class  ComputeShaderBuiltinSampler : IAssetReadable, IYAMLExportable
+	public sealed class ComputeShaderBuiltinSampler : IAssetReadable, IYAMLExportable
 	{
+		public static bool HaUnsignedSampler(UnityVersion version) => version.IsGreaterEqual(2017, 1, 0, UnityVersionType.Beta, 1);
+
 		public void Read(AssetReader reader)
 		{
-			Sampler = reader.ReadUInt32();
+			if (HaUnsignedSampler(reader.Version))
+			{
+				Sampler = reader.ReadUInt32();
+			}
+			else
+			{
+				SignedSampler = reader.ReadInt32();
+			}
+
 			BindPoint = reader.ReadInt32();
 		}
 
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			node.Add("sampler", Sampler);
+			node.Add("sampler", HaUnsignedSampler(container.Version) ? Sampler : SignedSampler);
 			node.Add("bindPoint", BindPoint);
 			return node;
 		}
 
 		public uint Sampler { get; set; }
+		public int SignedSampler { get; set; }
 		public int BindPoint { get; set; }
 	}
 }

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShaderCB.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShaderCB.cs
@@ -10,7 +10,7 @@ namespace AssetRipper.Core.Classes.ComputeShader
 	{
 		public void Read(AssetReader reader)
 		{
-			Name = reader.ReadString();
+			Name = reader.ReadAsset<FastPropertyName>();
 			ByteSize = reader.ReadInt32();
 			Params = reader.ReadAssetArray<ComputeShaderParam>();
 			reader.AlignStream();
@@ -19,13 +19,13 @@ namespace AssetRipper.Core.Classes.ComputeShader
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			node.Add("name", Name);
+			node.Add("name", Name.ExportYAML(container));
 			node.Add("byteSize", ByteSize);
 			node.Add("params", Params.ExportYAML(container));
 			return node;
 		}
 
-		public string Name { get; set; }
+		public FastPropertyName Name { get; set; }
 		public int ByteSize { get; set; }
 		public ComputeShaderParam[] Params { get; set; }
 	}

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShaderKernel.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShaderKernel.cs
@@ -1,16 +1,25 @@
-﻿using AssetRipper.Core.IO.Asset;
+﻿using AssetRipper.Core.Classes.Misc;
+using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.Project;
 using AssetRipper.Core.YAML;
 using AssetRipper.Core.YAML.Extensions;
+using System;
 
 namespace AssetRipper.Core.Classes.ComputeShader
 {
-	public sealed class  ComputeShaderKernel : IAssetReadable, IYAMLExportable
+	public sealed class ComputeShaderKernel : IAssetReadable, IYAMLExportable
 	{
+		public static bool HasThreadGroupSize(UnityVersion version) => version.IsGreaterEqual(5, 4, 0, UnityVersionType.Beta, 22);
+		public static bool HasPreprocessedSource(UnityVersion version) => version.IsLess(2020, 2, 0, UnityVersionType.Alpha, 15);
+		public static bool HasCacheKey(UnityVersion version) => version.IsLess(2020, 3, 2, UnityVersionType.Final, 1) ||
+		                                                        (version.IsGreaterEqual(2021, 1, 0, UnityVersionType.Alpha, 2) && version.IsLess(2021, 2, 0, UnityVersionType.Beta, 7));
+		public static bool HasRequirements(UnityVersion version) => version.IsGreaterEqual(2021, 1, 0, UnityVersionType.Alpha, 2);
+
 		public void Read(AssetReader reader)
 		{
-			Name = reader.ReadString();
+			Name = reader.ReadAsset<FastPropertyName>();
 			Cbs = reader.ReadAssetArray<ComputeShaderResource>();
 			reader.AlignStream();
 			Textures = reader.ReadAssetArray<ComputeShaderResource>();
@@ -23,24 +32,46 @@ namespace AssetRipper.Core.Classes.ComputeShader
 			reader.AlignStream();
 			Code = reader.ReadByteArray();
 			reader.AlignStream();
-			ThreadGroupSize = reader.ReadUInt32Array();
+			if (HasThreadGroupSize(reader.Version))
+			{
+				ThreadGroupSize = reader.ReadUInt32Array();
+			}
 		}
 
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			node.Add("name", Name);
+			node.Add("name", Name.ExportYAML(container));
 			node.Add("cbs", Cbs.ExportYAML(container));
 			node.Add("textures", Textures.ExportYAML(container));
 			node.Add("builtinSamplers", BuiltinSamplers.ExportYAML(container));
 			node.Add("inBuffers", InBuffers.ExportYAML(container));
 			node.Add("outBuffers", OutBuffers.ExportYAML(container));
 			node.Add("code", Code.ExportYAML());
-			node.Add("threadGroupSize", ThreadGroupSize.ExportYAML(true));
+			if (HasThreadGroupSize(container.Version))
+			{
+				node.Add("threadGroupSize", ThreadGroupSize.ExportYAML(true));
+			}
+			//Editor-only
+			if (HasPreprocessedSource(container.Version))
+			{
+				node.Add("preprocessedSource", string.Empty);
+			}
+			if (HasRequirements(container.Version))
+			{
+				node.Add("requirements", default(long));
+			}
+			node.Add("keywords", Array.Empty<string>().ExportYAML());
+			if (HasCacheKey(container.Version))
+			{
+				node.Add("cacheKey", new Hash128().ExportYAML(container));
+			}
+			node.Add("isCompiled", false);
+
 			return node;
 		}
 
-		public string Name { get; set; }
+		public FastPropertyName Name { get; set; }
 		public ComputeShaderResource[] Cbs { get; set; }
 		public ComputeShaderResource[] Textures { get; set; }
 		public ComputeShaderBuiltinSampler[] BuiltinSamplers { get; set; }

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShaderKernelParent.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShaderKernelParent.cs
@@ -1,0 +1,55 @@
+﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+using AssetRipper.Core.YAML.Extensions;
+using System.Collections.Generic;
+
+namespace AssetRipper.Core.Classes.ComputeShader
+{
+	public sealed class ComputeShaderKernelParent : IAssetReadable, IYAMLExportable
+	{
+		public static bool HasSplitedKeywords(UnityVersion version) => version.IsGreaterEqual(2020, 2, 0, UnityVersionType.Alpha, 15);
+
+		public void Read(AssetReader reader)
+		{
+			Name = reader.ReadString();
+			VariantMap = new Dictionary<string, ComputeShaderKernel>();
+			VariantMap.Read(reader);
+			if (HasSplitedKeywords(reader.Version))
+			{
+				GlobalKeywords = reader.ReadStringArray();
+				LocalKeywords = reader.ReadStringArray();
+			}
+			else
+			{
+				ValidKeywords = reader.ReadStringArray();
+			}
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("name", Name.ExportYAML());
+			node.Add("variantMap", VariantMap.ExportYAML(container));
+			if (HasSplitedKeywords(container.Version))
+			{
+				node.Add("globalKeywords", GlobalKeywords.ExportYAML());
+				node.Add("localKeywords", LocalKeywords.ExportYAML());
+			}
+			else
+			{
+				node.Add("validKeywords", ValidKeywords.ExportYAML());
+			}
+
+			return node;
+		}
+
+		public string Name { get; set; }
+		public Dictionary<string, ComputeShaderKernel> VariantMap { get; set; }
+		public string[] GlobalKeywords { get; set; }
+		public string[] LocalKeywords { get; set; }
+		public string[] ValidKeywords { get; set; }
+	}
+}

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShaderParam.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShaderParam.cs
@@ -8,7 +8,7 @@ namespace AssetRipper.Core.Classes.ComputeShader
 	{
 		public void Read(AssetReader reader)
 		{
-			Name = reader.ReadString();
+			Name = reader.ReadAsset<FastPropertyName>();
 			Type = reader.ReadInt32();
 			Offset = reader.ReadInt32();
 			ArraySize = reader.ReadInt32();
@@ -19,7 +19,7 @@ namespace AssetRipper.Core.Classes.ComputeShader
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			node.Add("name", Name);
+			node.Add("name", Name.ExportYAML(container));
 			node.Add("type", Type);
 			node.Add("offset", Offset);
 			node.Add("arraySize", ArraySize);
@@ -28,7 +28,7 @@ namespace AssetRipper.Core.Classes.ComputeShader
 			return node;
 		}
 
-		public string Name { get; set; }
+		public FastPropertyName Name { get; set; }
 		public int Type { get; set; }
 		public int Offset { get; set; }
 		public int ArraySize { get; set; }

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShaderPlatformVariant.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShaderPlatformVariant.cs
@@ -1,0 +1,64 @@
+﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+using AssetRipper.Core.YAML.Extensions;
+using System;
+
+namespace AssetRipper.Core.Classes.ComputeShader
+{
+	public sealed class ComputeShaderPlatformVariant : IAssetReadable, IYAMLExportable
+	{
+		public static bool HasKernelParent(UnityVersion version) => version.IsGreaterEqual(2020, 1, 0, UnityVersionType.Alpha, 9);
+		public static bool HasPlatformKeywords(UnityVersion version) => version.IsLess(2021, 2, 0, UnityVersionType.Alpha, 19);
+
+		public void Read(AssetReader reader)
+		{
+			TargetRenderer = reader.ReadInt32();
+			TargetLevel = reader.ReadInt32();
+			if (HasKernelParent(reader.Version))
+			{
+				KernelsParent = reader.ReadAssetArray<ComputeShaderKernelParent>();
+			}
+			else
+			{
+				Kernels = reader.ReadAssetArray<ComputeShaderKernel>();
+			}
+			reader.AlignStream();
+			ConstantBuffers = reader.ReadAssetArray<ComputeShaderCB>();
+			reader.AlignStream();
+			ResourcesResolved = reader.ReadBoolean();
+			reader.AlignStream();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("targetRenderer", TargetRenderer);
+			node.Add("targetLevel", TargetLevel);
+			node.Add("kernels", HasKernelParent(container.Version) ? KernelsParent.ExportYAML(container) : Kernels.ExportYAML(container));
+			node.Add("constantBuffers", ConstantBuffers.ExportYAML(container));
+			node.Add("resourcesResolved", ResourcesResolved);
+			//Editor-only
+			node.Add("compilerPlatform", default(int));
+			if (HasKernelParent(container.Version))
+			{
+				YAMLMappingNode fixedBitsetNode = new YAMLMappingNode();
+				node.Add("Array", Array.Empty<uint>().ExportYAML(false));
+				node.Add("platformKeywords", fixedBitsetNode);
+			}
+
+			node.Add("needsReflectionData", false);
+
+			return node;
+		}
+
+		public int TargetRenderer { get; set; }
+		public int TargetLevel { get; set; }
+		public ComputeShaderKernel[] Kernels { get; set; }
+		public ComputeShaderKernelParent[] KernelsParent { get; set; }
+		public ComputeShaderCB[] ConstantBuffers { get; set; }
+		public bool ResourcesResolved { get; set; }
+	}
+}

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShaderResource.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShaderResource.cs
@@ -1,4 +1,5 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.Project;
 using AssetRipper.Core.YAML;
 
@@ -6,29 +7,77 @@ namespace AssetRipper.Core.Classes.ComputeShader
 {
 	public sealed class  ComputeShaderResource : IAssetReadable, IYAMLExportable
 	{
+		public static bool HasGeneratedName(UnityVersion version) => version.IsGreaterEqual(5, 1, 0, UnityVersionType.Final, 3);
+
+		public static bool HasSecondaryBindPoint(UnityVersion version) => version.IsGreaterEqual(5, 1, 0, UnityVersionType.Final, 3) && version.IsLess(5, 2, 3, UnityVersionType.Final, 1);
+
+		public static bool HasComputeBufferCounter(UnityVersion version) => version.IsGreaterEqual(5, 2, 3, UnityVersionType.Final, 1) && version.IsLess(2018, 1, 0, UnityVersionType.Beta, 11);
+
+		public static bool HasSamplerBindPoint(UnityVersion version) => version.IsGreaterEqual(2018, 2, 0, UnityVersionType.Beta, 1);
+
+		public static bool HasTexDimension(UnityVersion version) => version.IsGreaterEqual(2018, 2, 0, UnityVersionType.Beta, 9);
+
+
 		public void Read(AssetReader reader)
 		{
-			Name = reader.ReadString();
-			GeneratedName = reader.ReadString();
+			Name = reader.ReadAsset<FastPropertyName>();
+			if (HasGeneratedName(reader.Version))
+			{
+				GeneratedName = reader.ReadAsset<FastPropertyName>();
+			}
 			BindPoint = reader.ReadInt32();
-			SamplerBindPoint = reader.ReadInt32();
-			TexDimension = reader.ReadInt32();
+			if (HasSecondaryBindPoint(reader.Version))
+			{
+				SecondaryBindPoint = reader.ReadInt32();
+			}
+			if (HasComputeBufferCounter(reader.Version))
+			{
+				Counter = reader.ReadAsset<ComputeBufferCounter>();
+			}
+			if (HasSamplerBindPoint(reader.Version))
+			{
+				SamplerBindPoint = reader.ReadInt32();
+			}
+			if (HasTexDimension(reader.Version))
+			{
+				TexDimension = reader.ReadInt32();
+			}
 		}
 
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			node.Add("name", Name);
-			node.Add("generatedName", GeneratedName);
+			node.Add("name", Name.ExportYAML(container));
+			if (HasGeneratedName(container.Version))
+			{
+				node.Add("generatedName", GeneratedName.ExportYAML(container));
+			}
 			node.Add("bindPoint", BindPoint);
-			node.Add("samplerBindPoint", SamplerBindPoint);
-			node.Add("texDimension", TexDimension);
+			if (HasSecondaryBindPoint(container.Version))
+			{
+				node.Add("secondaryBindPoint", SecondaryBindPoint);
+			}
+			if (HasComputeBufferCounter(container.Version))
+			{
+				node.Add("counter", Counter.ExportYAML(container));
+			}
+			if (HasSamplerBindPoint(container.Version))
+			{
+				node.Add("samplerBindPoint", SamplerBindPoint);
+			}
+			if (HasTexDimension(container.Version))
+			{
+				node.Add("texDimension", TexDimension);
+			}
+
 			return node;
 		}
 
-		public string Name { get; set; }
-		public string GeneratedName { get; set; }
+		public FastPropertyName Name { get; set; }
+		public FastPropertyName GeneratedName { get; set; }
 		public int BindPoint { get; set; }
+		public int SecondaryBindPoint { get; set; }
+		public ComputeBufferCounter Counter { get; set; }
 		public int SamplerBindPoint { get; set; }
 		public int TexDimension { get; set; }
 	}

--- a/AssetRipperCore/Classes/ComputeShader/ComputeShaderVariant.cs
+++ b/AssetRipperCore/Classes/ComputeShader/ComputeShaderVariant.cs
@@ -1,13 +1,16 @@
 ﻿using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.Project;
 using AssetRipper.Core.YAML;
 using AssetRipper.Core.YAML.Extensions;
 
 namespace AssetRipper.Core.Classes.ComputeShader
 {
-	public sealed class  ComputeShaderVariant : IAssetReadable, IYAMLExportable
+	public sealed class ComputeShaderVariant : IAssetReadable, IYAMLExportable
 	{
+		public static bool HasResourcesResolved(UnityVersion version) => version.IsGreaterEqual(5, 1, 0, UnityVersionType.Final, 3);
+
 		public void Read(AssetReader reader)
 		{
 			TargetRenderer = reader.ReadInt32();
@@ -16,8 +19,11 @@ namespace AssetRipper.Core.Classes.ComputeShader
 			reader.AlignStream();
 			ConstantBuffers = reader.ReadAssetArray<ComputeShaderCB>();
 			reader.AlignStream();
-			ResourcesResolved = reader.ReadBoolean();
-			reader.AlignStream();
+			if (HasResourcesResolved(reader.Version))
+			{
+				ResourcesResolved = reader.ReadBoolean();
+				reader.AlignStream();
+			}
 		}
 
 		public YAMLNode ExportYAML(IExportContainer container)
@@ -27,7 +33,11 @@ namespace AssetRipper.Core.Classes.ComputeShader
 			node.Add("targetLevel", TargetLevel);
 			node.Add("kernels", Kernels.ExportYAML(container));
 			node.Add("constantBuffers", ConstantBuffers.ExportYAML(container));
-			node.Add("resourcesResolved", ResourcesResolved);
+			if (HasResourcesResolved(container.Version))
+			{
+				node.Add("resourcesResolved", ResourcesResolved);
+			}
+
 			return node;
 		}
 

--- a/AssetRipperCore/Classes/ComputeShader/EditorOnly/ComputeShaderCompilationContext.cs
+++ b/AssetRipperCore/Classes/ComputeShader/EditorOnly/ComputeShaderCompilationContext.cs
@@ -1,0 +1,62 @@
+﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+using AssetRipper.Core.YAML.Extensions;
+using System;
+using System.Collections.Generic;
+
+namespace AssetRipper.Core.Classes.ComputeShader
+{
+	public sealed class ComputeShaderCompilationContext :  IYAMLExportable
+	{
+		public static bool HasIsEditor(UnityVersion version) => (version.IsGreaterEqual(2020, 2, 4, UnityVersionType.Final, 1) && version.IsLess(2021, 1, 0, UnityVersionType.Alpha, 2)) ||
+		                                                        version.IsGreaterEqual(2021, 1, 0, UnityVersionType.Alpha, 7);
+
+		public static bool HasDxcAPI(UnityVersion version) => version.IsGreaterEqual(2021, 1, 0, UnityVersionType.Alpha, 2);
+		public static bool HasApiMask(UnityVersion version) => version.IsLess(2021, 2, 0, UnityVersionType.Alpha, 8);
+		public static bool HasPlatformGroup(UnityVersion version) => version.IsGreaterEqual(2021, 2, 0, UnityVersionType.Final, 1) && version.IsLess(2022, 1, 0, UnityVersionType.Alpha, 7);
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+
+			YAMLMappingNode buildTargetNode = new YAMLMappingNode();
+			buildTargetNode.Add("platform", default(int));
+			buildTargetNode.Add("subTarget",  default(int));
+			buildTargetNode.Add("extendedPlatform",  default(int));
+			if (HasIsEditor(container.Version))
+			{
+				buildTargetNode.Add("isEditor",  default(int));
+			}
+			node.Add("buildTarget", buildTargetNode);
+
+			if (HasPlatformGroup(container.Version))
+			{
+				node.Add("platformGroup", default(int));
+			}
+			node.Add("sourceFileName", string.Empty);
+			node.Add("source", string.Empty);
+			node.Add("sourceFile", string.Empty);
+			node.Add("kernels", Array.Empty<string>().ExportYAML());
+			node.Add("kernelMacros", Array.Empty<string[]>().ExportYAML());
+			node.Add("compilationFlags", default(int));
+			if (HasApiMask(container.Version))
+			{
+				node.Add("apiMask", default(uint));
+			}
+			node.Add("supportedAPIs", default(uint));
+			if (HasDxcAPI(container.Version))
+			{
+				buildTargetNode.Add("useDxcAPIs",  default(uint));
+				buildTargetNode.Add("neverUseDxcAPIs",  default(uint));
+			}
+			node.Add("includeHash0", default(uint));
+			node.Add("includeHash1", default(uint));
+			node.Add("includeHash2", default(uint));
+			node.Add("includeHash3", default(uint));
+			node.Add("includeFiles", Array.Empty<string>().ExportYAML());
+
+			return node;
+		}
+	}
+}

--- a/AssetRipperCore/Classes/FastPropertyName.cs
+++ b/AssetRipperCore/Classes/FastPropertyName.cs
@@ -4,14 +4,14 @@ using AssetRipper.Core.Project;
 using AssetRipper.Core.Utils;
 using AssetRipper.Core.YAML;
 
-namespace AssetRipper.Core.Classes.Material
+namespace AssetRipper.Core.Classes
 {
 	public sealed class FastPropertyName : IAssetReadable, IYAMLExportable
 	{
 		/// <summary>
 		/// 2017.3 and greater
 		/// </summary>
-		private static bool IsPlainString(UnityVersion version) => version.IsGreaterEqual(2017, 3);
+		private static bool IsPlainString(UnityVersion version) => version.IsGreaterEqual(5, 6, 0, UnityVersionType.Beta, 1);
 
 		public bool IsCRC28Match(uint crc)
 		{
@@ -48,6 +48,7 @@ namespace AssetRipper.Core.Classes.Material
 			{
 				return base.ToString();
 			}
+
 			return Value;
 		}
 

--- a/AssetRipperCore/Classes/Shader/ShaderError.cs
+++ b/AssetRipperCore/Classes/Shader/ShaderError.cs
@@ -15,6 +15,10 @@ namespace AssetRipper.Core.Classes.Shader
 		/// 4.5.0 and greater
 		/// </summary>
 		public static bool HasFile(UnityVersion version) => version.IsGreaterEqual(4, 5);
+		/// <summary>
+		/// 5.5.0f3 and greater
+		/// </summary>
+		public static bool IsRuntimeError(UnityVersion version) => version.IsGreaterEqual(5, 5, 0, UnityVersionType.Final, 3);
 
 		public void Read(AssetReader reader)
 		{
@@ -37,12 +41,20 @@ namespace AssetRipper.Core.Classes.Shader
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
 			node.Add(MessageName, Message);
-			node.Add(MessageDetailsName, GetMessageDetails(container.Version));
-			node.Add(FileName, GetFile(container.Version));
-			node.Add(CompilerPlatformName, (int)CompilerPlatform);
+			if (HasMessageDetails(container.Version))
+			{
+				node.Add(MessageDetailsName, GetMessageDetails(container.Version));
+			}
+
+			if (HasFile(container.Version))
+			{
+				node.Add(FileName, GetFile(container.Version));
+				node.Add(CompilerPlatformName, (int)CompilerPlatform);
+			}
+
 			node.Add(LineName, Line);
 			node.Add(WarningName, Warning);
-			node.Add(ProgramErrorName, ProgramError);
+			node.Add(ProgramErrorName(container.Version), ProgramError);
 			return node;
 		}
 
@@ -69,6 +81,6 @@ namespace AssetRipper.Core.Classes.Shader
 		public const string CompilerPlatformName = "compilerPlatform";
 		public const string LineName = "line";
 		public const string WarningName = "warning";
-		public const string ProgramErrorName = "programError";
+		public string ProgramErrorName(UnityVersion version) => IsRuntimeError(version) ? "runtimeError" : "programError";
 	}
 }

--- a/AssetRipperCore/Parser/Asset/AssetFactory.cs
+++ b/AssetRipperCore/Parser/Asset/AssetFactory.cs
@@ -133,7 +133,7 @@ namespace AssetRipper.Core.Parser.Asset
 				ClassIDType.CompositeCollider2D => new CompositeCollider2D(assetInfo),
 				ClassIDType.EdgeCollider2D => new EdgeCollider2D(assetInfo),
 				ClassIDType.CapsuleCollider2D => new CapsuleCollider2D(assetInfo),
-				//ClassIDType.ComputeShader => new ComputeShader(assetInfo),
+				ClassIDType.ComputeShader => new ComputeShader(assetInfo),
 				ClassIDType.AnimationClip => new AnimationClip(assetInfo),
 				ClassIDType.ConstantForce => new ConstantForce(assetInfo),
 				ClassIDType.TagManager => new TagManager(assetInfo),


### PR DESCRIPTION
Should fix export from version 3.4.0 to 2021.2.X
Tested with: Subnautica (2019.2.17f1)