### PR TITLE
Make shader exportable as assets

### DIFF
--- a/AssetRipperCommon/Parser/Asset/DependencyContext.cs
+++ b/AssetRipperCommon/Parser/Asset/DependencyContext.cs
@@ -80,6 +80,17 @@ namespace AssetRipper.Core.Parser.Asset
 			}
 		}
 
+		public IEnumerable<PPtr<IUnityObjectBase>> FetchDependencies<T1, T2>(IDictionary<T1, PPtr<T2>> pointers, string name) where T2 : IUnityObjectBase
+		{
+			foreach (KeyValuePair<T1, PPtr<T2>> pointerPair in pointers)
+			{
+				if (!pointerPair.Value.IsNull)
+				{
+					yield return FetchDependency(pointerPair.Value, name);
+				}
+			}
+		}
+
 		public PPtr<IUnityObjectBase> FetchDependency<T>(PPtr<T> pointer, string name) where T : IUnityObjectBase
 		{
 			if (IsLog)

--- a/AssetRipperCore/Classes/Shader/Parameters/BufferBinding.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/BufferBinding.cs
@@ -32,7 +32,7 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			YAMLMappingNode node = new YAMLMappingNode();
 			node.Add("m_NameIndex", NameIndex);
 			node.Add("m_Index", Index);
-			if (HasArraySize(container.Version))
+			if (HasArraySize(container.ExportVersion))
 			{
 				node.Add("m_ArraySize", ArraySize);
 			}

--- a/AssetRipperCore/Classes/Shader/Parameters/ConstantBuffer.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/ConstantBuffer.cs
@@ -56,13 +56,13 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			node.Add("m_NameIndex", NameIndex);
 			node.Add("m_MatrixParams", MatrixParams.ExportYAML(container));
 			node.Add("m_VectorParams", VectorParams.ExportYAML(container));
-			if (HasStructParams(container.Version))
+			if (HasStructParams(container.ExportVersion))
 			{
 				node.Add("m_StructParams", StructParams.ExportYAML(container));
 			}
 
 			node.Add("m_Size", Size);
-			if (HasIsPartialCB(container.Version))
+			if (HasIsPartialCB(container.ExportVersion))
 			{
 				node.Add("m_IsPartialCB", IsPartialCB);
 			}

--- a/AssetRipperCore/Classes/Shader/Parameters/TextureParameter.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/TextureParameter.cs
@@ -51,7 +51,7 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			node.Add("m_Index", Index);
 			node.Add("m_SamplerIndex", SamplerIndex);
 			
-			if (HasMultiSampled(container.Version))
+			if (HasMultiSampled(container.ExportVersion))
 			{
 				node.Add("m_MultiSampled", MultiSampled);
 			}

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedPass.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedPass.cs
@@ -93,11 +93,11 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			if (HasHash(container.Version))
+			if (HasHash(container.ExportVersion))
 			{
 				node.Add("m_EditorDataHash", EditorDataHash.ExportYAML(container));
 				node.Add("m_Platforms", Platforms.ExportYAML());
-				if (!HasKeywordStateMaskInsteadOfKeywordMasks(container.Version))
+				if (!HasKeywordStateMaskInsteadOfKeywordMasks(container.ExportVersion))
 				{
 					node.Add("m_LocalKeywordMask", LocalKeywordMask.ExportYAML(false));
 					node.Add("m_GlobalKeywordMask", GlobalKeywordMask.ExportYAML(false));
@@ -113,13 +113,13 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			node.Add("progGeometry", ProgGeometry.ExportYAML(container));
 			node.Add("progHull", ProgHull.ExportYAML(container));
 			node.Add("progDomain", ProgDomain.ExportYAML(container));
-			if (HasProgRayTracing(container.Version))
+			if (HasProgRayTracing(container.ExportVersion))
 			{
 				node.Add("progRayTracing", ProgRayTracing.ExportYAML(container));
 			}
 
 			node.Add("m_HasInstancingVariant", HasInstancingVariant);
-			if (HasProceduralInstancingVariantField(container.Version))
+			if (HasProceduralInstancingVariantField(container.ExportVersion))
 			{
 				node.Add("m_HasProceduralInstancingVariant", HasProceduralInstancingVariant);
 			}
@@ -128,13 +128,13 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			node.Add("m_Name", Name);
 			node.Add("m_TextureName", TextureName);
 			node.Add("m_Tags", Tags.ExportYAML(container));
-			if (HasKeywordStateMaskInsteadOfKeywordMasks(container.Version))
+			if (HasKeywordStateMaskInsteadOfKeywordMasks(container.ExportVersion))
 			{
 				node.Add("m_SerializedKeywordStateMask", SerializedKeywordStateMask.ExportYAML(false));
 			}
 
 			// Editor Only
-			if (HasSerializedPackageRequirements(container.Version, container.Flags))
+			if (HasSerializedPackageRequirements(container.ExportVersion, container.ExportFlags))
 			{
 				node.Add("m_PackageRequirements", new SerializedPackageRequirements().ExportYAML(container));
 			}

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProgram.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProgram.cs
@@ -26,7 +26,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
 			node.Add("m_SubPrograms", SubPrograms.ExportYAML(container));
-			if (HasCommonParameters(container.Version))
+			if (HasCommonParameters(container.ExportVersion))
 			{
 				node.Add("m_CommonParameters", CommonParameters.ExportYAML(container));
 			}

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShader.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShader.cs
@@ -70,7 +70,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			YAMLMappingNode node = new YAMLMappingNode();
 			node.Add("m_PropInfo", m_PropInfo.ExportYAML(container));
 			node.Add("m_SubShaders", SubShaders.ExportYAML(container));
-			if (HasKeywordData(container.Version))
+			if (HasKeywordData(container.ExportVersion))
 			{
 				node.Add("m_KeywordNames", KeywordNames.ExportYAML());
 				node.Add("m_KeywordFlags", KeywordFlags.ExportYAML());
@@ -80,7 +80,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			node.Add("m_CustomEditorName", CustomEditorName);
 			node.Add("m_FallbackName", FallbackName);
 			node.Add("m_Dependencies", Dependencies.ExportYAML(container));
-			if (HasCustomEditorForRenderPipelines(container.Version))
+			if (HasCustomEditorForRenderPipelines(container.ExportVersion))
 			{
 				node.Add("m_CustomEditorForRenderPipelines", CustomEditorForRenderPipelines.ExportYAML(container));
 			}

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderState.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderState.cs
@@ -78,7 +78,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			node.AddSerializedVersion(ToSerializedVersion(container.Version));
+			node.AddSerializedVersion(ToSerializedVersion(container.ExportVersion));
 			node.Add("m_Name", Name);
 			node.Add("rtBlend0", RtBlend0.ExportYAML(container));
 			node.Add("rtBlend1", RtBlend1.ExportYAML(container));
@@ -89,7 +89,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			node.Add("rtBlend6", RtBlend6.ExportYAML(container));
 			node.Add("rtBlend7", RtBlend7.ExportYAML(container));
 			node.Add("rtSeparateBlend", RtSeparateBlend);
-			if (HasZClip(container.Version))
+			if (HasZClip(container.ExportVersion))
 			{
 				node.Add("zClip", ZClip.ExportYAML(container));
 			}
@@ -97,7 +97,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			node.Add("zTest", ZTest.ExportYAML(container));
 			node.Add("zWrite", ZWrite.ExportYAML(container));
 			node.Add("culling", Culling.ExportYAML(container));
-			if (HasConservative(container.Version))
+			if (HasConservative(container.ExportVersion))
 			{
 				node.Add("conservative", Conservative.ExportYAML(container));
 			}

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedSubProgram.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedSubProgram.cs
@@ -128,17 +128,17 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 		public YAMLNode ExportYAML(IExportContainer container)
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
-			node.AddSerializedVersion(ToSerializedVersion(container.Version));
+			node.AddSerializedVersion(ToSerializedVersion(container.ExportVersion));
 			node.Add("m_BlobIndex", BlobIndex);
 			node.Add("m_Channels", Channels.ExportYAML(container));
-			if (HasMergedKeywordIndices(container.Version))
+			if (HasMergedKeywordIndices(container.ExportVersion))
 			{
 				node.Add("m_KeywordIndices", GlobalKeywordIndices.ExportYAML(false));
 			}
 			else
 			{
 				node.Add("m_GlobalKeywordIndices", GlobalKeywordIndices.ExportYAML(false));
-				if (HasLocalKeywordIndices(container.Version))
+				if (HasLocalKeywordIndices(container.ExportVersion))
 				{
 					node.Add("m_LocalKeywordIndices", LocalKeywordIndices.ExportYAML(false));
 				}
@@ -146,7 +146,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 
 			node.Add("m_ShaderHardwareTier", ShaderHardwareTier);
 			node.Add("m_GpuProgramType", GpuProgramType);
-			if (HasUnifiedParameters(container.Version))
+			if (HasUnifiedParameters(container.ExportVersion))
 			{
 				node.Add("m_Parameters", Parameters.ExportYAML(container));
 			}
@@ -159,15 +159,15 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 				node.Add("m_ConstantBuffers", ConstantBuffers.ExportYAML(container));
 				node.Add("m_ConstantBufferBindings", ConstantBufferBindings.ExportYAML(container));
 				node.Add("m_UAVParams", UAVParams.ExportYAML(container));
-				if (HasSamplers(container.Version))
+				if (HasSamplers(container.ExportVersion))
 				{
 					node.Add("m_Samplers", Samplers.ExportYAML(container));
 				}
 			}
 
-			if (HasShaderRequirements(container.Version))
+			if (HasShaderRequirements(container.ExportVersion))
 			{
-				if (IsShaderRequirementsInt64(container.Version))
+				if (IsShaderRequirementsInt64(container.ExportVersion))
 					node.Add("m_ShaderRequirements", ShaderRequirements);
 				else
 					node.Add("m_ShaderRequirements", (int)ShaderRequirements);

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedSubShader.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedSubShader.cs
@@ -28,7 +28,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			node.Add("m_LOD", LOD);
 
 			// Editor Only
-			if (HasSerializedPackageRequirements(container.Version, container.Flags))
+			if (HasSerializedPackageRequirements(container.ExportVersion, container.ExportFlags))
 			{
 				node.Add("m_PackageRequirements", new SerializedPackageRequirements().ExportYAML(container));
 			}

--- a/AssetRipperCore/Classes/Shader/Shader.cs
+++ b/AssetRipperCore/Classes/Shader/Shader.cs
@@ -194,13 +194,13 @@ namespace AssetRipper.Core.Classes.Shader
 		protected override YAMLMappingNode ExportYAMLRoot(IExportContainer container)
 		{
 			YAMLMappingNode node;
-			if (IsSerialized(container.Version))
+			if (IsSerialized(container.ExportVersion))
 			{
 				node = ExportBaseYAMLRoot(container);
 				node.InsertSerializedVersion(ToSerializedVersion(container.ExportVersion));
 				node.Add("m_ParsedForm", m_ParsedForm.ExportYAML(container));
 				node.Add("platforms", Array.ConvertAll(Platforms, value => (int)value).ExportYAML(false));
-				if (IsDoubleArray(container.Version))
+				if (IsDoubleArray(container.ExportVersion))
 				{
 					node.Add("offsets", Offsets2D.ExportYAML(false));
 					node.Add("compressedLengths", CompressedLengths2D.ExportYAML(false));
@@ -220,45 +220,45 @@ namespace AssetRipper.Core.Classes.Shader
 				node = base.ExportYAMLRoot(container);
 				node.InsertSerializedVersion(ToSerializedVersion(container.ExportVersion));
 
-				if (HasBlob(container.Version))
+				if (HasBlob(container.ExportVersion))
 				{
 					node.Add("decompressedSize", DecompressedSize);
 					node.Add("m_SubProgramBlob", CompressedBlob.ExportYAML());
 				}
 			}
 
-			if (HasDependencies(container.Version))
+			if (HasDependencies(container.ExportVersion))
 			{
 				node.Add(DependenciesName, Dependencies.ExportYAML(container));
 			}
 
-			if (HasNonModifiableTextures(container.Version))
+			if (HasNonModifiableTextures(container.ExportVersion))
 			{
 				node.Add(NonModifiableTexturesName, NonModifiableTextures.ExportYAML(container));
 			}
 
-			if (HasShaderIsBaked(container.Version))
+			if (HasShaderIsBaked(container.ExportVersion))
 			{
 				node.Add("m_ShaderIsBaked", ShaderIsBaked);
 			}
 
 			//Editor-Only
-			if (HasErrors(container.Version))
+			if (HasErrors(container.ExportVersion, container.ExportFlags))
 			{
 				node.Add("errors", (new HashSet<ShaderError>()).ExportYAML(container));
 			}
 
-			if (HasDefaultTextures(container.Version))
+			if (HasDefaultTextures(container.ExportVersion, container.ExportFlags))
 			{
 				node.Add("m_DefaultTextures", (new Dictionary<string, PPtr<Texture>>()).ExportYAML(container));
 			}
 
-			if (HasCompileInfo(container.Version))
+			if (HasCompileInfo(container.ExportVersion, container.ExportFlags))
 			{
 				node.Add("m_CompileInfo", (new ShaderCompilationInfo()).ExportYAML(container));
 			}
 
-			if (HasCompileSmokeTest(container.Version))
+			if (HasCompileSmokeTest(container.ExportVersion, container.ExportFlags))
 			{
 				node.Add("m_CompileSmokeTestAfterImport", default(bool));
 			}

--- a/AssetRipperCore/Classes/Shader/Shader.cs
+++ b/AssetRipperCore/Classes/Shader/Shader.cs
@@ -7,8 +7,10 @@ using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
 using AssetRipper.Core.Layout;
 using AssetRipper.Core.Parser.Asset;
+using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.Project;
 using AssetRipper.Core.YAML;
+using AssetRipper.Core.YAML.Extensions;
 using System;
 using System.Collections.Generic;
 using UnityVersion = AssetRipper.Core.Parser.Files.UnityVersion;
@@ -63,11 +65,12 @@ namespace AssetRipper.Core.Classes.Shader
 		/// </summary>
 		public static bool HasShaderIsBaked(UnityVersion version) => version.IsGreaterEqual(4);
 		/// <summary>
-		/// 3.4.0 to 5.5.0 exclusive and Not Release
+		/// 3.4.0 to 5.5.0 as well as 2021.2.0a19 and greater while Not Release
 		/// </summary>
 		public static bool HasErrors(UnityVersion version, TransferInstructionFlags flags)
 		{
-			return !flags.IsRelease() && version.IsGreaterEqual(3, 4) && version.IsLess(5, 5);
+			return !flags.IsRelease() && ((version.IsGreaterEqual(3, 4) && version.IsLess(5, 5, 0, UnityVersionType.Final, 3)) ||
+			        (version.IsGreaterEqual(2021, 2, 0, UnityVersionType.Alpha, 19)));
 		}
 		/// <summary>
 		/// 4.2.0 and greater and Not Release
@@ -84,6 +87,10 @@ namespace AssetRipper.Core.Classes.Shader
 		/// 2019.3 and greater
 		/// </summary>
 		private static bool IsDoubleArray(UnityVersion version) => version.IsGreaterEqual(2019, 3);
+		/// <summary>
+		/// 2020.1.0b4 and greater and Not Release
+		/// </summary>
+		private static bool HasCompileSmokeTest(UnityVersion version, TransferInstructionFlags flags) => !flags.IsRelease() && version.IsGreaterEqual(2020, 1, 0, UnityVersionType.Beta, 4);
 		#endregion
 
 		public override void Read(AssetReader reader)
@@ -98,23 +105,23 @@ namespace AssetRipper.Core.Classes.Shader
 				Platforms = reader.ReadArray((t) => (GPUPlatform)t);
 				if (IsDoubleArray(reader.Version))
 				{
-					uint[][] offsets = reader.ReadUInt32ArrayArray();
-					uint[][] compressedLengths = reader.ReadUInt32ArrayArray();
-					uint[][] decompressedLengths = reader.ReadUInt32ArrayArray();
-					byte[] compressedBlob = reader.ReadByteArray();
+					Offsets2D = reader.ReadUInt32ArrayArray();
+					CompressedLengths2D = reader.ReadUInt32ArrayArray();
+					DecompressedLengths2D = reader.ReadUInt32ArrayArray();
+					CompressedBlob = reader.ReadByteArray();
 					reader.AlignStream();
 
-					UnpackSubProgramBlobs(reader.Info, offsets, compressedLengths, decompressedLengths, compressedBlob);
+					UnpackSubProgramBlobs(reader.Info, Offsets2D, CompressedLengths2D, DecompressedLengths2D, CompressedBlob);
 				}
 				else
 				{
-					uint[] offsets = reader.ReadUInt32Array();
-					uint[] compressedLengths = reader.ReadUInt32Array();
-					uint[] decompressedLengths = reader.ReadUInt32Array();
-					byte[] compressedBlob = reader.ReadByteArray();
+					Offsets1D = reader.ReadUInt32Array();
+					CompressedLengths1D = reader.ReadUInt32Array();
+					DecompressedLengths1D = reader.ReadUInt32Array();
+					CompressedBlob = reader.ReadByteArray();
 					reader.AlignStream();
 
-					UnpackSubProgramBlobs(reader.Info, offsets, compressedLengths, decompressedLengths, compressedBlob);
+					UnpackSubProgramBlobs(reader.Info, Offsets1D, CompressedLengths1D, DecompressedLengths1D, CompressedBlob);
 				}
 			}
 			else
@@ -123,11 +130,11 @@ namespace AssetRipper.Core.Classes.Shader
 
 				if (HasBlob(reader.Version))
 				{
-					uint decompressedSize = reader.ReadUInt32();
-					byte[] compressedBlob = reader.ReadByteArray();
+					DecompressedSize = reader.ReadUInt32();
+					CompressedBlob = reader.ReadByteArray();
 					reader.AlignStream();
 
-					UnpackSubProgramBlobs(reader.Info, 0, (uint)compressedBlob.Length, decompressedSize, compressedBlob);
+					UnpackSubProgramBlobs(reader.Info, 0, (uint)CompressedBlob.Length, DecompressedSize, CompressedBlob );
 				}
 
 				if (HasFallback(reader.Version))
@@ -174,11 +181,89 @@ namespace AssetRipper.Core.Classes.Shader
 					yield return asset;
 				}
 			}
+
+			if (HasNonModifiableTextures(context.Version))
+			{
+				foreach (PPtr<IUnityObjectBase> asset in context.FetchDependencies(NonModifiableTextures, NonModifiableTexturesName))
+				{
+					yield return asset;
+				}
+			}
 		}
 
 		protected override YAMLMappingNode ExportYAMLRoot(IExportContainer container)
 		{
-			throw new NotSupportedException();
+			YAMLMappingNode node;
+			if (IsSerialized(container.Version))
+			{
+				node = ExportBaseYAMLRoot(container);
+				node.InsertSerializedVersion(ToSerializedVersion(container.ExportVersion));
+				node.Add("m_ParsedForm", m_ParsedForm.ExportYAML(container));
+				node.Add("platforms", Array.ConvertAll(Platforms, value => (int)value).ExportYAML(false));
+				if (IsDoubleArray(container.Version))
+				{
+					node.Add("offsets", Offsets2D.ExportYAML(false));
+					node.Add("compressedLengths", CompressedLengths2D.ExportYAML(false));
+					node.Add("decompressedLengths", DecompressedLengths2D.ExportYAML(false));
+				}
+				else
+				{
+					node.Add("offsets", Offsets1D.ExportYAML(false));
+					node.Add("compressedLengths", CompressedLengths1D.ExportYAML(false));
+					node.Add("decompressedLengths", DecompressedLengths1D.ExportYAML(false));
+				}
+
+				node.Add("compressedBlob", CompressedBlob.ExportYAML());
+			}
+			else //Shader as TextAsset (old format)
+			{
+				node = base.ExportYAMLRoot(container);
+				node.InsertSerializedVersion(ToSerializedVersion(container.ExportVersion));
+
+				if (HasBlob(container.Version))
+				{
+					node.Add("decompressedSize", DecompressedSize);
+					node.Add("m_SubProgramBlob", CompressedBlob.ExportYAML());
+				}
+			}
+
+			if (HasDependencies(container.Version))
+			{
+				node.Add(DependenciesName, Dependencies.ExportYAML(container));
+			}
+
+			if (HasNonModifiableTextures(container.Version))
+			{
+				node.Add(NonModifiableTexturesName, NonModifiableTextures.ExportYAML(container));
+			}
+
+			if (HasShaderIsBaked(container.Version))
+			{
+				node.Add("m_ShaderIsBaked", ShaderIsBaked);
+			}
+
+			//Editor-Only
+			if (HasErrors(container.Version))
+			{
+				node.Add("errors", (new HashSet<ShaderError>()).ExportYAML(container));
+			}
+
+			if (HasDefaultTextures(container.Version))
+			{
+				node.Add("m_DefaultTextures", (new Dictionary<string, PPtr<Texture>>()).ExportYAML(container));
+			}
+
+			if (HasCompileInfo(container.Version))
+			{
+				node.Add("m_CompileInfo", (new ShaderCompilationInfo()).ExportYAML(container));
+			}
+
+			if (HasCompileSmokeTest(container.Version))
+			{
+				node.Add("m_CompileSmokeTestAfterImport", default(bool));
+			}
+
+			return node;
 		}
 
 		private void UnpackSubProgramBlobs(LayoutInfo layout, uint offset, uint compressedLength, uint decompressedLength, byte[] compressedBlob)
@@ -229,12 +314,25 @@ namespace AssetRipper.Core.Classes.Shader
 
 		public GPUPlatform[] Platforms { get; set; }
 		public ShaderSubProgramBlob[] Blobs { get; set; }
+
+		//2D arrays starting from 2019.3
+		public uint[][] Offsets2D { get; set; }
+		public uint[][] CompressedLengths2D { get; set; }
+		public uint[][] DecompressedLengths2D { get; set; }
+		//1D arrays before 2019.3
+		public uint[] Offsets1D { get; set; }
+		public uint[] CompressedLengths1D { get; set; }
+		public uint[] DecompressedLengths1D { get; set; }
+		//Not serialized
+		public uint DecompressedSize { get; set; }
+		public byte[] CompressedBlob { get; set; }
+
 		public PPtr<Shader>[] Dependencies { get; set; }
 		public Dictionary<string, PPtr<Texture>> NonModifiableTextures { get; set; }
 		public bool ShaderIsBaked { get; set; }
 
-		public const string ErrorsName = "errors";
 		public const string DependenciesName = "m_Dependencies";
+		public const string NonModifiableTexturesName = "m_NonModifiableTextures";
 
 		public SerializedShader.ISerializedShader ParsedForm => m_ParsedForm;
 		private SerializedShader.SerializedShader m_ParsedForm = new();

--- a/AssetRipperCore/Classes/Shader/ShaderCompilationInfo.cs
+++ b/AssetRipperCore/Classes/Shader/ShaderCompilationInfo.cs
@@ -32,7 +32,7 @@ namespace AssetRipper.Core.Classes.Shader
 			node.Add(SnippetsName, Snippets.ExportYAML(container));
 			node.Add(MeshComponentsFromSnippetsName, MeshComponentsFromSnippets);
 			node.Add(HasSurfaceShadersName, HasSurfaceShaders);
-			if (HasHasFixedFunctionShaders(container.Version))
+			if (HasHasFixedFunctionShaders(container.ExportVersion))
 			{
 				node.Add(HasFixedFunctionShadersName, HasFixedFunctionShaders);
 			}

--- a/AssetRipperCore/Classes/Shader/ShaderError.cs
+++ b/AssetRipperCore/Classes/Shader/ShaderError.cs
@@ -41,12 +41,12 @@ namespace AssetRipper.Core.Classes.Shader
 		{
 			YAMLMappingNode node = new YAMLMappingNode();
 			node.Add(MessageName, Message);
-			if (HasMessageDetails(container.Version))
+			if (HasMessageDetails(container.ExportVersion))
 			{
 				node.Add(MessageDetailsName, GetMessageDetails(container.Version));
 			}
 
-			if (HasFile(container.Version))
+			if (HasFile(container.ExportVersion))
 			{
 				node.Add(FileName, GetFile(container.Version));
 				node.Add(CompilerPlatformName, (int)CompilerPlatform);
@@ -54,7 +54,7 @@ namespace AssetRipper.Core.Classes.Shader
 
 			node.Add(LineName, Line);
 			node.Add(WarningName, Warning);
-			node.Add(ProgramErrorName(container.Version), ProgramError);
+			node.Add(ProgramErrorName(container.ExportVersion), ProgramError);
 			return node;
 		}
 

--- a/AssetRipperLibrary/Exporters/Shaders/YamlShaderExporter.cs
+++ b/AssetRipperLibrary/Exporters/Shaders/YamlShaderExporter.cs
@@ -1,11 +1,9 @@
 ﻿using AssetRipper.Core.Classes.Shader;
 using AssetRipper.Core.Interfaces;
 using AssetRipper.Core.Parser.Files.SerializedFiles;
-using AssetRipper.Core.Project;
 using AssetRipper.Core.Project.Collections;
 using AssetRipper.Core.Project.Exporters;
 using AssetRipper.Library.Configuration;
-using System;
 
 namespace AssetRipper.Library.Exporters.Shaders
 {
@@ -28,7 +26,6 @@ namespace AssetRipper.Library.Exporters.Shaders
 
 		public override IExportCollection CreateCollection(VirtualSerializedFile virtualFile, IUnityObjectBase asset)
 		{
-			throw new NotImplementedException("Shader export as yaml is currently not implemented.");
 			return new AssetExportCollection(this, asset, "asset");
 		}
 	}


### PR DESCRIPTION
This is a complex feature and will probably not work on every unity version as the yaml layout changed repeatedly through it's history. Furthermore the unity editor doesn't really like shaders as assets and therefor corrupts them from time to time.