### PR TITLE
Make shader components yaml exportable

### DIFF
--- a/AssetRipperCommon/YAML/Extensions/IDictionaryYAMLExtensions.cs
+++ b/AssetRipperCommon/YAML/Extensions/IDictionaryYAMLExtensions.cs
@@ -7,40 +7,48 @@ namespace AssetRipper.Core.YAML.Extensions
 	{
 		public static YAMLNode ExportYAML(this IReadOnlyDictionary<uint, string> _this)
 		{
-			YAMLMappingNode node = new YAMLMappingNode();
+			YAMLSequenceNode node = new YAMLSequenceNode(SequenceStyle.BlockCurve);
 			foreach (var kvp in _this)
 			{
-				node.Add(kvp.Key, kvp.Value);
+				YAMLMappingNode map = new YAMLMappingNode(MappingStyle.Block);
+				map.Add(kvp.Key, kvp.Value);
+				node.Add(map);
 			}
 			return node;
 		}
 
 		public static YAMLNode ExportYAML(this IReadOnlyDictionary<long, string> _this)
 		{
-			YAMLMappingNode node = new YAMLMappingNode();
+			YAMLSequenceNode node = new YAMLSequenceNode(SequenceStyle.BlockCurve);
 			foreach (var kvp in _this)
 			{
-				node.Add(kvp.Key, kvp.Value);
+				YAMLMappingNode map = new YAMLMappingNode(MappingStyle.Block);
+				map.Add(kvp.Key, kvp.Value);
+				node.Add(map);
 			}
 			return node;
 		}
 
 		public static YAMLNode ExportYAML(this IReadOnlyDictionary<string, string> _this)
 		{
-			YAMLMappingNode node = new YAMLMappingNode();
+			YAMLSequenceNode node = new YAMLSequenceNode(SequenceStyle.BlockCurve);
 			foreach (var kvp in _this)
 			{
-				node.Add(kvp.Key, kvp.Value);
+				YAMLMappingNode map = new YAMLMappingNode(MappingStyle.Block);
+				map.Add(kvp.Key, kvp.Value);
+				node.Add(map);
 			}
 			return node;
 		}
 
 		public static YAMLNode ExportYAML(this IReadOnlyDictionary<string, int> _this)
 		{
-			YAMLMappingNode node = new YAMLMappingNode();
+			YAMLSequenceNode node = new YAMLSequenceNode(SequenceStyle.BlockCurve);
 			foreach (var kvp in _this)
 			{
-				node.Add(kvp.Key, kvp.Value);
+				YAMLMappingNode map = new YAMLMappingNode(MappingStyle.Block);
+				map.Add(kvp.Key, kvp.Value);
+				node.Add(map);
 			}
 			return node;
 		}
@@ -50,7 +58,7 @@ namespace AssetRipper.Core.YAML.Extensions
 			YAMLSequenceNode node = new YAMLSequenceNode(SequenceStyle.BlockCurve);
 			foreach (var kvp in _this)
 			{
-				YAMLMappingNode map = new YAMLMappingNode();
+				YAMLMappingNode map = new YAMLMappingNode(MappingStyle.Block);
 				map.Add(kvp.Key, kvp.Value);
 				node.Add(map);
 			}

--- a/AssetRipperCommon/YAML/Extensions/IListYAMLExtensions.cs
+++ b/AssetRipperCommon/YAML/Extensions/IListYAMLExtensions.cs
@@ -14,6 +14,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				byte bvalue = unchecked((byte)(value ? 1 : 0));
 				sb.AppendHex(bvalue);
 			}
+
 			return new YAMLScalarNode(sb.ToString(), true);
 		}
 
@@ -24,6 +25,7 @@ namespace AssetRipper.Core.YAML.Extensions
 			{
 				sb.AppendHex((ushort)value);
 			}
+
 			return new YAMLScalarNode(sb.ToString(), true);
 		}
 
@@ -34,6 +36,7 @@ namespace AssetRipper.Core.YAML.Extensions
 			{
 				sb.AppendHex(value);
 			}
+
 			return new YAMLScalarNode(sb.ToString(), true);
 		}
 
@@ -46,6 +49,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					sb.AppendHex(value);
 				}
+
 				return new YAMLScalarNode(sb.ToString(), true);
 			}
 			else
@@ -55,6 +59,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					node.Add(value);
 				}
+
 				return node;
 			}
 		}
@@ -68,6 +73,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					sb.AppendHex(value);
 				}
+
 				return new YAMLScalarNode(sb.ToString(), true);
 			}
 			else
@@ -77,6 +83,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					node.Add(value);
 				}
+
 				return node;
 			}
 		}
@@ -90,6 +97,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					sb.AppendHex(value);
 				}
+
 				return new YAMLScalarNode(sb.ToString(), true);
 			}
 			else
@@ -99,8 +107,20 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					node.Add(value);
 				}
+
 				return node;
 			}
+		}
+
+		public static YAMLNode ExportYAML(this IReadOnlyList<IReadOnlyList<uint>> _this, bool isRaw)
+		{
+			YAMLSequenceNode node = new YAMLSequenceNode(SequenceStyle.Block);
+			foreach (var value in _this)
+			{
+				node.Add(value.ExportYAML(isRaw));
+			}
+
+			return node;
 		}
 
 		public static YAMLNode ExportYAML(this IReadOnlyList<int> _this, bool isRaw)
@@ -112,6 +132,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					sb.AppendHex(value);
 				}
+
 				return new YAMLScalarNode(sb.ToString(), true);
 			}
 			else
@@ -121,6 +142,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					node.Add(value);
 				}
+
 				return node;
 			}
 		}
@@ -134,6 +156,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					sb.AppendHex(value);
 				}
+
 				return new YAMLScalarNode(sb.ToString(), true);
 			}
 			else
@@ -143,6 +166,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					node.Add(value);
 				}
+
 				return node;
 			}
 		}
@@ -156,6 +180,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					sb.AppendHex(value);
 				}
+
 				return new YAMLScalarNode(sb.ToString(), true);
 			}
 			else
@@ -165,6 +190,7 @@ namespace AssetRipper.Core.YAML.Extensions
 				{
 					node.Add(value);
 				}
+
 				return node;
 			}
 		}

--- a/AssetRipperCore/Classes/Shader/Parameters/BufferBinding.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/BufferBinding.cs
@@ -1,9 +1,11 @@
 ﻿using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.Parameters
 {
-	public sealed class BufferBinding : IAssetReadable
+	public sealed class BufferBinding : IAssetReadable, IYAMLExportable
 	{
 		public BufferBinding() { }
 
@@ -23,6 +25,19 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			{
 				ArraySize = reader.ReadInt32();
 			}
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_NameIndex", NameIndex);
+			node.Add("m_Index", Index);
+			if (HasArraySize(container.Version))
+			{
+				node.Add("m_ArraySize", ArraySize);
+			}
+
+			return node;
 		}
 
 		/// <summary>

--- a/AssetRipperCore/Classes/Shader/Parameters/ConstantBuffer.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/ConstantBuffer.cs
@@ -1,9 +1,12 @@
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
 using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.Parameters
 {
-	public sealed class ConstantBuffer : IAssetReadable
+	public sealed class ConstantBuffer : IAssetReadable, IYAMLExportable
 	{
 		/// <summary>
 		/// 2017.3 and greater
@@ -38,12 +41,33 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			{
 				StructParams = reader.ReadAssetArray<StructParameter>();
 			}
+
 			Size = reader.ReadInt32();
 			if (HasIsPartialCB(reader.Version))
 			{
 				IsPartialCB = reader.ReadBoolean();
 				reader.AlignStream();
 			}
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_NameIndex", NameIndex);
+			node.Add("m_MatrixParams", MatrixParams.ExportYAML(container));
+			node.Add("m_VectorParams", VectorParams.ExportYAML(container));
+			if (HasStructParams(container.Version))
+			{
+				node.Add("m_StructParams", StructParams.ExportYAML(container));
+			}
+
+			node.Add("m_Size", Size);
+			if (HasIsPartialCB(container.Version))
+			{
+				node.Add("m_IsPartialCB", IsPartialCB);
+			}
+
+			return node;
 		}
 
 		public string Name { get; set; }

--- a/AssetRipperCore/Classes/Shader/Parameters/MatrixParameter.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/MatrixParameter.cs
@@ -1,9 +1,11 @@
 ﻿using AssetRipper.Core.Classes.Shader.Enums;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.Parameters
 {
-	public sealed class MatrixParameter : IAssetReadable
+	public sealed class MatrixParameter : IAssetReadable, IYAMLExportable
 	{
 		public MatrixParameter() { }
 
@@ -32,6 +34,17 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			RowCount = reader.ReadByte();
 			ColumnCount = 4;
 			reader.AlignStream();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_NameIndex", NameIndex);
+			node.Add("m_Index", Index);
+			node.Add("m_ArraySize", ArraySize);
+			node.Add("m_Type", (byte)Type);
+			node.Add("m_RowCount", RowCount);
+			return node;
 		}
 
 		public string Name { get; set; }

--- a/AssetRipperCore/Classes/Shader/Parameters/SamplerParameter.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/SamplerParameter.cs
@@ -1,8 +1,11 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+using System.IO;
 
 namespace AssetRipper.Core.Classes.Shader.Parameters
 {
-	public sealed class SamplerParameter : IAssetReadable
+	public sealed class SamplerParameter : IAssetReadable, IYAMLExportable
 	{
 		public SamplerParameter() { }
 
@@ -16,6 +19,14 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 		{
 			Sampler = reader.ReadUInt32();
 			BindPoint = reader.ReadInt32();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("sampler", Sampler);
+			node.Add("bindPoint", BindPoint);
+			return node;
 		}
 
 		public uint Sampler { get; set; }

--- a/AssetRipperCore/Classes/Shader/Parameters/StructParameter.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/StructParameter.cs
@@ -1,8 +1,11 @@
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.Parameters
 {
-	public sealed class StructParameter : IAssetReadable
+	public sealed class StructParameter : IAssetReadable, IYAMLExportable
 	{
 		public StructParameter() { }
 
@@ -27,6 +30,18 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			reader.AlignStream();
 			MatrixMembers = reader.ReadAssetArray<MatrixParameter>();
 			reader.AlignStream();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_NameIndex", NameIndex);
+			node.Add("m_Index", Index);
+			node.Add("m_ArraySize", ArraySize);
+			node.Add("m_StructSize", StructSize);
+			node.Add("m_VectorMembers", VectorMembers.ExportYAML(container));
+			node.Add("m_MatrixMembers", MatrixMembers.ExportYAML(container));
+			return node;
 		}
 
 		public string Name { get; set; }

--- a/AssetRipperCore/Classes/Shader/Parameters/TextureParameter.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/TextureParameter.cs
@@ -1,9 +1,11 @@
-﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.Parameters
 {
-	public sealed class TextureParameter : IAssetReadable
+	public sealed class TextureParameter : IAssetReadable, IYAMLExportable
 	{
 		/// <summary>
 		/// 2017.3 and greater
@@ -37,8 +39,25 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			{
 				MultiSampled = reader.ReadBoolean();
 			}
+
 			Dim = reader.ReadByte();
 			reader.AlignStream();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_NameIndex", NameIndex);
+			node.Add("m_Index", Index);
+			node.Add("m_SamplerIndex", SamplerIndex);
+			
+			if (HasMultiSampled(container.Version))
+			{
+				node.Add("m_MultiSampled", MultiSampled);
+			}
+
+			node.Add("m_Dim", Dim);
+			return node;
 		}
 
 		public string Name { get; set; }

--- a/AssetRipperCore/Classes/Shader/Parameters/UAVParameter.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/UAVParameter.cs
@@ -1,8 +1,10 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.Parameters
 {
-	public sealed class UAVParameter : IAssetReadable
+	public sealed class UAVParameter : IAssetReadable, IYAMLExportable
 	{
 		public UAVParameter() { }
 
@@ -19,6 +21,15 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			NameIndex = reader.ReadInt32();
 			Index = reader.ReadInt32();
 			OriginalIndex = reader.ReadInt32();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_NameIndex", NameIndex);
+			node.Add("m_Index", Index);
+			node.Add("m_OriginalIndex", OriginalIndex);
+			return node;
 		}
 
 		public string Name { get; set; }

--- a/AssetRipperCore/Classes/Shader/Parameters/VectorParameter.cs
+++ b/AssetRipperCore/Classes/Shader/Parameters/VectorParameter.cs
@@ -1,9 +1,11 @@
 ﻿using AssetRipper.Core.Classes.Shader.Enums;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.Parameters
 {
-	public sealed class VectorParameter : IAssetReadable
+	public sealed class VectorParameter : IAssetReadable, IYAMLExportable
 	{
 		public VectorParameter() { }
 
@@ -30,6 +32,17 @@ namespace AssetRipper.Core.Classes.Shader.Parameters
 			Type = (ShaderParamType)reader.ReadByte();
 			Dim = reader.ReadByte();
 			reader.AlignStream();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_NameIndex", NameIndex);
+			node.Add("m_Index", Index);
+			node.Add("m_ArraySize", ArraySize);
+			node.Add("m_Type", (byte)Type);
+			node.Add("m_Dim", Dim);
+			return node;
 		}
 
 		public string Name { get; set; }

--- a/AssetRipperCore/Classes/Shader/ParserBindChannels.cs
+++ b/AssetRipperCore/Classes/Shader/ParserBindChannels.cs
@@ -1,8 +1,11 @@
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader
 {
-	public sealed class ParserBindChannels : IAssetReadable
+	public sealed class ParserBindChannels : IAssetReadable, IYAMLExportable
 	{
 		public ParserBindChannels() { }
 
@@ -17,6 +20,14 @@ namespace AssetRipper.Core.Classes.Shader
 			Channels = reader.ReadAssetArray<ShaderBindChannel>();
 			reader.AlignStream();
 			SourceMap = reader.ReadInt32();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_Channels", Channels.ExportYAML(container));
+			node.Add("m_SourceMap", SourceMap);
+			return node;
 		}
 
 		public ShaderBindChannel[] Channels { get; set; }

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedCustomEditorForRenderPipeline.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedCustomEditorForRenderPipeline.cs
@@ -1,17 +1,27 @@
 ﻿using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedCustomEditorForRenderPipeline : IAssetReadable
+	public sealed class SerializedCustomEditorForRenderPipeline : IAssetReadable, IYAMLExportable
 	{
-		public string customEditorName { get; set; }
-		public string renderPipelineType { get; set; }
+		public string CustomEditorName { get; set; }
+		public string RenderPipelineType { get; set; }
 
 		public void Read(AssetReader reader)
 		{
-			customEditorName = reader.ReadAlignedString();
-			renderPipelineType = reader.ReadAlignedString();
+			CustomEditorName = reader.ReadAlignedString();
+			RenderPipelineType = reader.ReadAlignedString();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("customEditorName", CustomEditorName);
+			node.Add("renderPipelineType", RenderPipelineType);
+			return node;
 		}
 	}
 }

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedPackageRequirements.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedPackageRequirements.cs
@@ -1,0 +1,21 @@
+﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+using AssetRipper.Core.YAML.Extensions;
+using System;
+
+namespace AssetRipper.Core.Classes.Shader.SerializedShader
+{
+	public sealed class SerializedPackageRequirements : IYAMLExportable
+	{
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_Requirements", Array.Empty<string>().ExportYAML()); // As we have an empty array we don't need to use SerializedPackageRequirement
+			node.Add("m_StatusMessage", default(string));
+			node.Add("m_CombinedStatus", default(sbyte));
+			return node;
+		}
+	}
+}

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedPass.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedPass.cs
@@ -2,26 +2,42 @@ using AssetRipper.Core.Classes.Misc;
 using AssetRipper.Core.Classes.Shader.SerializedShader.Enum;
 using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+using AssetRipper.Core.YAML.Extensions;
 using System.Collections.Generic;
 using UnityVersion = AssetRipper.Core.Parser.Files.UnityVersion;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedPass : IAssetReadable
+	public sealed class SerializedPass : IAssetReadable, IYAMLExportable
 	{
 		/// <summary>
 		/// 2020.2 and greater
 		/// </summary>
 		public static bool HasHash(UnityVersion version) => version.IsGreaterEqual(2020, 2);
+
 		/// <summary>
 		/// 2019.3 and greater
 		/// </summary>
 		public static bool HasProgRayTracing(UnityVersion version) => version.IsGreaterEqual(2019, 3);
 
 		/// <summary>
-		/// 2021.2 and greater
+		/// 2021.2.0a16 and greater
 		/// </summary>
-		public static bool HasKeywordStateMaskInsteadOfKeywordMasks(UnityVersion version) => version.IsGreaterEqual(2021, 2);
+		public static bool HasKeywordStateMaskInsteadOfKeywordMasks(UnityVersion version) => version.IsGreaterEqual(2021, 2, 0, UnityVersionType.Alpha, 16);
+
+		/// <summary>
+		/// 2018.1.0b11 and greater
+		/// </summary>
+		public static bool HasProceduralInstancingVariantField(UnityVersion version) => version.IsGreaterEqual(2018, 1, 0, UnityVersionType.Alpha, 11);
+
+		/// <summary>
+		/// 2021.2.0a17 and greater and Not Release
+		/// </summary>
+		private static bool HasSerializedPackageRequirements(UnityVersion version, TransferInstructionFlags flags) => !flags.IsRelease() && version.IsGreaterEqual(2021, 2, 0, UnityVersionType.Alpha, 17);
+
 
 		public void Read(AssetReader reader)
 		{
@@ -55,7 +71,12 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			{
 				ProgRayTracing.Read(reader);
 			}
+
 			HasInstancingVariant = reader.ReadBoolean();
+			if (HasProceduralInstancingVariantField(reader.Version))
+			{
+				HasProceduralInstancingVariant = reader.ReadBoolean();
+			}
 			reader.AlignStream();
 
 			UseName = reader.ReadString();
@@ -65,8 +86,60 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 
 			if (HasKeywordStateMaskInsteadOfKeywordMasks(reader.Version))
 			{
-				reader.ReadUInt16Array(); //m_SerializedKeywordStateMask
+				SerializedKeywordStateMask = reader.ReadUInt16Array();
 			}
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			if (HasHash(container.Version))
+			{
+				node.Add("m_EditorDataHash", EditorDataHash.ExportYAML(container));
+				node.Add("m_Platforms", Platforms.ExportYAML());
+				if (!HasKeywordStateMaskInsteadOfKeywordMasks(container.Version))
+				{
+					node.Add("m_LocalKeywordMask", LocalKeywordMask.ExportYAML(false));
+					node.Add("m_GlobalKeywordMask", GlobalKeywordMask.ExportYAML(false));
+				}
+			}
+
+			node.Add("m_NameIndices", NameIndices.ExportYAML());
+			node.Add("m_Type", (int)Type);
+			node.Add("m_State", State.ExportYAML(container));
+			node.Add("m_ProgramMask", ProgramMask);
+			node.Add("progVertex", ProgVertex.ExportYAML(container));
+			node.Add("progFragment", ProgFragment.ExportYAML(container));
+			node.Add("progGeometry", ProgGeometry.ExportYAML(container));
+			node.Add("progHull", ProgHull.ExportYAML(container));
+			node.Add("progDomain", ProgDomain.ExportYAML(container));
+			if (HasProgRayTracing(container.Version))
+			{
+				node.Add("progRayTracing", ProgRayTracing.ExportYAML(container));
+			}
+
+			node.Add("m_HasInstancingVariant", HasInstancingVariant);
+			if (HasProceduralInstancingVariantField(container.Version))
+			{
+				node.Add("m_HasProceduralInstancingVariant", HasProceduralInstancingVariant);
+			}
+
+			node.Add("m_UseName", UseName);
+			node.Add("m_Name", Name);
+			node.Add("m_TextureName", TextureName);
+			node.Add("m_Tags", Tags.ExportYAML(container));
+			if (HasKeywordStateMaskInsteadOfKeywordMasks(container.Version))
+			{
+				node.Add("m_SerializedKeywordStateMask", SerializedKeywordStateMask.ExportYAML(false));
+			}
+
+			// Editor Only
+			if (HasSerializedPackageRequirements(container.Version, container.Flags))
+			{
+				node.Add("m_PackageRequirements", new SerializedPackageRequirements().ExportYAML(container));
+			}
+
+			return node;
 		}
 
 		public Hash128[] EditorDataHash { get; set; }
@@ -77,9 +150,11 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 		public SerializedPassType Type { get; set; }
 		public uint ProgramMask { get; set; }
 		public bool HasInstancingVariant { get; set; }
+		public bool HasProceduralInstancingVariant { get; set; }
 		public string UseName { get; set; }
 		public string Name { get; set; }
 		public string TextureName { get; set; }
+		public ushort[] SerializedKeywordStateMask { get; set; }
 
 		public SerializedShaderState State = new();
 		public SerializedProgram ProgVertex = new();

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProgram.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProgram.cs
@@ -1,9 +1,12 @@
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
 using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedProgram : IAssetReadable
+	public sealed class SerializedProgram : IAssetReadable, IYAMLExportable
 	{
 		/// <summary>
 		/// 2020.3.2 and greater
@@ -19,6 +22,18 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			}
 		}
 
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_SubPrograms", SubPrograms.ExportYAML(container));
+			if (HasCommonParameters(container.Version))
+			{
+				node.Add("m_CommonParameters", CommonParameters.ExportYAML(container));
+			}
+
+			return node;
+		}
+
 		public int GetTierCount()
 		{
 			int tierCount = 1;
@@ -32,6 +47,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 
 				tierCount++;
 			}
+
 			return tierCount;
 		}
 

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProgramParameters.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProgramParameters.cs
@@ -1,9 +1,12 @@
 ﻿using AssetRipper.Core.Classes.Shader.Parameters;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedProgramParameters : IAssetReadable
+	public sealed class SerializedProgramParameters : IAssetReadable, IYAMLExportable
 	{
 		public VectorParameter[] VectorParams { get; set; }
 		public MatrixParameter[] MatrixParams { get; set; }
@@ -24,6 +27,20 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			ConstantBufferBindings = reader.ReadAssetArray<BufferBinding>();
 			UAVParams = reader.ReadAssetArray<UAVParameter>();
 			Samplers = reader.ReadAssetArray<SamplerParameter>();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_VectorParams", VectorParams.ExportYAML(container));
+			node.Add("m_MatrixParams", MatrixParams.ExportYAML(container));
+			node.Add("m_TextureParams", TextureParams.ExportYAML(container));
+			node.Add("m_BufferParams", BufferParams.ExportYAML(container));
+			node.Add("m_ConstantBuffers", ConstantBuffers.ExportYAML(container));
+			node.Add("m_ConstantBufferBindings", ConstantBufferBindings.ExportYAML(container));
+			node.Add("m_UAVParams", UAVParams.ExportYAML(container));
+			node.Add("m_Samplers", Samplers.ExportYAML(container));
+			return node;
 		}
 	}
 }

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProperties.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProperties.cs
@@ -1,12 +1,22 @@
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedProperties : IAssetReadable, ISerializedProperties
+	public sealed class SerializedProperties : IAssetReadable, ISerializedProperties, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
 			m_Props = reader.ReadAssetArray<SerializedProperty>();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_Props", m_Props.ExportYAML(container));
+			return node;
 		}
 
 		private SerializedProperty[] m_Props;

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProperty.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedProperty.cs
@@ -1,9 +1,12 @@
 using AssetRipper.Core.Classes.Shader.SerializedShader.Enum;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedProperty : IAssetReadable, ISerializedProperty
+	public sealed class SerializedProperty : IAssetReadable, ISerializedProperty, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
@@ -17,6 +20,22 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			DefValue2 = reader.ReadSingle();
 			DefValue3 = reader.ReadSingle();
 			m_DefTexture.Read(reader);
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_Name", Name);
+			node.Add("m_Description", Description);
+			node.Add("m_Attributes", Attributes.ExportYAML(container));
+			node.Add("m_Type", (int)Type);
+			node.Add("m_Flags", (uint)Flags);
+			node.Add("m_DefValue[0]", DefValue0);
+			node.Add("m_DefValue[1]", DefValue1);
+			node.Add("m_DefValue[2]", DefValue2);
+			node.Add("m_DefValue[3]", DefValue3);
+			node.Add("m_DefTexture", m_DefTexture.ExportYAML(container));
+			return node;
 		}
 
 		public string Name { get; set; }

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderDependency.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderDependency.cs
@@ -1,13 +1,23 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedShaderDependency : IAssetReadable
+	public sealed class SerializedShaderDependency : IAssetReadable, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
 			From = reader.ReadString();
 			To = reader.ReadString();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("from", From);
+			node.Add("to", To);
+			return node;
 		}
 
 		public string From { get; set; }

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderFloatValue.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderFloatValue.cs
@@ -1,13 +1,23 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedShaderFloatValue : IAssetReadable
+	public sealed class SerializedShaderFloatValue : IAssetReadable, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
 			Val = reader.ReadSingle();
 			Name = reader.ReadString();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("val", Val);
+			node.Add("name", Name);
+			return node;
 		}
 
 		public bool IsZero => Val == 0.0f;

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderRTBlendState.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderRTBlendState.cs
@@ -1,9 +1,11 @@
 using AssetRipper.Core.Classes.Shader.SerializedShader.Enum;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedShaderRTBlendState : IAssetReadable
+	public sealed class SerializedShaderRTBlendState : IAssetReadable, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
@@ -23,6 +25,19 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 		public SerializedShaderFloatValue BlendOp = new();
 		public SerializedShaderFloatValue BlendOpAlpha = new();
 		public SerializedShaderFloatValue ColMask = new();
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("srcBlend", SrcBlend.ExportYAML(container));
+			node.Add("destBlend", DestBlend.ExportYAML(container));
+			node.Add("srcBlendAlpha", SrcBlendAlpha.ExportYAML(container));
+			node.Add("destBlendAlpha", DestBlendAlpha.ExportYAML(container));
+			node.Add("blendOp", BlendOp.ExportYAML(container));
+			node.Add("blendOpAlpha", BlendOpAlpha.ExportYAML(container));
+			node.Add("colMask", ColMask.ExportYAML(container));
+			return node;
+		}
 
 		public BlendMode SrcBlendValue => (BlendMode)SrcBlend.Val;
 		public BlendMode DestBlendValue => (BlendMode)DestBlend.Val;

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderState.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderState.cs
@@ -1,15 +1,26 @@
 using AssetRipper.Core.Classes.Shader.SerializedShader.Enum;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
 using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedShaderState : IAssetReadable
+	public sealed class SerializedShaderState : IAssetReadable, IYAMLExportable
 	{
+		public static int ToSerializedVersion(UnityVersion version)
+		{
+#warning TODO:
+			return 2;
+			// return 1;
+		}
+
 		/// <summary>
 		/// 2017.2 and greater
 		/// </summary>
 		public static bool HasZClip(UnityVersion version) => version.IsGreaterEqual(2017, 2);
+
 		/// <summary>
 		/// 2020 and greater
 		/// </summary>
@@ -33,6 +44,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			{
 				ZClip.Read(reader);
 			}
+
 			ZTest.Read(reader);
 			ZWrite.Read(reader);
 			Culling.Read(reader);
@@ -40,6 +52,7 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			{
 				Conservative.Read(reader);
 			}
+
 			OffsetFactor.Read(reader);
 			OffsetUnits.Read(reader);
 			AlphaToMask.Read(reader);
@@ -60,6 +73,54 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			LOD = reader.ReadInt32();
 			Lighting = reader.ReadBoolean();
 			reader.AlignStream();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.AddSerializedVersion(ToSerializedVersion(container.Version));
+			node.Add("m_Name", Name);
+			node.Add("rtBlend0", RtBlend0.ExportYAML(container));
+			node.Add("rtBlend1", RtBlend1.ExportYAML(container));
+			node.Add("rtBlend2", RtBlend2.ExportYAML(container));
+			node.Add("rtBlend3", RtBlend3.ExportYAML(container));
+			node.Add("rtBlend4", RtBlend4.ExportYAML(container));
+			node.Add("rtBlend5", RtBlend5.ExportYAML(container));
+			node.Add("rtBlend6", RtBlend6.ExportYAML(container));
+			node.Add("rtBlend7", RtBlend7.ExportYAML(container));
+			node.Add("rtSeparateBlend", RtSeparateBlend);
+			if (HasZClip(container.Version))
+			{
+				node.Add("zClip", ZClip.ExportYAML(container));
+			}
+
+			node.Add("zTest", ZTest.ExportYAML(container));
+			node.Add("zWrite", ZWrite.ExportYAML(container));
+			node.Add("culling", Culling.ExportYAML(container));
+			if (HasConservative(container.Version))
+			{
+				node.Add("conservative", Conservative.ExportYAML(container));
+			}
+
+			node.Add("offsetFactor", OffsetFactor.ExportYAML(container));
+			node.Add("offsetUnits", OffsetUnits.ExportYAML(container));
+			node.Add("alphaToMask", AlphaToMask.ExportYAML(container));
+			node.Add("stencilOp", StencilOp.ExportYAML(container));
+			node.Add("stencilOpFront", StencilOpFront.ExportYAML(container));
+			node.Add("stencilOpBack", StencilOpBack.ExportYAML(container));
+			node.Add("stencilReadMask", StencilReadMask.ExportYAML(container));
+			node.Add("stencilWriteMask", StencilWriteMask.ExportYAML(container));
+			node.Add("stencilRef", StencilRef.ExportYAML(container));
+			node.Add("fogStart", FogStart.ExportYAML(container));
+			node.Add("fogEnd", FogEnd.ExportYAML(container));
+			node.Add("fogDensity", FogDensity.ExportYAML(container));
+			node.Add("fogColor", FogColor.ExportYAML(container));
+			node.Add("fogMode", (int)FogMode);
+			node.Add("gpuProgramID", GpuProgramID);
+			node.Add("m_Tags", Tags.ExportYAML(container));
+			node.Add("m_LOD", LOD);
+			node.Add("lighting", Lighting);
+			return node;
 		}
 
 		public string Name { get; set; }

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderVectorValue.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedShaderVectorValue.cs
@@ -1,8 +1,10 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedShaderVectorValue : IAssetReadable
+	public sealed class SerializedShaderVectorValue : IAssetReadable, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
@@ -11,6 +13,17 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			Z.Read(reader);
 			W.Read(reader);
 			Name = reader.ReadString();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("x", X.ExportYAML(container));
+			node.Add("y", Y.ExportYAML(container));
+			node.Add("z", Z.ExportYAML(container));
+			node.Add("w", W.ExportYAML(container));
+			node.Add("name", Name);
+			return node;
 		}
 
 		public bool IsZero => X.IsZero && Y.IsZero && Z.IsZero && W.IsZero;

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedStencilOp.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedStencilOp.cs
@@ -1,9 +1,11 @@
 using AssetRipper.Core.Classes.Shader.SerializedShader.Enum;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedStencilOp : IAssetReadable
+	public sealed class SerializedStencilOp : IAssetReadable, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
@@ -11,6 +13,16 @@ namespace AssetRipper.Core.Classes.Shader.SerializedShader
 			Fail.Read(reader);
 			ZFail.Read(reader);
 			Comp.Read(reader);
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("pass", Pass.ExportYAML(container));
+			node.Add("fail", Fail.ExportYAML(container));
+			node.Add("zFail", ZFail.ExportYAML(container));
+			node.Add("comp", Comp.ExportYAML(container));
+			return node;
 		}
 
 		public bool IsDefault => PassValue.IsKeep() && FailValue.IsKeep() && ZFailValue.IsKeep() && CompValue.IsAlways();

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedSubShader.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedSubShader.cs
@@ -1,14 +1,38 @@
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Parser.Files;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedSubShader : IAssetReadable
+	public sealed class SerializedSubShader : IAssetReadable, IYAMLExportable
 	{
+		/// <summary>
+		/// 2021.2.0a17 and greater and Not Release
+		/// </summary>
+		private static bool HasSerializedPackageRequirements(UnityVersion version, TransferInstructionFlags flags) => !flags.IsRelease() && version.IsGreaterEqual(2021, 2, 0, UnityVersionType.Alpha, 17);
+
 		public void Read(AssetReader reader)
 		{
 			Passes = reader.ReadAssetArray<SerializedPass>();
 			Tags.Read(reader);
 			LOD = reader.ReadInt32();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_Passes", Passes.ExportYAML(container));
+			node.Add("m_Tags", Tags.ExportYAML(container));
+			node.Add("m_LOD", LOD);
+
+			// Editor Only
+			if (HasSerializedPackageRequirements(container.Version, container.Flags))
+			{
+				node.Add("m_PackageRequirements", new SerializedPackageRequirements().ExportYAML(container));
+			}
+			return node;
 		}
 
 		public SerializedPass[] Passes { get; set; }

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedTagMap.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedTagMap.cs
@@ -1,20 +1,28 @@
 using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.IO.Extensions;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
+using AssetRipper.Core.YAML.Extensions;
 using System.Collections.Generic;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedTagMap : IAssetReadable
+	public sealed class SerializedTagMap : IAssetReadable, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
 			m_tags = new Dictionary<string, string>();
-
 			m_tags.Read(reader);
 		}
 
-		public IReadOnlyDictionary<string, string> Tags => m_tags;
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("tags", m_tags.ExportYAML());
+			return node;
+		}
 
+		public IReadOnlyDictionary<string, string> Tags => m_tags;
 		private Dictionary<string, string> m_tags;
 	}
 }

--- a/AssetRipperCore/Classes/Shader/SerializedShader/SerializedTextureProperty.cs
+++ b/AssetRipperCore/Classes/Shader/SerializedShader/SerializedTextureProperty.cs
@@ -1,13 +1,23 @@
 ﻿using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader.SerializedShader
 {
-	public sealed class SerializedTextureProperty : IAssetReadable, ISerializedTextureProperty
+	public sealed class SerializedTextureProperty : IAssetReadable, ISerializedTextureProperty, IYAMLExportable
 	{
 		public void Read(AssetReader reader)
 		{
 			DefaultName = reader.ReadString();
 			TexDim = reader.ReadInt32();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("m_DefaultName", DefaultName);
+			node.Add("m_TexDim", TexDim);
+			return node;
 		}
 
 		public string DefaultName { get; set; }

--- a/AssetRipperCore/Classes/Shader/ShaderBindChannel.cs
+++ b/AssetRipperCore/Classes/Shader/ShaderBindChannel.cs
@@ -1,9 +1,11 @@
-﻿using AssetRipper.Core.Classes.Shader.Enums;
+using AssetRipper.Core.Classes.Shader.Enums;
 using AssetRipper.Core.IO.Asset;
+using AssetRipper.Core.Project;
+using AssetRipper.Core.YAML;
 
 namespace AssetRipper.Core.Classes.Shader
 {
-	public sealed class ShaderBindChannel : IAssetReadable
+	public sealed class ShaderBindChannel : IAssetReadable, IYAMLExportable
 	{
 		public ShaderBindChannel() { }
 
@@ -17,6 +19,14 @@ namespace AssetRipper.Core.Classes.Shader
 		{
 			Source = reader.ReadByte();
 			Target = (VertexComponent)reader.ReadByte();
+		}
+
+		public YAMLNode ExportYAML(IExportContainer container)
+		{
+			YAMLMappingNode node = new YAMLMappingNode();
+			node.Add("source", Source);
+			node.Add("target", (byte)Target);
+			return node;
 		}
 
 		/// <summary>

--- a/AssetRipperCore/Classes/Shader/ShaderCompilationInfo.cs
+++ b/AssetRipperCore/Classes/Shader/ShaderCompilationInfo.cs
@@ -32,7 +32,11 @@ namespace AssetRipper.Core.Classes.Shader
 			node.Add(SnippetsName, Snippets.ExportYAML(container));
 			node.Add(MeshComponentsFromSnippetsName, MeshComponentsFromSnippets);
 			node.Add(HasSurfaceShadersName, HasSurfaceShaders);
-			node.Add(HasFixedFunctionShadersName, HasFixedFunctionShaders);
+			if (HasHasFixedFunctionShaders(container.Version))
+			{
+				node.Add(HasFixedFunctionShadersName, HasFixedFunctionShaders);
+			}
+
 			return node;
 		}
 


### PR DESCRIPTION
As discussed this pr makes all "components/child properties" of `Shader.cs` yaml exportable but not itself 