### PR TITLE
Changed SpriteMeshType default value to FullRect

### DIFF
--- a/AssetRipperLibrary/Exporters/Textures/TextureExportCollection.cs
+++ b/AssetRipperLibrary/Exporters/Textures/TextureExportCollection.cs
@@ -109,7 +109,7 @@ namespace AssetRipper.Library.Exporters.Textures
 			{
 				importer.SpriteMode = SpriteImportMode.Single;
 				importer.SpriteExtrude = 1;
-				importer.SpriteMeshType = SpriteMeshType.Tight;
+				importer.SpriteMeshType = SpriteMeshType.FullRect;
 				importer.Alignment = SpriteAlignment.Center;
 				importer.SpritePivot = new Vector2f(0.5f, 0.5f);
 				importer.SpriteBorder = new();


### PR DESCRIPTION
This is to discussion as it's a matter of preference and generalization.
In my opinion `SpriteMeshType.FullRect` is the more used option by developers. While Subnautica sprites seems to be fixed with this change I am looking forward with results from other games.