### PR TITLE
Fix Multidimensional Arrays/Lists in Serialization

### DIFF
--- a/AssetRipper.Fundamentals/Structure/Assembly/Serializable/SerializableType.cs
+++ b/AssetRipper.Fundamentals/Structure/Assembly/Serializable/SerializableType.cs
@@ -113,7 +113,7 @@ namespace AssetRipper.Core.Structure.Assembly.Serializable
 		public string Name { get; }
 		public SerializableType? Base { get; protected set; }
 		public IReadOnlyList<Field> Fields { get; protected set; }
-		public int FieldCount => BaseFieldCount + (Fields?.Count ?? 0);
+		public int FieldCount => BaseFieldCount + Fields.Count;
 
 		internal int BaseFieldCount
 		{

--- a/AssetRipper.Fundamentals/Structure/Assembly/Serializable/SerializableType.cs
+++ b/AssetRipper.Fundamentals/Structure/Assembly/Serializable/SerializableType.cs
@@ -1,9 +1,9 @@
 using AssetRipper.Core.IO.Asset;
-using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.Structure.Assembly.Mono;
 using AssetRipper.Core.VersionHandling;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using static AssetRipper.Core.Structure.Assembly.Mono.MonoUtils;
 
 namespace AssetRipper.Core.Structure.Assembly.Serializable
@@ -12,20 +12,26 @@ namespace AssetRipper.Core.Structure.Assembly.Serializable
 	{
 		public readonly struct Field
 		{
-			public Field(SerializableType type, bool isArray, string name)
+			public Field(SerializableType type, int arrayDepth, string name)
 			{
 				Type = type;
-				IsArray = isArray;
+				ArrayDepth = arrayDepth;
 				Name = name;
 			}
 
-			public override string ToString()
+			public override string? ToString()
 			{
-				return Type == null ? base.ToString() : IsArray ? $"{Type}[] {Name}" : $"{Type} {Name}";
+				if (Type == null)
+				{
+					return base.ToString();
+				}
+
+				return $"{Type}{string.Concat(Enumerable.Repeat("[]", ArrayDepth))} {Name}";
 			}
 
 			public SerializableType Type { get; }
-			public bool IsArray { get; }
+			public int ArrayDepth { get; }
+			public bool IsArray => ArrayDepth > 0;
 			public string Name { get; }
 		}
 
@@ -34,6 +40,8 @@ namespace AssetRipper.Core.Structure.Assembly.Serializable
 			Namespace = @namespace ?? throw new ArgumentNullException(nameof(@namespace));
 			Type = type;
 			Name = name ?? throw new ArgumentNullException(nameof(name));
+			// is a placeholder - Is assigned by inheriting types.
+			Fields = new List<Field>();
 		}
 
 		public SerializableStructure CreateSerializableStructure()
@@ -43,11 +51,11 @@ namespace AssetRipper.Core.Structure.Assembly.Serializable
 
 		public IAsset CreateInstance(int depth, UnityVersion version)
 		{
-			if (MonoUtils.IsEngineStruct(this.Namespace, this.Name))
+			if (MonoUtils.IsEngineStruct(Namespace, Name))
 			{
-				return VersionManager.AssetFactory.CreateEngineAsset(this.Name);
+				return VersionManager.AssetFactory.CreateEngineAsset(Name);
 			}
-			if (this.IsEnginePointer())
+			if (IsEnginePointer())
 			{
 				return new SerializablePointer();
 			}
@@ -56,7 +64,7 @@ namespace AssetRipper.Core.Structure.Assembly.Serializable
 
 		public Field GetField(int index)
 		{
-			if (index < BaseFieldCount)
+			if (index < BaseFieldCount && Base != null)
 			{
 				return Base.GetField(index);
 			}
@@ -103,9 +111,9 @@ namespace AssetRipper.Core.Structure.Assembly.Serializable
 		public string Namespace { get; }
 		public PrimitiveType Type { get; }
 		public string Name { get; }
-		public SerializableType Base { get; protected set; }
+		public SerializableType? Base { get; protected set; }
 		public IReadOnlyList<Field> Fields { get; protected set; }
-		public int FieldCount => BaseFieldCount + Fields.Count;
+		public int FieldCount => BaseFieldCount + (Fields?.Count ?? 0);
 
 		internal int BaseFieldCount
 		{


### PR DESCRIPTION
When reading through MonoTypes with fields that (for example) are typed with `List<string>[]`, an argument exception is thrown which breaks asset ripping. This pull request aims to fix it.

**Changes**
- `SerializableType` is rewritten to use array depths, which can be used in the future if Unity adds support for multi-dimensional array types.
- `MonoType` will skip fields if they have an array depth greater than `1`.
- Adds messages to the argument exceptions in `MonoType` so they are more descriptive.