### PR TITLE
[Enhancement] Export AssemblyDefinition assets

### DIFF
--- a/AssetRipperLibrary/Exporters/Scripts/Assemblies/AssemblyDefinitionAsset.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/Assemblies/AssemblyDefinitionAsset.cs
@@ -6,15 +6,7 @@ namespace AssetRipper.Library.Exporters.Scripts.Assemblies
 	{
 		public string name;
 		public List<string> references = new();
-		public List<string> includePlatforms = new();
-		public List<string> excludePlatforms = new();
 		public bool allowUnsafeCode;
-		public bool overrideReferences;
-		public List<string> precompiledReferences = new();
-		public bool autoReferenced;
-		public List<string> defineConstraints = new();
-		public List<string> versionDefines = new();
-		public bool noEngineReferences;
 
 		public AssemblyDefinitionAsset(string name)
 		{

--- a/AssetRipperLibrary/Exporters/Scripts/Assemblies/AssemblyDefinitionAsset.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/Assemblies/AssemblyDefinitionAsset.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace AssetRipper.Library.Exporters.Scripts.Assemblies
+{
+	public class AssemblyDefinitionAsset
+	{
+		public string name;
+		public List<string> references = new();
+		public List<string> includePlatforms = new();
+		public List<string> excludePlatforms = new();
+		public bool allowUnsafeCode;
+		public bool overrideReferences;
+		public List<string> precompiledReferences = new();
+		public bool autoReferenced;
+		public List<string> defineConstraints = new();
+		public List<string> versionDefines = new();
+		public bool noEngineReferences;
+
+		public AssemblyDefinitionAsset(string name)
+		{
+			this.name = name;
+		}
+	}
+}

--- a/AssetRipperLibrary/Exporters/Scripts/Assemblies/AssemblyDefinitionAsset.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/Assemblies/AssemblyDefinitionAsset.cs
@@ -11,6 +11,7 @@ namespace AssetRipper.Library.Exporters.Scripts.Assemblies
 		public AssemblyDefinitionAsset(string name)
 		{
 			this.name = name;
+			allowUnsafeCode = true;
 		}
 	}
 }

--- a/AssetRipperLibrary/Exporters/Scripts/Assemblies/AssemblyDefinitionExporter.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/Assemblies/AssemblyDefinitionExporter.cs
@@ -1,0 +1,34 @@
+﻿using AssetRipper.Core.Logging;
+using Mono.Cecil;
+using System.IO;
+using System.Text.Json;
+
+namespace AssetRipper.Library.Exporters.Scripts.Assemblies
+{
+	public static class AssemblyDefinitionExporter
+	{
+		public static void Export(AssemblyDefinition assembly, string outputFolder)
+		{
+			string assetPath = Path.Combine(outputFolder, assembly.Name.Name + ".asmdef");
+			Logger.Info(LogCategory.Export, $"Exporting assembly definition '{assembly.Name.Name}.asmdef'");
+
+			AssemblyDefinitionAsset asset = new(assembly.Name.Name);
+			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences)
+			{
+				if (ReferenceAssemblies.IsReferenceAssembly(reference.Name))
+				{
+					continue;
+				}
+
+				asset.references.Add(reference.Name);
+			}
+
+			string assetData = JsonSerializer.Serialize(asset, new JsonSerializerOptions()
+			{
+				IncludeFields = true,
+				WriteIndented = true,
+			});
+			File.WriteAllText(assetPath, assetData);
+		}
+	}
+}

--- a/AssetRipperLibrary/Exporters/Scripts/ReferenceAssemblies.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/ReferenceAssemblies.cs
@@ -23,6 +23,23 @@ namespace AssetRipper.Library.Exporters.Scripts
 			"Mono.Security.dll",
 			"Mono.Security"
 		};
+		private static readonly HashSet<string> predefinedAssemblies = new()
+		{
+			"Assembly-CSharp.dll",
+			"Assembly-CSharp",
+			"Assembly-CSharp-firstpass.dll",
+			"Assembly-CSharp-firstpass"
+		};
+
+		public static bool IsPredefinedAssembly(string assemblyName)
+		{
+			if (assemblyName is null)
+			{
+				throw new ArgumentNullException(assemblyName);
+			}
+
+			return predefinedAssemblies.Contains(assemblyName);
+		}
 
 		public static bool IsReferenceAssembly(string assemblyName)
 		{

--- a/AssetRipperLibrary/Exporters/Scripts/ScriptExporter.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/ScriptExporter.cs
@@ -94,7 +94,15 @@ namespace AssetRipper.Library.Exporters.Scripts
 				string outputDirectory = Path.Combine(dirPath, assembly.Name.Name);
 				Directory.CreateDirectory(outputDirectory);
 				Decompiler.DecompileWholeProject(assembly, outputDirectory);
-				AssemblyDefinitionExporter.Export(assembly, outputDirectory);
+
+				// assembly definitions were added in 2017.3:
+				//     https://blog.unity.com/technology/unity-2017-3b-feature-preview-assembly-definition-files-and-transform-tool
+				if (container.ExportVersion.IsGreaterEqual(2017, 3) && 
+					// exclude predefined assemblies like Assembly-CSharp.dll
+					!ReferenceAssemblies.IsPredefinedAssembly(assembly.Name.Name))
+				{
+					AssemblyDefinitionExporter.Export(assembly, outputDirectory);
+				}
 			}
 			if(callback is not null)
 			{

--- a/AssetRipperLibrary/Exporters/Scripts/ScriptExporter.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/ScriptExporter.cs
@@ -95,10 +95,11 @@ namespace AssetRipper.Library.Exporters.Scripts
 				Directory.CreateDirectory(outputDirectory);
 				Decompiler.DecompileWholeProject(assembly, outputDirectory);
 
-				// assembly definitions were added in 2017.3:
-				//     https://blog.unity.com/technology/unity-2017-3b-feature-preview-assembly-definition-files-and-transform-tool
+				// assembly definitions were added in 2017.3
+				//     see: https://blog.unity.com/technology/unity-2017-3b-feature-preview-assembly-definition-files-and-transform-tool
 				if (container.ExportVersion.IsGreaterEqual(2017, 3) && 
 					// exclude predefined assemblies like Assembly-CSharp.dll
+					//    see: https://docs.unity3d.com/2017.3/Documentation/Manual/ScriptCompilationAssemblyDefinitionFiles.html
 					!ReferenceAssemblies.IsPredefinedAssembly(assembly.Name.Name))
 				{
 					AssemblyDefinitionExporter.Export(assembly, outputDirectory);

--- a/AssetRipperLibrary/Exporters/Scripts/ScriptExporter.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/ScriptExporter.cs
@@ -11,6 +11,7 @@ using AssetRipper.Core.SourceGenExtensions;
 using AssetRipper.Core.Structure.Assembly.Managers;
 using AssetRipper.Core.Utils;
 using AssetRipper.Library.Configuration;
+using AssetRipper.Library.Exporters.Scripts.Assemblies;
 using AssetRipper.SourceGenerated.Classes.ClassID_115;
 using Mono.Cecil;
 using System;
@@ -93,6 +94,7 @@ namespace AssetRipper.Library.Exporters.Scripts
 				string outputDirectory = Path.Combine(dirPath, assembly.Name.Name);
 				Directory.CreateDirectory(outputDirectory);
 				Decompiler.DecompileWholeProject(assembly, outputDirectory);
+				AssemblyDefinitionExporter.Export(assembly, outputDirectory);
 			}
 			if(callback is not null)
 			{


### PR DESCRIPTION
When a game has multiple assemblies, getting compilable scripts often times requires setup from the user for manually creating these assembly definition assets. Furthermore, the user has to setup references to other assemblies, thus requiring extra work.

AssetRipper already knows the assemblies it wants to export, as well as the references those assemblies have to other assemblies, so generating the Assembly Definition Assets seems like another step to remove compiler errors and reduce the setup required once a project is exported. 