### PR TITLE
[Enhancement] Fix Exported IL2CPP Event Declarations

### DIFF
--- a/AssetRipperLibrary/Exporters/Scripts/ScriptDecompiler.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/ScriptDecompiler.cs
@@ -64,6 +64,7 @@ namespace AssetRipper.Library.Exporters.Scripts
 				decompiler.CustomTransforms.Add(new EnsureOutParamsSetTransform());
 				decompiler.CustomTransforms.Add(new EnsureStructFieldsSetTransform());
 				decompiler.CustomTransforms.Add(new EnsureValidBaseConstructorTransform());
+				decompiler.CustomTransforms.Add(new FixEventDeclarationsTransform());
 			}
 
 			DecompileWholeProject(decompiler, assembly, outputFolder);

--- a/AssetRipperLibrary/Exporters/Scripts/Transforms/FixEventDeclarationsTransform.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/Transforms/FixEventDeclarationsTransform.cs
@@ -28,17 +28,19 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 		{
 			base.VisitCustomEventDeclaration(eventDeclaration);
 
-			bool hasAccessorImpl = AccessorHasImplementation(eventDeclaration.AddAccessor) || AccessorHasImplementation(eventDeclaration.RemoveAccessor);
+			bool hasAccessorImplementation = AccessorHasImplementation(eventDeclaration.AddAccessor) || AccessorHasImplementation(eventDeclaration.RemoveAccessor);
 
-			if (!hasAccessorImpl)
+			if (hasAccessorImplementation)
 			{
-				EventDeclaration declaration = new EventDeclaration();
-				declaration.Modifiers = eventDeclaration.Modifiers;
-				declaration.ReturnType = eventDeclaration.ReturnType.Clone();
-				declaration.Variables.Add(new VariableInitializer(eventDeclaration.Name));
-				((TypeDeclaration)eventDeclaration.Parent!).Members.Add(declaration);
-				eventDeclaration.Remove();
+				return;
 			}
+
+			EventDeclaration declaration = new EventDeclaration();
+			declaration.Modifiers = eventDeclaration.Modifiers;
+			declaration.ReturnType = eventDeclaration.ReturnType.Clone();
+			declaration.Variables.Add(new VariableInitializer(eventDeclaration.Name));
+			((TypeDeclaration)eventDeclaration.Parent!).Members.Add(declaration);
+			eventDeclaration.Remove();
 		}
 
 		public void Run(AstNode rootNode, TransformContext context)

--- a/AssetRipperLibrary/Exporters/Scripts/Transforms/FixEventDeclarationsTransform.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/Transforms/FixEventDeclarationsTransform.cs
@@ -1,0 +1,49 @@
+﻿using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.CSharp.Transforms;
+
+namespace AssetRipper.Library.Exporters.Scripts.Transforms
+{
+	/// <summary>
+	/// Fixed event declarations that look like:
+	/// <code>
+	/// event MyEvent
+	/// {
+	///     add;
+	///     remove;
+	/// }
+	/// </code>
+	/// And instead replaces them with:
+	/// <code>
+	/// event MyEvent;
+	/// </code>
+	/// </summary>
+	internal class FixEventDeclarationsTransform : DepthFirstAstVisitor, IAstTransform
+	{
+		private static bool AccessorHasImplementation(Accessor accessor)
+		{
+			return !accessor.IsNull && !accessor.Body.IsNull;
+		}
+
+		public override void VisitCustomEventDeclaration(CustomEventDeclaration eventDeclaration)
+		{
+			base.VisitCustomEventDeclaration(eventDeclaration);
+
+			bool hasAccessorImpl = AccessorHasImplementation(eventDeclaration.AddAccessor) || AccessorHasImplementation(eventDeclaration.RemoveAccessor);
+
+			if (!hasAccessorImpl)
+			{
+				EventDeclaration declaration = new EventDeclaration();
+				declaration.Modifiers = eventDeclaration.Modifiers;
+				declaration.ReturnType = eventDeclaration.ReturnType.Clone();
+				declaration.Variables.Add(new VariableInitializer(eventDeclaration.Name));
+				((TypeDeclaration)eventDeclaration.Parent!).Members.Add(declaration);
+				eventDeclaration.Remove();
+			}
+		}
+
+		public void Run(AstNode rootNode, TransformContext context)
+		{
+			rootNode.AcceptVisitor(this);
+		}
+	}
+}

--- a/AssetRipperLibrary/Exporters/Scripts/Transforms/FixEventDeclarationsTransform.cs
+++ b/AssetRipperLibrary/Exporters/Scripts/Transforms/FixEventDeclarationsTransform.cs
@@ -4,7 +4,7 @@ using ICSharpCode.Decompiler.CSharp.Transforms;
 namespace AssetRipper.Library.Exporters.Scripts.Transforms
 {
 	/// <summary>
-	/// Fixed event declarations that look like:
+	/// Fixes event declarations that look like:
 	/// <code>
 	/// event MyEvent
 	/// {


### PR DESCRIPTION
Due to the `[CompilerGenerated]` accessor stripping, Event Declarations are invalid.

They export as:
```cs
Modifiers event Type Name
{
    add;
    remove;
}
```
Which gives compiler error `CS0073: An add or remove accessor must have a body`

This PR fixes it by checking for empty event declarations like these and instead exporting them as bare events:
```cs
Modifiers event Type Name;
```
