### PR TITLE
Fix Magic number 0 doesn' t match

### DIFF
--- a/ShaderTextRestorer/Exporters/DirectX/DXShaderTextExtractor.cs
+++ b/ShaderTextRestorer/Exporters/DirectX/DXShaderTextExtractor.cs
@@ -24,7 +24,24 @@ namespace ShaderTextRestorer.Exporters.DirectX
 				uint fourCC = BitConverter.ToUInt32(data, dataOffset);
 				if (!D3DHandler.IsCompatible(fourCC))
 				{
-					throw new Exception($"Magic number {fourCC} doesn't match");
+					int length = data.Length - 0x20;
+					int offset = 0;
+					byte[] newData = new byte[length];
+					for (int j = 0; j < length; j++)
+					{
+						if (j == 6)
+						{
+							offset += 0x20; 
+						}
+						newData[j] = data[offset];
+						offset++;
+					}
+					data = newData;
+
+					fourCC = BitConverter.ToUInt32(data, dataOffset);
+					if (!D3DHandler.IsCompatible(fourCC)) { 
+						throw new Exception($"Magic number {fourCC} doesn't match");
+					}
 				}
 				return D3DHandler.TryGetShaderText(data, dataOffset, out disassemblyText);
 			}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/102138304/174535142-968183f5-9bf3-4efb-912c-a5d8e725ed69.png)
In 2019.4 and greater shader header file added 0x20 blank bytes, resulting in the Magic number 0 doesn' t match, in fact, just need to skip these fields can be successfully exported shader