### PR TITLE
Improved command line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ bin
 *.blend1
 launchSettings.json
 AssetRipper.SourceGenerated.xml
+
+/Ripped
+/AssetRipper.log

--- a/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
+++ b/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
@@ -78,7 +78,11 @@ namespace AssetRipper.Core.Configuration
 		/// Should objects get exported with dependencies or without?
 		/// </summary>
 		public bool ExportDependencies { get; set; }
-		public BundledAssetsExportMode BundledAssetsExportMode { get; set; }
+		public BundledAssetsExportMode BundledAssetsExportMode
+		{
+			get { return this.GetSetting<BundledAssetsExportMode>(); }
+			set { this.SetSetting<BundledAssetsExportMode>(value); }
+		}
 		/// <summary>
 		/// A function to determine if an object is allowed to be exported.<br/>
 		/// Set by default to allow everything.

--- a/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
+++ b/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
@@ -81,7 +81,11 @@ namespace AssetRipper.Core.Configuration
 		/// <summary>
 		/// Should objects get exported with dependencies or without?
 		/// </summary>
-		public bool ExportDependencies { get; set; }
+		public bool ExportDependencies
+		{
+			get { return this.GetSetting<ExportDependencies>() == Configuration.ExportDependencies.Export; }
+			set { this.SetSetting<ExportDependencies>(value ? Configuration.ExportDependencies.Export : Configuration.ExportDependencies.Ignore); }
+		}
 		public BundledAssetsExportMode BundledAssetsExportMode
 		{
 			get { return this.GetSetting<BundledAssetsExportMode>(); }

--- a/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
+++ b/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
@@ -3,12 +3,43 @@ using AssetRipper.Core.IO.Asset;
 using AssetRipper.Core.Logging;
 using AssetRipper.Core.Parser.Files;
 using AssetRipper.Core.Utils;
+using System.Collections.Generic;
 using System.IO;
 
 namespace AssetRipper.Core.Configuration
 {
 	public class CoreConfiguration
 	{
+		public Dictionary<Type, object> settings = new Dictionary<Type, object>();
+
+		public T? GetSetting<T>()
+		{
+			object? result = this.settings.GetValueOrDefault(typeof(T));
+
+			if (result == null || result == default)
+				return default(T);
+
+			return (T?)result;
+		}
+
+		public void SetSetting(Type type, object value)
+		{
+			if (value == null)
+				return;
+
+			this.settings.Remove(type);
+			this.settings.Add(type, value);
+		}
+
+		public void SetSetting<T>(object value)
+		{
+			if (value == null)
+				return;
+
+			this.settings.Remove(typeof(T));
+			this.settings.Add(typeof(T), value);
+		}
+
 		#region Import Settings
 		/// <summary>
 		/// Disabling scripts can allow some games to export when they previously did not.
@@ -23,16 +54,12 @@ namespace AssetRipper.Core.Configuration
 		/// </summary>
 		public bool IgnoreStreamingAssets
 		{
-			get => StreamingAssetsMode == StreamingAssetsMode.Ignore;
+			get => this.GetSetting<StreamingAssetsMode>() == StreamingAssetsMode.Ignore;
 			set
 			{
-				StreamingAssetsMode = value ? StreamingAssetsMode.Ignore : StreamingAssetsMode.Extract;
+				this.SetSetting<StreamingAssetsMode>(value ? StreamingAssetsMode.Ignore : StreamingAssetsMode.Extract);
 			}
 		}
-		/// <summary>
-		/// How the StreamingAssets folder is handled
-		/// </summary>
-		public StreamingAssetsMode StreamingAssetsMode { get; set; }
 		#endregion
 
 		#region Export Settings
@@ -86,7 +113,7 @@ namespace AssetRipper.Core.Configuration
 		public virtual void ResetToDefaultValues()
 		{
 			ScriptContentLevel = ScriptContentLevel.Level2;
-			StreamingAssetsMode = StreamingAssetsMode.Extract;
+			IgnoreStreamingAssets = false;
 			ExportRootPath = ExecutingDirectory.Combine("Ripped");
 			ExportDependencies = false;
 			BundledAssetsExportMode = BundledAssetsExportMode.GroupByBundleName;
@@ -97,7 +124,7 @@ namespace AssetRipper.Core.Configuration
 		{
 			Logger.Info(LogCategory.General, $"Configuration Settings:");
 			Logger.Info(LogCategory.General, $"{nameof(ScriptContentLevel)}: {ScriptContentLevel}");
-			Logger.Info(LogCategory.General, $"{nameof(StreamingAssetsMode)}: {StreamingAssetsMode}");
+			Logger.Info(LogCategory.General, $"{nameof(StreamingAssetsMode)}: {this.GetSetting<StreamingAssetsMode>()}");
 			Logger.Info(LogCategory.General, $"{nameof(ExportRootPath)}: {ExportRootPath}");
 			Logger.Info(LogCategory.General, $"{nameof(ExportDependencies)}: {ExportDependencies}");
 			Logger.Info(LogCategory.General, $"{nameof(BundledAssetsExportMode)}: {BundledAssetsExportMode}");

--- a/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
+++ b/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
@@ -48,7 +48,11 @@ namespace AssetRipper.Core.Configuration
 		/// <summary>
 		/// The level of scripts to export
 		/// </summary>
-		public ScriptContentLevel ScriptContentLevel { get; set; }
+		public ScriptContentLevel ScriptContentLevel
+		{
+			get { return this.GetSetting<ScriptContentLevel>(); }
+			set { this.SetSetting<ScriptContentLevel>(value); }
+		}
 		/// <summary>
 		/// Including the streaming assets directory can cause some games to fail while exporting.
 		/// </summary>

--- a/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
+++ b/AssetRipper.Fundamentals/Configuration/CoreConfiguration.cs
@@ -33,11 +33,7 @@ namespace AssetRipper.Core.Configuration
 
 		public void SetSetting<T>(object value)
 		{
-			if (value == null)
-				return;
-
-			this.settings.Remove(typeof(T));
-			this.settings.Add(typeof(T), value);
+			SetSetting(typeof(T), value);
 		}
 
 		#region Import Settings

--- a/AssetRipper.Fundamentals/Configuration/ExportDependencies.cs
+++ b/AssetRipper.Fundamentals/Configuration/ExportDependencies.cs
@@ -1,0 +1,14 @@
+﻿namespace AssetRipper.Core.Configuration
+{
+	public enum ExportDependencies
+	{
+		/// <summary>
+		/// Dependencies are exported with the project.
+		/// </summary>
+		Export,
+		/// <summary>
+		/// Dependencies are ignored during export.
+		/// </summary>
+		Ignore,
+	}
+}

--- a/AssetRipper.GUI.SourceGenerator/Program.cs
+++ b/AssetRipper.GUI.SourceGenerator/Program.cs
@@ -4,13 +4,16 @@ namespace AssetRipper.GUI.SourceGenerator;
 
 public static class Program
 {
+	private const string repositoryPath = "../../../../";
+
+	private static string GetPathForProject(string project)
+	{
+		return Path.Combine(repositoryPath, project);
+	}
+
 	public static void Main(string[] args)
 	{
-		string repositoryPath = "../../../../";
-		string outputPath = Path.Combine(repositoryPath, "AssetRipper.GUI", "LocalizationManager.g.cs");
-		
-		string source = LocalizationSourceGenerator.MakeLocalizationClass(repositoryPath);
-
-		File.WriteAllText(outputPath, source);
+		string localizationPath = Path.Combine(GetPathForProject("AssetRipper.GUI"), "LocalizationManager.g.cs");
+		File.WriteAllText(localizationPath, LocalizationSourceGenerator.MakeLocalizationClass(repositoryPath));
 	}
 }

--- a/AssetRipper.GUI/AssetRipper.GUI.csproj
+++ b/AssetRipper.GUI/AssetRipper.GUI.csproj
@@ -39,13 +39,13 @@
 		<PackageReference Include="Avalonia" Version="0.10.18" />
 		<PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
 		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.18" />
-		<PackageReference Include="CommandLineParser" Version="2.9.1" />
 		<PackageReference Include="LibVLCSharp" Version="3.6.6" />
 		<PackageReference Include="LibVLCSharp.Avalonia" Version="3.6.6" />
 		<PackageReference Include="MessageBox.Avalonia" Version="2.0.2" />
 		<PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
 		<PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
 		<PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.17.4" />

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Diagnostics;
-using System.Reflection;
 using System.Linq;
 
 using System.CommandLine;
@@ -13,7 +12,6 @@ using AssetRipper.Core.Logging;
 using AssetRipper.Core.Utils;
 using AssetRipper.Library;
 using AssetRipper.Library.Configuration;
-using YamlDotNet.Core.Tokens;
 
 namespace AssetRipper.GUI
 {
@@ -24,18 +22,6 @@ namespace AssetRipper.GUI
 		/*
 		internal class Options
 		{
-			[Option('i', "input", Required = true, HelpText = "Input files or directory to export")]
-			public IReadOnlyList<string>? FilesToExport { get; set; }
-
-			[Option('o', "output", Required = true, HelpText = "Directory to export to (will be cleared if already exists)")]
-			public DirectoryInfo? OutputDirectory { get; set; }
-
-			[Option('w', "log-file", Default = DefaultLogFileName, HelpText = "File to log to")]
-			public FileInfo? LogFile { get; set; }
-
-			[Option('v', "verbose", Default = false, HelpText = "Verbose logging output")]
-			public bool Verbose { get; set; }
-
 			[Option('k', "keep-open", Default = false, HelpText = "Keep console open after exporting finishes")]
 			public bool KeepOpen { get; set; }
 
@@ -45,53 +31,23 @@ namespace AssetRipper.GUI
 			[Option('g', "ignore-streaming", Default = false, HelpText = "Ignore StreamingAssets folder")]
 			public bool IgnoreStreaming { get; set; }
 
-			[Option('a', "audio-format", Default = AudioExportFormat.Default, HelpText = "Audio export format\n")]
-			public AudioExportFormat AudioExportFormat { get; set; }
-
-			[Option('p', "image-format", Default = ImageExportFormat.Png, HelpText = "Image export format\n")]
-			public ImageExportFormat ImageExportFormat { get; set; }
-
-			[Option('m', "mesh-format", Default = MeshExportFormat.Native, HelpText = "Mesh export format\n")]
-			public MeshExportFormat MeshExportFormat { get; set; }
-
-			[Option('s', "sprite-mode", Default = SpriteExportMode.Native, HelpText = "Sprite export mode\n")]
-			public SpriteExportMode SpriteExportMode { get; set; }
-
-			[Option('t', "terrain-mode", Default = TerrainExportMode.Yaml, HelpText = "Terrain export mode\n")]
-			public TerrainExportMode TerrainExportMode { get; set; }
-
-			[Option('x', "text-mode", Default = TextExportMode.Parse, HelpText = "Text export mode\n")]
-			public TextExportMode TextExportMode { get; set; }
-
-			[Option('d', "shader-mode", Default = ShaderExportMode.Dummy, HelpText = "Shader export mode\n")]
-			public ShaderExportMode ShaderExportMode { get; set; }
-
-			[Option('c', "script-mode", Default = ScriptExportMode.Hybrid, HelpText = "Script export mode\n")]
-			public ScriptExportMode ScriptExportMode { get; set; }
-
 			[Option('r', "script-level", Default = ScriptContentLevel.Level2, HelpText = "Script content level\n")]
 			public ScriptContentLevel ScriptContentLevel { get; set; }
-
-			[Option('l', "script-language-version", Default = ScriptLanguageVersion.AutoSafe, HelpText = "Script language version\n")]
-			public ScriptLanguageVersion ScriptLanguageVersion { get; set; }
 		}
 		*/
 
-		private static void RootCommandHandler(InvocationContext context, Ripper ripper)
+		private static void RootCommandHandler(InvocationContext context, Ripper ripper, Dictionary<string, Option> options)
 		{
 			// TODO: Remove this
 			Console.WriteLine("Root command handler");
 
 			// TODO: Don't run the extract handler, but refactor that so that extracting happens elsewhere.
 			// Then call that from here with -k, as the root command is called when a file is dropped onto the exe.
-			ExtractCommandHandler(context, ripper);
+			ExtractCommandHandler(context, ripper, options);
 		}
 
-		private static void ExtractCommandHandler(InvocationContext context, Ripper ripper)
+		private static void ExtractCommandHandler(InvocationContext context, Ripper ripper, Dictionary<string, Option> options)
 		{
-			// TODO: Remove this
-			Console.WriteLine("Extract command handler");
-
 			List<string>? input = context.ParseResult.GetValueForOption(inputOption);
 			DirectoryInfo? output = context.ParseResult.GetValueForOption(outputOption);
 			FileInfo? logFile = context.ParseResult.GetValueForOption(logFileOption);
@@ -107,20 +63,33 @@ namespace AssetRipper.GUI
 
 			Logger.LogSystemInformation("AssetRipper Console Version");
 
-			/*
-			ripper.Settings.BundledAssetsExportMode = options.BundledAssetsExportMode;
-			ripper.Settings.IgnoreStreamingAssets = options.IgnoreStreaming;
-			ripper.Settings.AudioExportFormat = options.AudioExportFormat;
-			ripper.Settings.ImageExportFormat = options.ImageExportFormat;
-			ripper.Settings.MeshExportFormat = options.MeshExportFormat;
-			ripper.Settings.SpriteExportMode = options.SpriteExportMode;
-			ripper.Settings.TerrainExportMode = options.TerrainExportMode;
-			ripper.Settings.TextExportMode = options.TextExportMode;
-			ripper.Settings.ShaderExportMode = options.ShaderExportMode;
-			ripper.Settings.ScriptExportMode = options.ScriptExportMode;
-			ripper.Settings.ScriptContentLevel = options.ScriptContentLevel;
-			ripper.Settings.ScriptLanguageVersion = options.ScriptLanguageVersion;
-			*/
+			// Get a list of options supported by LibraryConfiguration
+			// MUST be run after defaults have been filled, as it only lists
+			// options with values.
+			foreach (Type type in ripper.Settings.settings.Keys.ToList())
+			{
+				string optionName = $"-{ToHyphenCase(type.Name)}";
+
+				if (type == null)
+					continue;
+
+				options.TryGetValue(optionName, out Option? option);
+
+				if (option == null)
+					continue;
+
+				object? settingValue = context.ParseResult.GetValueForOption(option);
+
+				if (settingValue == null)
+					continue;
+
+				string? enumKey = settingValue.ToString();
+
+				if (string.IsNullOrEmpty(enumKey))
+					continue;
+
+				ripper.Settings.SetSetting(type, Enum.Parse(type, enumKey));
+			}
 
 			ripper.Settings.LogConfigurationValues();
 
@@ -145,6 +114,7 @@ namespace AssetRipper.GUI
 			get {
 				Option<List<string>> option = new Option<List<string>>(name: "--input", description: "Input files or directory to export");
 				option.AddAlias("-i");
+				option.IsRequired = true;
 
 				return option;
 			}
@@ -156,6 +126,8 @@ namespace AssetRipper.GUI
 			{
 				Option<DirectoryInfo> option = new Option<DirectoryInfo>(name: "--output", description: "Directory to export to (will be cleared if already exists)");
 				option.AddAlias("-o");
+				option.SetDefaultValue(".");
+				option.IsRequired = false;
 
 				return option;
 			}
@@ -167,6 +139,7 @@ namespace AssetRipper.GUI
 			{
 				Option<bool> option = new Option<bool>(name: "--verbose", description: "Verbose logging output");
 				option.AddAlias("-v");
+				option.SetDefaultValue(false);
 
 				return option;
 			}
@@ -178,6 +151,7 @@ namespace AssetRipper.GUI
 			{
 				Option<FileInfo> option = new Option<FileInfo>(name: "--log-file", description: "File to log to");
 				option.AddAlias("-w");
+				option.SetDefaultValue("AssetRipper.log");
 
 				return option;
 			}
@@ -194,57 +168,47 @@ namespace AssetRipper.GUI
 			return string.Join("", result);
 		}
 
-		private static List<Option> CreateOptions(Ripper ripper)
+		private static Dictionary<string, Option> CreateOptions(Ripper ripper)
 		{
-			List<Option> list = new List<Option>();
+			Dictionary<string, Option> options = new Dictionary<string, Option>();
 
-			list.Add(inputOption);
-			list.Add(outputOption);
-			list.Add(verboseOption);
-			list.Add(logFileOption);
+			options.Add(inputOption.Name, inputOption);
+			options.Add(outputOption.Name, outputOption);
+			options.Add(verboseOption.Name, verboseOption);
+			options.Add(logFileOption.Name, logFileOption);
 
-			// WIP
-			// Generate a list of options by looking at properties of the LibraryConfiguration class
-
-			// IEnumerable<object> values1 = ripper.Settings.GetType().GetFields().Select(a => (LibraryConfiguration)a.GetValue(null));
-
-			var members = ripper.Settings.GetType().GetMembers();
-			Console.WriteLine($"[TRACE] Found {members.Length} members.");
-
-			foreach (var member in members)
+			foreach (Type type in ripper.Settings.settings.Keys)
 			{
-				if (member.MemberType != MemberTypes.Property || member.DeclaringType != typeof(LibraryConfiguration))
-					continue;
+				string optionName = $"-{ToHyphenCase(type.Name)}";
+				Option option = new Option<string>(name: optionName);
 
-				Option option = new Option<int>(name: $"-{ToHyphenCase(member.Name)}");
-
-				Console.WriteLine($"{member.Name} is enum: {member.GetType().IsEnum}. It is: {member.GetType()}. Member type: {member.MemberType}");
-
-				if (member.GetType().IsEnum)
+				if (type.IsEnum)
 				{
-					string[] values = Enum.GetNames(member.GetType());
+					string[] values = Enum.GetNames(type);
 					option.AddCompletions(values);
 				}
 
-				list.Add(option);
+				options.Add(optionName, option);
 			}
 
-			return list;
+			return options;
 		}
 
 		public static void ParseArgumentsAndRun(string[] args)
 		{
 			Ripper ripper = new();
+			ripper.Settings.ResetToDefaultValues();
+
+			Dictionary<string, Option> options = CreateOptions(ripper);
 
 			RootCommand rootCommand = new RootCommand("AssetRipper");
-			rootCommand.SetHandler((InvocationContext context) => RootCommandHandler(context, ripper));
+			rootCommand.SetHandler((InvocationContext context) => RootCommandHandler(context, ripper, options));
 
 			Command extractCommand = new Command("extract");
-			extractCommand.SetHandler((InvocationContext context) => ExtractCommandHandler(context, ripper));
+			extractCommand.AddAlias("e");
+			extractCommand.SetHandler((InvocationContext context) => ExtractCommandHandler(context, ripper, options));
 
-			List<Option> options = CreateOptions(ripper);
-
-			foreach (Option option in options)
+			foreach (Option option in options.Values)
 			{
 				extractCommand.AddOption(option);
 			}

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -50,12 +50,6 @@ namespace AssetRipper.GUI
 			DirectoryInfo output = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.outputOption, new DirectoryInfo(ConsoleOptions.DefaultOutputPath));
 			bool quit = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.quitOption, false);
 
-			if (inputs == null)
-				throw new Exception("Internal error - Input was lost");
-
-			if (output == null)
-				throw new Exception("Internal error - Output was lost");
-
 			SetupLogger(false, ConsoleOptions.DefaultLogFileName);
 
 			try
@@ -110,12 +104,6 @@ namespace AssetRipper.GUI
 
 				ripper.Settings.SetSetting(type, Enum.Parse(type, enumKey));
 			}
-
-			if (inputs == null)
-				throw new Exception("Internal error - Input was lost");
-
-			if (output == null)
-				throw new Exception("Internal error - Output was lost");
 
 			if (logFile != null)
 				SetupLogger(verbose, logFile.FullName);

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -82,13 +82,9 @@ namespace AssetRipper.GUI
 				.WithParsed(options =>
 				{
 					if (ValidateOptions(options))
-					{
 						Run(options);
-					}
 					else
-					{
 						Environment.ExitCode = 1;
-					}
 
 					if (options.KeepOpen)
 					{
@@ -160,8 +156,8 @@ namespace AssetRipper.GUI
 			}
 			catch (Exception ex)
 			{
-				System.Console.WriteLine($"Failed to initialize the output and log paths.");
-				System.Console.WriteLine(ex.ToString());
+				Console.WriteLine($"Failed to initialize the output and log paths.");
+				Console.WriteLine(ex.ToString());
 				return false;
 			}
 

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -206,16 +206,9 @@ namespace AssetRipper.GUI
 			// WIP
 			// Generate a list of options by looking at properties of the LibraryConfiguration class
 
-			IEnumerable<object> values1 = typeof(LibraryConfiguration).GetFields(BindingFlags.Public | BindingFlags.Static).Select(a => (LibraryConfiguration)a.GetValue(null));
+			// IEnumerable<object> values1 = ripper.Settings.GetType().GetFields().Select(a => (LibraryConfiguration)a.GetValue(null));
 
-			Console.WriteLine($"Got {values1.Count()} values");
-
-			foreach (object value in values1)
-			{
-				Console.WriteLine("Vaklue", value);
-			}
-
-			var members = typeof(LibraryConfiguration).GetMembers();
+			var members = ripper.Settings.GetType().GetMembers();
 			Console.WriteLine($"[TRACE] Found {members.Length} members.");
 
 			foreach (var member in members)

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -305,6 +305,22 @@ namespace AssetRipper.GUI
 				{
 					string[] values = Enum.GetNames(type);
 					option.AddCompletions(values);
+
+					option.AddValidator((symbolResult) =>
+					{
+						object? input = symbolResult.GetValueForOption(option);
+
+						if (input == null)
+							return;
+
+						string[] names = Enum.GetNames(type);
+
+						if (!names.Contains(input))
+						{
+							symbolResult.ErrorMessage = $"{input} is not a valid option. Valid options: {string.Join(", ", names)}";
+							return;
+						}
+					});
 				}
 
 				options.Add(optionName, option);

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -107,12 +107,14 @@ namespace AssetRipper.GUI
 			DoRipping(ripper, inputs, output.FullName, verbose, logFile.FullName);
 		}
 
-			DoRipping(ripper, inputs, output.FullName);
+		private static void HandleException(Exception ex, InvocationContext context)
+		{
+			HandleException(ex);
 		}
 
 		private static void HandleException(Exception ex)
 		{
-			Environment.ExitCode = 1;
+			Environment.ExitCode = (int)ExitCode.ExtractingError;
 
 #if DEBUG
 			Console.WriteLine("===================================================");
@@ -157,6 +159,8 @@ namespace AssetRipper.GUI
 			rootCommand.AddCommand(extractCommand);
 
 			Parser parser = new CommandLineBuilder(rootCommand)
+				.UseExceptionHandler(HandleException)
+				.UseParseErrorReporting((int)ExitCode.ArgumentError)
 				.UseVersionOption()
 				.UseHelp()
 				.RegisterWithDotnetSuggest()

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -32,8 +32,8 @@ namespace AssetRipper.GUI
 			[Option('v', "verbose", Default = false, HelpText = "Verbose logging output")]
 			public bool Verbose { get; set; }
 
-			[Option('q', "quit", Default = false, HelpText = "Close console after export.")]
-			public bool Quit { get; set; }
+			[Option('k', "keep-open", Default = false, HelpText = "Keep console open after exporting finishes")]
+			public bool KeepOpen { get; set; }
 
 			[Option('b', "bundle-mode", Default = BundledAssetsExportMode.GroupByBundleName, HelpText = "Bundled asset export mode\n")]
 			public BundledAssetsExportMode BundledAssetsExportMode { get; set; }
@@ -90,9 +90,10 @@ namespace AssetRipper.GUI
 						Environment.ExitCode = 1;
 					}
 
-					if (!options.Quit)
+					if (options.KeepOpen)
 					{
-						System.Console.ReadKey();
+						Console.WriteLine("AssetRipper finished, press any key to exit.");
+						Console.ReadKey();
 					}
 				})
 				.WithNotParsed((errors) =>

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -1,31 +1,19 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.CommandLine.Builder;
 
-using AssetRipper.Core.Configuration;
-using AssetRipper.Core.IO.MultiFile;
 using AssetRipper.Core.Logging;
-using AssetRipper.Core.Utils;
 using AssetRipper.Library;
-using AssetRipper.Library.Configuration;
-using AssetRipper.Core.Classes.Misc;
 
 namespace AssetRipper.GUI
 {
 	internal static class ConsoleApp
 	{
-		private const string DefaultLogFileName = "AssetRipper.log";
-		private const string DefaultOutputPath = "Ripped";
-		private const bool DefaultQuit = false;
-		private const bool DefaultVerbose = false;
-
 		private static void SetupLogger(bool verbose, string path)
 		{
 			Logger.AllowVerbose = verbose;
@@ -33,26 +21,34 @@ namespace AssetRipper.GUI
 
 			// Do not log to a file if the logging target is null. It should be AssetRipper.log
 			// if the user didn't specify one.
-			if (!string.IsNullOrEmpty(path))
-				Logger.Add(new FileLogger(path));
+			if (string.IsNullOrEmpty(path))
+				return;
+
+			Logger.Add(new FileLogger(path));
 		}
 
 		private static void DoRipping(Ripper ripper, List<string> inputPaths, string outputPath)
 		{
 			Logger.LogSystemInformation("AssetRipper Console Version");
 			ripper.Settings.LogConfigurationValues();
-
 			ripper.Load(inputPaths);
 
-			PrepareExportDirectory(outputPath);
+			if (Directory.Exists(outputPath))
+			{
+				Logger.Info("Clearing export directory...");
+				Directory.Delete(outputPath, true);
+			}
+
 			ripper.ExportProject(outputPath);
 		}
 
-		private static Task RootCommandHandler(InvocationContext context, Ripper ripper)
+		private static void RootCommandHandler(InvocationContext context, Ripper ripper)
 		{
-			List<string>? inputs = context.ParseResult.GetValueForArgument(inputArgument);
-			DirectoryInfo? output = context.ParseResult.GetValueForOption(outputOption);
-			bool quit = context.ParseResult.GetValueForOption(quitOption);
+			ConsoleOptions.SetContext(context);
+
+			List<string> inputs = ConsoleOptions.GetArgumentOrFallback(ConsoleOptions.inputArgument, new List<string>());
+			DirectoryInfo output = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.outputOption, new DirectoryInfo(ConsoleOptions.DefaultOutputPath));
+			bool quit = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.quitOption, false);
 
 			if (inputs == null)
 				throw new Exception("Internal error - Input was lost");
@@ -60,7 +56,7 @@ namespace AssetRipper.GUI
 			if (output == null)
 				throw new Exception("Internal error - Output was lost");
 
-			SetupLogger(false, DefaultLogFileName);
+			SetupLogger(false, ConsoleOptions.DefaultLogFileName);
 
 			try
 			{
@@ -78,24 +74,21 @@ namespace AssetRipper.GUI
 					Console.ReadKey();
 				}
 			}
-
-			return Task.CompletedTask;
 		}
 
 		private static void ExtractCommandHandler(InvocationContext context, Ripper ripper, Dictionary<string, Option> options)
 		{
-			List<string>? inputs = context.ParseResult.GetValueForOption(inputOption);
-			DirectoryInfo? output = context.ParseResult.GetValueForOption(outputOption);
-			FileInfo? logFile = context.ParseResult.GetValueForOption(logFileOption);
-
-			bool verbose = context.ParseResult.GetValueForOption(verboseOption);
+			List<string>? inputs = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.inputOption, new List<string>());
+			DirectoryInfo? output = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.outputOption, new DirectoryInfo(ConsoleOptions.DefaultOutputPath));
+			FileInfo? logFile = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.logFileOption, new FileInfo(ConsoleOptions.DefaultLogFileName));
+			bool verbose = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.verboseOption, false);
 
 			// Get a list of options supported by LibraryConfiguration
 			// MUST be run after defaults have been filled, as it only lists
 			// options with values.
 			foreach (Type type in ripper.Settings.settings.Keys.ToList())
 			{
-				string optionName = $"-{ToHyphenCase(type.Name)}";
+				string optionName = ConsoleOptions.OptionNameFromType(type);
 
 				if (type == null)
 					continue;
@@ -130,253 +123,17 @@ namespace AssetRipper.GUI
 			DoRipping(ripper, inputs, output.FullName);
 		}
 
-		#region Options
-
-		private static Argument<List<string>>? _inputArgument;
-
-		private static Argument<List<string>> inputArgument
-		{
-			get
-			{
-				if (_inputArgument != null)
-					return _inputArgument;
-
-				Argument<List<string>> argument = new Argument<List<string>>(name: "input", description: "Input files or directory to export");
-
-				argument.AddValidator((symbolResult) =>
-				{
-					List<string>? inputs = symbolResult.GetValueForArgument(argument);
-
-					if (inputs.Count < 1)
-					{
-						symbolResult.ErrorMessage = "No files to export. You must provide at least one path using --input. Use --help for help.";
-						return;
-					}
-
-					foreach (string input in inputs)
-					{
-						string path = ExecutingDirectory.Combine(input);
-
-						if (!MultiFileStream.Exists(path) && !Directory.Exists(path))
-						{
-							symbolResult.ErrorMessage = MultiFileStream.IsMultiFile(path)
-								? $"File '{path}' doesn't have all parts for combining"
-								: $"Neither file nor directory with path '{path}' exists";
-							return;
-						}
-					}
-				});
-
-				_inputArgument = argument;
-
-				return argument;
-			}
-		}
-
-		private static Option<List<string>>? _inputOption;
-
-		private static Option<List<string>> inputOption
-		{
-			get {
-				if (_inputOption != null)
-					return _inputOption;
-
-				Option<List<string>> option = new Option<List<string>>(name: "--input", description: "Input files or directory to export");
-				option.AddAlias("-i");
-				option.IsRequired = true;
-
-				option.AddValidator((symbolResult) =>
-				{
-					List<string>? inputs = symbolResult.GetValueForOption(option);
-
-					if (inputs == null || inputs.Count < 1)
-					{
-						symbolResult.ErrorMessage = "No files to export. You must provide at least one path using --input. Use --help for help.";
-						return;
-					}
-
-					foreach (string input in inputs)
-					{
-						string path = ExecutingDirectory.Combine(input);
-
-						if (!MultiFileStream.Exists(path) && !Directory.Exists(path))
-						{
-							symbolResult.ErrorMessage = MultiFileStream.IsMultiFile(path)
-								? $"File '{path}' doesn't have all parts for combining"
-								: $"Neither file nor directory with path '{path}' exists";
-							return;
-						}
-					}
-				});
-
-				_inputOption = option;
-
-				return option;
-			}
-		}
-
-		private static Option<DirectoryInfo>? _outputOption;
-
-		private static Option<DirectoryInfo> outputOption
-		{
-			get
-			{
-				if (_outputOption != null)
-					return _outputOption;
-
-				Option<DirectoryInfo> option = new Option<DirectoryInfo>(name: "--output", description: "Directory to export to (will be cleared if already exists)");
-				option.AddAlias("-o");
-				option.SetDefaultValue(DefaultOutputPath);
-				option.IsRequired = false;
-
-				option.AddValidator((symbolResult) =>
-				{
-					DirectoryInfo? dirInfo = symbolResult.GetValueForOption(option);
-
-					if (dirInfo == null)
-						dirInfo = new DirectoryInfo(DefaultOutputPath);
-
-					string path = ExecutingDirectory.Combine(dirInfo.FullName);
-
-					if (!Directory.Exists(System.IO.Path.GetDirectoryName(path)))
-						symbolResult.ErrorMessage = "Directory for output does not exist";
-				});
-
-				_outputOption = option;
-
-				return option;
-			}
-		}
-
-		private static Option<bool>? _quitOption;
-
-		private static Option<bool> quitOption
-		{
-			get
-			{
-				if (_quitOption != null)
-					return _quitOption;
-
-				Option<bool> option = new Option<bool>(name: "--quit", description: "Quit after ripping");
-				option.AddAlias("-q");
-				option.SetDefaultValue(DefaultQuit);
-
-				_quitOption = option;
-
-				return option;
-			}
-		}
-
-		private static Option<bool>? _verboseOption;
-
-		private static Option<bool> verboseOption
-		{
-			get
-			{
-				if (_verboseOption != null)
-					return verboseOption;
-
-				Option<bool> option = new Option<bool>(name: "--verbose", description: "Verbose logging output");
-				option.AddAlias("-v");
-				option.SetDefaultValue(DefaultVerbose);
-
-				_verboseOption = option;
-
-				return option;
-			}
-		}
-
-		private static Option<FileInfo>? _logFileOption;
-
-		private static Option<FileInfo> logFileOption
-		{
-			get
-			{
-				if (_logFileOption != null)
-					return _logFileOption;
-
-				Option<FileInfo> option = new Option<FileInfo>(name: "--log-file", description: "File to log to");
-				option.AddAlias("-w");
-				option.SetDefaultValue(DefaultLogFileName);
-
-				option.AddValidator((symbolResult) =>
-				{
-					FileInfo? fileInfo = symbolResult.GetValueForOption(option);
-
-					if (fileInfo == null)
-						fileInfo = new FileInfo(DefaultLogFileName);
-
-					string path = ExecutingDirectory.Combine(fileInfo.FullName);
-
-					if (!Directory.Exists(System.IO.Path.GetDirectoryName(path)))
-						symbolResult.ErrorMessage = "Directory for log file does not exist";
-				});
-
-				_logFileOption = option;
-
-				return option;
-			}
-		}
-
-		#endregion
-
-		private static string ToHyphenCase(string input)
-		{
-			IEnumerable<string> result = input.Select(x =>
-			 {
-				 if (char.IsUpper(x)) return "-" + char.ToLower(x);
-				 return x.ToString();
-			 });
-
-			return string.Join("", result);
-		}
-
-		private static Dictionary<string, Option> CreateOptions(Ripper ripper)
-		{
-			Dictionary<string, Option> options = new Dictionary<string, Option>();
-
-			foreach (Type type in ripper.Settings.settings.Keys)
-			{
-				string optionName = $"-{ToHyphenCase(type.Name)}";
-				Option option = new Option<string>(name: optionName);
-
-				if (type.IsEnum)
-				{
-					string[] values = Enum.GetNames(type);
-					option.AddCompletions(values);
-
-					option.AddValidator((symbolResult) =>
-					{
-						object? input = symbolResult.GetValueForOption(option);
-
-						if (input == null)
-							return;
-
-						string[] names = Enum.GetNames(type);
-
-						if (!names.Contains(input))
-						{
-							symbolResult.ErrorMessage = $"{input} is not a valid option. Valid options: {string.Join(", ", names)}";
-							return;
-						}
-					});
-				}
-
-				options.Add(optionName, option);
-			}
-
-			return options;
-		}
-
 		private static void HandleException(Exception ex)
 		{
+			Environment.ExitCode = 1;
+
 #if DEBUG
 			Console.WriteLine("===================================================");
-			Console.WriteLine("Error during command invocation, extraction aborted");
+			Console.WriteLine("      Error during ripping, extraction aborted     ");
 			Console.WriteLine("===================================================");
 			Console.WriteLine(ex.ToString());
 #else
-			Console.WriteLine("Error during command invocation, extraction aborted");
+			Console.WriteLine("Error during ripping, extraction aborted");
 			Console.WriteLine("See this message below for details:");
 			Console.WriteLine(ex.Message);
 #endif
@@ -387,21 +144,21 @@ namespace AssetRipper.GUI
 			Ripper ripper = new();
 			ripper.Settings.ResetToDefaultValues();
 
-			Dictionary<string, Option> options = CreateOptions(ripper);
+			Dictionary<string, Option> options = ConsoleOptions.GenerateFromRipper(ripper);
 
 			RootCommand rootCommand = new RootCommand();
 			rootCommand.SetHandler((InvocationContext context) => RootCommandHandler(context, ripper));
-			rootCommand.AddArgument(inputArgument);
-			rootCommand.AddOption(outputOption);
-			rootCommand.AddOption(quitOption);
+			rootCommand.AddArgument(ConsoleOptions.inputArgument);
+			rootCommand.AddOption(ConsoleOptions.outputOption);
+			rootCommand.AddOption(ConsoleOptions.quitOption);
 
 			Command extractCommand = new Command("extract");
 			extractCommand.SetHandler((InvocationContext context) => ExtractCommandHandler(context, ripper, options));
 			extractCommand.AddAlias("e");
-			extractCommand.AddOption(inputOption);
-			extractCommand.AddOption(outputOption);
-			extractCommand.AddOption(verboseOption);
-			extractCommand.AddOption(logFileOption);
+			extractCommand.AddOption(ConsoleOptions.inputOption);
+			extractCommand.AddOption(ConsoleOptions.outputOption);
+			extractCommand.AddOption(ConsoleOptions.verboseOption);
+			extractCommand.AddOption(ConsoleOptions.logFileOption);
 
 			foreach (Option option in options.Values)
 			{
@@ -425,15 +182,6 @@ namespace AssetRipper.GUI
 			} catch (Exception ex)
 			{
 				HandleException(ex);
-			}
-		}
-
-		private static void PrepareExportDirectory(string path)
-		{
-			if (Directory.Exists(path))
-			{
-				Logger.Info("Clearing export directory...");
-				Directory.Delete(path, true);
 			}
 		}
 	}

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -1,7 +1,9 @@
-﻿using AssetRipper.Core.IO.MultiFile;
+﻿using AssetRipper.Core.Configuration;
+using AssetRipper.Core.IO.MultiFile;
 using AssetRipper.Core.Logging;
 using AssetRipper.Core.Utils;
 using AssetRipper.Library;
+using AssetRipper.Library.Configuration;
 using CommandLine;
 using System.Collections.Generic;
 using System.IO;
@@ -14,7 +16,7 @@ namespace AssetRipper.GUI
 
 		internal class Options
 		{
-			[Value(0, Required = true, HelpText = "Input files or directory to export.")]
+			[Option('i', "input", Required = true, HelpText = "Input files or directory to export.")]
 			public IReadOnlyList<string> FilesToExport { get; set; }
 
 			[Option('o', "output", HelpText = "Directory to export to. Will be cleared if already exists.")]
@@ -28,6 +30,42 @@ namespace AssetRipper.GUI
 
 			[Option('q', "quit", Default = false, HelpText = "Close console after export.")]
 			public bool Quit { get; set; }
+
+			[Option('b', "bundle-mode", Default = BundledAssetsExportMode.GroupByBundleName, HelpText = "Bundled asset export mode")]
+			public BundledAssetsExportMode BundledAssetsExportMode { get; set; }
+
+			[Option('g', "ignore-streaming", Default = false, HelpText = "Ignore StreamingAssets folder")]
+			public bool IgnoreStreaming { get; set; }
+
+			[Option('a', "audio-format", Default = AudioExportFormat.Default, HelpText = "Audio export format")]
+			public AudioExportFormat AudioExportFormat { get; set; }
+
+			[Option('p', "image-format", Default = ImageExportFormat.Png, HelpText = "Image export format")]
+			public ImageExportFormat ImageExportFormat { get; set; }
+
+			[Option('m', "mesh-format", Default = MeshExportFormat.Native, HelpText = "Mesh export format")]
+			public MeshExportFormat MeshExportFormat { get; set; }
+
+			[Option('s', "sprite-mode", Default = SpriteExportMode.Native, HelpText = "Sprite export mode")]
+			public SpriteExportMode SpriteExportMode { get; set; }
+
+			[Option('t', "terrain-mode", Default = TerrainExportMode.Yaml, HelpText = "Terrain export mode")]
+			public TerrainExportMode TerrainExportMode { get; set; }
+
+			[Option('x', "text-mode", Default = TextExportMode.Parse, HelpText = "Text export mode")]
+			public TextExportMode TextExportMode { get; set; }
+
+			[Option('d', "shader-mode", Default = ShaderExportMode.Dummy, HelpText = "Shader export mode")]
+			public ShaderExportMode ShaderExportMode { get; set; }
+
+			[Option('c', "script-mode", Default = ScriptExportMode.Hybrid, HelpText = "Script export mode")]
+			public ScriptExportMode ScriptExportMode { get; set; }
+
+			[Option('r', "script-level", Default = ScriptContentLevel.Level2, HelpText = "Script content level")]
+			public ScriptContentLevel ScriptContentLevel { get; set; }
+
+			[Option('l', "script-language-version", Default = ScriptLanguageVersion.AutoSafe, HelpText = "Script language version")]
+			public ScriptLanguageVersion ScriptLanguageVersion { get; set; }
 		}
 
 		public static void ParseArgumentsAndRun(string[] args)
@@ -102,6 +140,20 @@ namespace AssetRipper.GUI
 #endif
 			{
 				Ripper ripper = new();
+
+				ripper.Settings.BundledAssetsExportMode = options.BundledAssetsExportMode;
+				ripper.Settings.IgnoreStreamingAssets = options.IgnoreStreaming;
+				ripper.Settings.AudioExportFormat = options.AudioExportFormat;
+				ripper.Settings.ImageExportFormat = options.ImageExportFormat;
+				ripper.Settings.MeshExportFormat = options.MeshExportFormat;
+				ripper.Settings.SpriteExportMode = options.SpriteExportMode;
+				ripper.Settings.TerrainExportMode = options.TerrainExportMode;
+				ripper.Settings.TextExportMode = options.TextExportMode;
+				ripper.Settings.ShaderExportMode = options.ShaderExportMode;
+				ripper.Settings.ScriptExportMode = options.ScriptExportMode;
+				ripper.Settings.ScriptContentLevel = options.ScriptContentLevel;
+				ripper.Settings.ScriptLanguageVersion = options.ScriptLanguageVersion;
+
 				ripper.Settings.LogConfigurationValues();
 				ripper.Load(options.FilesToExport);
 				PrepareExportDirectory(options.OutputDirectory.FullName);

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -81,11 +81,10 @@ namespace AssetRipper.GUI
 			// options with values.
 			foreach (Type type in ripper.Settings.settings.Keys.ToList())
 			{
-				string optionName = ConsoleOptions.OptionNameFromType(type);
-
 				if (type == null)
 					continue;
 
+				string optionName = ConsoleOptions.OptionNameFromType(type);
 				options.TryGetValue(optionName, out Option? option);
 
 				if (option == null)

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -1,12 +1,16 @@
-﻿using AssetRipper.Core.Configuration;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Diagnostics;
+
+using CommandLine;
+using CommandLine.Text;
+
+using AssetRipper.Core.Configuration;
 using AssetRipper.Core.IO.MultiFile;
 using AssetRipper.Core.Logging;
 using AssetRipper.Core.Utils;
 using AssetRipper.Library;
 using AssetRipper.Library.Configuration;
-using CommandLine;
-using System.Collections.Generic;
-using System.IO;
 
 namespace AssetRipper.GUI
 {
@@ -31,46 +35,50 @@ namespace AssetRipper.GUI
 			[Option('q', "quit", Default = false, HelpText = "Close console after export.")]
 			public bool Quit { get; set; }
 
-			[Option('b', "bundle-mode", Default = BundledAssetsExportMode.GroupByBundleName, HelpText = "Bundled asset export mode")]
+			[Option('b', "bundle-mode", Default = BundledAssetsExportMode.GroupByBundleName, HelpText = "Bundled asset export mode\n")]
 			public BundledAssetsExportMode BundledAssetsExportMode { get; set; }
 
 			[Option('g', "ignore-streaming", Default = false, HelpText = "Ignore StreamingAssets folder")]
 			public bool IgnoreStreaming { get; set; }
 
-			[Option('a', "audio-format", Default = AudioExportFormat.Default, HelpText = "Audio export format")]
+			[Option('a', "audio-format", Default = AudioExportFormat.Default, HelpText = "Audio export format\n")]
 			public AudioExportFormat AudioExportFormat { get; set; }
 
-			[Option('p', "image-format", Default = ImageExportFormat.Png, HelpText = "Image export format")]
+			[Option('p', "image-format", Default = ImageExportFormat.Png, HelpText = "Image export format\n")]
 			public ImageExportFormat ImageExportFormat { get; set; }
 
-			[Option('m', "mesh-format", Default = MeshExportFormat.Native, HelpText = "Mesh export format")]
+			[Option('m', "mesh-format", Default = MeshExportFormat.Native, HelpText = "Mesh export format\n")]
 			public MeshExportFormat MeshExportFormat { get; set; }
 
-			[Option('s', "sprite-mode", Default = SpriteExportMode.Native, HelpText = "Sprite export mode")]
+			[Option('s', "sprite-mode", Default = SpriteExportMode.Native, HelpText = "Sprite export mode\n")]
 			public SpriteExportMode SpriteExportMode { get; set; }
 
-			[Option('t', "terrain-mode", Default = TerrainExportMode.Yaml, HelpText = "Terrain export mode")]
+			[Option('t', "terrain-mode", Default = TerrainExportMode.Yaml, HelpText = "Terrain export mode\n")]
 			public TerrainExportMode TerrainExportMode { get; set; }
 
-			[Option('x', "text-mode", Default = TextExportMode.Parse, HelpText = "Text export mode")]
+			[Option('x', "text-mode", Default = TextExportMode.Parse, HelpText = "Text export mode\n")]
 			public TextExportMode TextExportMode { get; set; }
 
-			[Option('d', "shader-mode", Default = ShaderExportMode.Dummy, HelpText = "Shader export mode")]
+			[Option('d', "shader-mode", Default = ShaderExportMode.Dummy, HelpText = "Shader export mode\n")]
 			public ShaderExportMode ShaderExportMode { get; set; }
 
-			[Option('c', "script-mode", Default = ScriptExportMode.Hybrid, HelpText = "Script export mode")]
+			[Option('c', "script-mode", Default = ScriptExportMode.Hybrid, HelpText = "Script export mode\n")]
 			public ScriptExportMode ScriptExportMode { get; set; }
 
-			[Option('r', "script-level", Default = ScriptContentLevel.Level2, HelpText = "Script content level")]
+			[Option('r', "script-level", Default = ScriptContentLevel.Level2, HelpText = "Script content level\n")]
 			public ScriptContentLevel ScriptContentLevel { get; set; }
 
-			[Option('l', "script-language-version", Default = ScriptLanguageVersion.AutoSafe, HelpText = "Script language version")]
+			[Option('l', "script-language-version", Default = ScriptLanguageVersion.AutoSafe, HelpText = "Script language version\n")]
 			public ScriptLanguageVersion ScriptLanguageVersion { get; set; }
 		}
 
 		public static void ParseArgumentsAndRun(string[] args)
 		{
-			Parser.Default.ParseArguments<Options>(args)
+			Parser parser = new Parser(with => with.HelpWriter = null);
+
+			ParserResult<Options> parserResult = parser.ParseArguments<Options>(args);
+
+			parserResult
 				.WithParsed(options =>
 				{
 					if (ValidateOptions(options))
@@ -89,7 +97,32 @@ namespace AssetRipper.GUI
 				})
 				.WithNotParsed((errors) =>
 				{
-					System.Console.ReadKey();
+					HelpText? helpText = HelpText.AutoBuild(parserResult, h =>
+					{
+						Process currentProcess = Process.GetCurrentProcess();
+
+						// System.Diagnostics provides nullable interfaces, so we check all of them
+						// and skip showing the usage example if any of them are null.
+						if (
+							currentProcess != null
+							&& currentProcess.MainModule != null
+							&& !string.IsNullOrEmpty(currentProcess.MainModule.FileName)
+						)
+						{
+							string exeName = Path.GetFileName(currentProcess.MainModule.FileName);
+							h.AddPreOptionsText($"Example: {exeName} -i Games/MyGame -o Code/MyGameDecompiled");
+						}
+
+#if DEBUG
+						h.AddPreOptionsText(string.Join('\n', errors));
+#endif
+
+						h.AddEnumValuesToHelpText = true;
+						h.AdditionalNewLineAfterOption = true;
+						return h;
+					}, e => e);
+
+					Console.WriteLine(helpText);
 				});
 		}
 

--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -19,7 +19,7 @@ namespace AssetRipper.GUI
 			Logger.AllowVerbose = verbose;
 			Logger.Add(new ConsoleLogger(false));
 
-			// Do not log to a file if the logging target is null. It should be AssetRipper.log
+			// Do not log to a file if the logging target is null. It should be set from ConsoleOptions.DefaultLogFileName
 			// if the user didn't specify one.
 			if (string.IsNullOrEmpty(path))
 				return;
@@ -72,6 +72,8 @@ namespace AssetRipper.GUI
 
 		private static void ExtractCommandHandler(InvocationContext context, Ripper ripper, Dictionary<string, Option> options)
 		{
+			ConsoleOptions.SetContext(context);
+
 			List<string>? inputs = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.inputOption, new List<string>());
 			DirectoryInfo? output = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.outputOption, new DirectoryInfo(ConsoleOptions.DefaultOutputPath));
 			FileInfo? logFile = ConsoleOptions.GetOptionOrFallback(ConsoleOptions.logFileOption, new FileInfo(ConsoleOptions.DefaultLogFileName));

--- a/AssetRipper.GUI/ConsoleOptions.cs
+++ b/AssetRipper.GUI/ConsoleOptions.cs
@@ -1,0 +1,308 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+using AssetRipper.Core.IO.MultiFile;
+using AssetRipper.Core.Utils;
+using AssetRipper.Library;
+
+
+namespace AssetRipper.GUI
+{
+	internal static class ConsoleOptions
+	{
+		public const string DefaultLogFileName = "AssetRipper.log";
+		public const string DefaultOutputPath = "Ripped";
+		public const bool DefaultQuit = false;
+		public const bool DefaultVerbose = false;
+
+		private static InvocationContext? _context;
+
+		#region Utilities
+
+		public static string OptionNameFromType(Type input)
+		{
+			IEnumerable<string> result = input.Name.Select(x =>
+			{
+				if (char.IsUpper(x)) return "-" + char.ToLower(x);
+				return x.ToString();
+			});
+
+			return $"-{string.Join("", result)}";
+		}
+
+		public static Dictionary<string, Option> GenerateFromRipper(Ripper ripper)
+		{
+			Dictionary<string, Option> options = new Dictionary<string, Option>();
+
+			foreach (Type type in ripper.Settings.settings.Keys)
+			{
+				string optionName = OptionNameFromType(type);
+				Option option = new Option<string>(name: optionName);
+
+				if (type.IsEnum)
+				{
+					string[] values = Enum.GetNames(type);
+					option.AddCompletions(values);
+
+					option.AddValidator((symbolResult) =>
+					{
+						object? input = symbolResult.GetValueForOption(option);
+
+						if (input == null)
+							return;
+
+						string[] names = Enum.GetNames(type);
+
+						if (!names.Contains(input))
+						{
+							symbolResult.ErrorMessage = $"{input} is not a valid option. Valid options: {string.Join(", ", names)}";
+							return;
+						}
+					});
+				}
+
+				options.Add(optionName, option);
+			}
+
+			return options;
+		}
+
+		public static void SetContext(InvocationContext context)
+		{
+			_context = context;
+		}
+
+		public static T GetOptionOrFallback<T>(Option<T> option, T fallback)
+		{
+			if (_context == null)
+			{
+#if DEBUG
+				Console.WriteLine("Programming error: Context was not set before trying to get an option from it. Returning fallback.");
+#endif
+				return fallback;
+			}
+
+			T? result = _context.ParseResult.GetValueForOption<T>(option);
+
+			if (result == null)
+				return fallback;
+
+			return result;
+		}
+
+		public static T GetArgumentOrFallback<T>(Argument<T> argument, T fallback)
+		{
+			if (_context == null)
+			{
+#if DEBUG
+				Console.WriteLine("Programming error: Context was not set before trying to get an argument from it. Returning fallback.");
+#endif
+				return fallback;
+			}
+
+			T? result = _context.ParseResult.GetValueForArgument<T>(argument);
+
+			if (result == null)
+				return fallback;
+
+			return result;
+		}
+
+		#endregion
+
+		#region Options and Arguments
+
+		private static Argument<List<string>>? _inputArgument;
+
+		public static Argument<List<string>> inputArgument
+		{
+			get
+			{
+				if (_inputArgument != null)
+					return _inputArgument;
+
+				Argument<List<string>> argument = new Argument<List<string>>(name: "input", description: "Input files or directory to export");
+
+				argument.AddValidator((symbolResult) =>
+				{
+					List<string>? inputs = symbolResult.GetValueForArgument(argument);
+
+					if (inputs.Count < 1)
+					{
+						symbolResult.ErrorMessage = "No files to export. You must provide at least one path using --input. Use --help for help.";
+						return;
+					}
+
+					foreach (string input in inputs)
+					{
+						string path = ExecutingDirectory.Combine(input);
+
+						if (!MultiFileStream.Exists(path) && !Directory.Exists(path))
+						{
+							symbolResult.ErrorMessage = MultiFileStream.IsMultiFile(path)
+								? $"File '{path}' doesn't have all parts for combining"
+								: $"Neither file nor directory with path '{path}' exists";
+							return;
+						}
+					}
+				});
+
+				_inputArgument = argument;
+
+				return argument;
+			}
+		}
+
+		private static Option<List<string>>? _inputOption;
+
+		public static Option<List<string>> inputOption
+		{
+			get
+			{
+				if (_inputOption != null)
+					return _inputOption;
+
+				Option<List<string>> option = new Option<List<string>>(name: "--input", description: "Input files or directory to export");
+				option.AddAlias("-i");
+				option.IsRequired = true;
+
+				option.AddValidator((symbolResult) =>
+				{
+					List<string>? inputs = symbolResult.GetValueForOption(option);
+
+					if (inputs == null || inputs.Count < 1)
+					{
+						symbolResult.ErrorMessage = "No files to export. You must provide at least one path using --input. Use --help for help.";
+						return;
+					}
+
+					foreach (string input in inputs)
+					{
+						string path = ExecutingDirectory.Combine(input);
+
+						if (!MultiFileStream.Exists(path) && !Directory.Exists(path))
+						{
+							symbolResult.ErrorMessage = MultiFileStream.IsMultiFile(path)
+								? $"File '{path}' doesn't have all parts for combining"
+								: $"Neither file nor directory with path '{path}' exists";
+							return;
+						}
+					}
+				});
+
+				_inputOption = option;
+
+				return option;
+			}
+		}
+
+		private static Option<DirectoryInfo>? _outputOption;
+
+		public static Option<DirectoryInfo> outputOption
+		{
+			get
+			{
+				if (_outputOption != null)
+					return _outputOption;
+
+				Option<DirectoryInfo> option = new Option<DirectoryInfo>(name: "--output", description: "Directory to export to (will be cleared if already exists)");
+				option.AddAlias("-o");
+				option.SetDefaultValue(DefaultOutputPath);
+				option.IsRequired = false;
+
+				option.AddValidator((symbolResult) =>
+				{
+					DirectoryInfo? dirInfo = symbolResult.GetValueForOption(option);
+
+					if (dirInfo == null)
+						dirInfo = new DirectoryInfo(DefaultOutputPath);
+
+					string path = ExecutingDirectory.Combine(dirInfo.FullName);
+
+					if (!Directory.Exists(System.IO.Path.GetDirectoryName(path)))
+						symbolResult.ErrorMessage = "Directory for output does not exist";
+				});
+
+				_outputOption = option;
+
+				return option;
+			}
+		}
+
+		private static Option<bool>? _quitOption;
+
+		public static Option<bool> quitOption
+		{
+			get
+			{
+				if (_quitOption != null)
+					return _quitOption;
+
+				Option<bool> option = new Option<bool>(name: "--quit", description: "Quit after ripping");
+				option.AddAlias("-q");
+				option.SetDefaultValue(DefaultQuit);
+
+				_quitOption = option;
+
+				return option;
+			}
+		}
+
+		private static Option<bool>? _verboseOption;
+
+		public static Option<bool> verboseOption
+		{
+			get
+			{
+				if (_verboseOption != null)
+					return verboseOption;
+
+				Option<bool> option = new Option<bool>(name: "--verbose", description: "Verbose logging output");
+				option.AddAlias("-v");
+				option.SetDefaultValue(DefaultVerbose);
+
+				_verboseOption = option;
+
+				return option;
+			}
+		}
+
+		private static Option<FileInfo>? _logFileOption;
+
+		public static Option<FileInfo> logFileOption
+		{
+			get
+			{
+				if (_logFileOption != null)
+					return _logFileOption;
+
+				Option<FileInfo> option = new Option<FileInfo>(name: "--log-file", description: "File to log to");
+				option.AddAlias("-w");
+				option.SetDefaultValue(DefaultLogFileName);
+
+				option.AddValidator((symbolResult) =>
+				{
+					FileInfo? fileInfo = symbolResult.GetValueForOption(option);
+
+					if (fileInfo == null)
+						fileInfo = new FileInfo(DefaultLogFileName);
+
+					string path = ExecutingDirectory.Combine(fileInfo.FullName);
+
+					if (!Directory.Exists(System.IO.Path.GetDirectoryName(path)))
+						symbolResult.ErrorMessage = "Directory for log file does not exist";
+				});
+
+				_logFileOption = option;
+
+				return option;
+			}
+		}
+
+		#endregion
+	}
+}

--- a/AssetRipper.GUI/ConsoleOptions.cs
+++ b/AssetRipper.GUI/ConsoleOptions.cs
@@ -127,15 +127,10 @@ namespace AssetRipper.GUI
 
 				Argument<List<string>> argument = new Argument<List<string>>(name: "input", description: "Input files or directory to export");
 
+				argument.Arity = ArgumentArity.OneOrMore;
 				argument.AddValidator((symbolResult) =>
 				{
 					List<string>? inputs = symbolResult.GetValueForArgument(argument);
-
-					if (inputs.Count < 1)
-					{
-						symbolResult.ErrorMessage = "No files to export. You must provide at least one path using --input. Use --help for help.";
-						return;
-					}
 
 					foreach (string input in inputs)
 					{

--- a/AssetRipper.GUI/ConsoleOptions.cs
+++ b/AssetRipper.GUI/ConsoleOptions.cs
@@ -259,7 +259,7 @@ namespace AssetRipper.GUI
 			get
 			{
 				if (_verboseOption != null)
-					return verboseOption;
+					return _verboseOption;
 
 				Option<bool> option = new Option<bool>(name: "--verbose", description: "Verbose logging output");
 				option.AddAlias("-v");

--- a/AssetRipper.GUI/ConsoleOptions.cs
+++ b/AssetRipper.GUI/ConsoleOptions.cs
@@ -29,17 +29,31 @@ namespace AssetRipper.GUI
 
 		#region Utilities
 
-		public static string OptionNameFromType(Type input)
+		/// <summary>
+		/// Converts the name of the given type to hyphen-case, with a leading hyphen.
+		/// For example: ConsoleOptions -> -console-options (if using the default separator)
+		/// </summary>
+		/// <param name="input">The type to get the name of</param>
+		/// <param name="separator">Char to use as separator</param>
+		/// <returns></returns>
+		public static string OptionNameFromType(Type input, char separator = '-')
 		{
-			IEnumerable<string> result = input.Name.Select(x =>
+			IEnumerable<string> result = input.Name.Select((character) =>
 			{
-				if (char.IsUpper(x)) return "-" + char.ToLower(x);
-				return x.ToString();
+				if (char.IsUpper(character))
+					return $"{separator}{char.ToLower(character)}";
+
+				return character.ToString();
 			});
 
-			return $"-{string.Join("", result)}";
+			return $"{separator}{string.Join("", result)}";
 		}
 
+		/// <summary>
+		/// Generates a Dictionary of `System.CommandLine.Option`s indexed by their name,
+		/// based on what settings are currently available. Each option will be named in
+		/// hyphen-case sa standard for cli options.
+		/// </summary>
 		public static Dictionary<string, Option> GenerateFromRipper(Ripper ripper)
 		{
 			Dictionary<string, Option> options = new Dictionary<string, Option>();
@@ -77,11 +91,23 @@ namespace AssetRipper.GUI
 			return options;
 		}
 
+		/// <summary>
+		/// Sets the given InvocationContext so that GetOptionOrFallback and GetArgumentOrFallback
+		/// can read from it later. This function MUST be called before the above mentioned ones do.
+		/// </summary>
+		/// <param name="context">InvocationContext provided by System.CommandLine</param>
 		public static void SetContext(InvocationContext context)
 		{
 			_context = context;
 		}
 
+		/// <summary>
+		/// Gets the values for a given Option. If the result is null, the fallback value is returned.
+		/// </summary>
+		/// <typeparam name="T">The type of the resulting object</typeparam>
+		/// <param name="option">An Option object from System.CommandLine</param>
+		/// <param name="fallback">The value to return if the parse result is null</param>
+		/// <returns>T</returns>
 		public static T GetOptionOrFallback<T>(Option<T> option, T fallback)
 		{
 			if (_context == null)
@@ -100,6 +126,13 @@ namespace AssetRipper.GUI
 			return result;
 		}
 
+		/// <summary>
+		/// Gets the values for a given positional Argument. If the result is null, the fallback value is returned.
+		/// </summary>
+		/// <typeparam name="T">The type of the resulting object</typeparam>
+		/// <param name="option">An Argument object from System.CommandLine</param>
+		/// <param name="fallback">The value to return if the parse result is null</param>
+		/// <returns>T</returns>
 		public static T GetArgumentOrFallback<T>(Argument<T> argument, T fallback)
 		{
 			if (_context == null)

--- a/AssetRipper.GUI/MainWindow.ViewModel.Configuration.cs
+++ b/AssetRipper.GUI/MainWindow.ViewModel.Configuration.cs
@@ -28,80 +28,80 @@ namespace AssetRipper.GUI
 
 		public AudioExportFormat AudioExportFormat
 		{
-			get => _ripper.Settings.AudioExportFormat;
+			get => _ripper.Settings.GetSetting<AudioExportFormat>();
 			set
 			{
-				_ripper.Settings.AudioExportFormat = value;
+				_ripper.Settings.SetSetting<AudioExportFormat>(value);
 				OnPropertyChanged();
 			}
 		}
 
 		public ImageExportFormat ImageExportFormat
 		{
-			get => _ripper.Settings.ImageExportFormat;
+			get => _ripper.Settings.GetSetting<ImageExportFormat>();
 			set
 			{
-				_ripper.Settings.ImageExportFormat = value;
+				_ripper.Settings.SetSetting<ImageExportFormat>(value);
 				OnPropertyChanged();
 			}
 		}
 
 		public MeshExportFormat MeshExportFormat
 		{
-			get => _ripper.Settings.MeshExportFormat;
+			get => _ripper.Settings.GetSetting<MeshExportFormat>();
 			set
 			{
-				_ripper.Settings.MeshExportFormat = value;
+				_ripper.Settings.SetSetting<MeshExportFormat>(value);
 				OnPropertyChanged();
 			}
 		}
 
 		public SpriteExportMode SpriteExportMode
 		{
-			get => _ripper.Settings.SpriteExportMode;
+			get => _ripper.Settings.GetSetting<SpriteExportMode>();
 			set
 			{
-				_ripper.Settings.SpriteExportMode = value;
+				_ripper.Settings.SetSetting<SpriteExportMode>(value);
 				OnPropertyChanged();
 			}
 		}
 
 		public TerrainExportMode TerrainExportMode
 		{
-			get => _ripper.Settings.TerrainExportMode;
+			get => _ripper.Settings.GetSetting<TerrainExportMode>();
 			set
 			{
-				_ripper.Settings.TerrainExportMode = value;
+				_ripper.Settings.SetSetting<TerrainExportMode>(value);
 				OnPropertyChanged();
 			}
 		}
 
 		public TextExportMode TextExportMode
 		{
-			get => _ripper.Settings.TextExportMode;
+			get => _ripper.Settings.GetSetting<TextExportMode>();
 			set
 			{
-				_ripper.Settings.TextExportMode = value;
+				_ripper.Settings.SetSetting<TextExportMode>(value);
 				OnPropertyChanged();
 			}
 		}
 
 		public ShaderExportMode ShaderExportMode
 		{
-			get => _ripper.Settings.ShaderExportMode;
+			get => _ripper.Settings.GetSetting<ShaderExportMode>();
 			set
 			{
-				_ripper.Settings.ShaderExportMode = value;
+				_ripper.Settings.SetSetting<ShaderExportMode>(value);
 				OnPropertyChanged();
 			}
 		}
 
 		public ScriptExportMode ScriptExportMode
 		{
-			get => _ripper.Settings.ScriptExportMode;
+			get => _ripper.Settings.GetSetting<ScriptExportMode>();
 			set
 			{
-				_ripper.Settings.ScriptExportMode = value;
+				_ripper.Settings.SetSetting<ScriptExportMode>(value);
 				OnPropertyChanged();
 			}
 		}
@@ -118,10 +118,10 @@ namespace AssetRipper.GUI
 
 		public ScriptLanguageVersion ScriptLanguageVersion
 		{
-			get => _ripper.Settings.ScriptLanguageVersion;
+			get => _ripper.Settings.GetSetting<ScriptLanguageVersion>();
 			set
 			{
-				_ripper.Settings.ScriptLanguageVersion = value;
+				_ripper.Settings.SetSetting<ScriptLanguageVersion>(value);
 				OnPropertyChanged();
 			}
 		}

--- a/AssetRipper.Library/Configuration/LibraryConfiguration.cs
+++ b/AssetRipper.Library/Configuration/LibraryConfiguration.cs
@@ -9,60 +9,46 @@ namespace AssetRipper.Library.Configuration
 	{
 		public Dictionary<Type, object> settings = new Dictionary<Type, object>();
 
-		/*
-		/// <summary>
-		/// The file format that audio clips get exported in. Recommended: Ogg
-		/// </summary>
-		public AudioExportFormat AudioExportFormat { get; set; }
-		/// <summary>
-		/// The file format that images (like textures) get exported in.
-		/// </summary>
-		public ImageExportFormat ImageExportFormat { get; set; }
-		/// <summary>
-		/// The format that meshes get exported in. Recommended: Native
-		/// </summary>
-		public MeshExportFormat MeshExportFormat { get; set; }
-		/// <summary>
-		/// How are MonoScripts exported? Recommended: Decompiled
-		/// </summary>
-		public ScriptExportMode ScriptExportMode { get; set; }
-		/// <summary>
-		/// The C# language version of decompiled scripts.
-		/// </summary>
-		public ScriptLanguageVersion ScriptLanguageVersion { get; set; }
-		/// <summary>
-		/// How to export shaders?
-		/// </summary>
-		public ShaderExportMode ShaderExportMode { get; set; }
-		/// <summary>
-		/// Should sprites be exported as a texture? Recommended: Native
-		/// </summary>
-		public SpriteExportMode SpriteExportMode { get; set; }
-		/// <summary>
-		/// How terrain data is exported. Recommended: Native
-		/// </summary>
-		public TerrainExportMode TerrainExportMode { get; set; }
-		/// <summary>
-		/// How are text assets exported?
-		/// </summary>
-		public TextExportMode TextExportMode { get; set; }
-		*/
-
 		public T? GetSetting<T>()
 		{
-			this.settings.TryGetValue(typeof(T), out object? result);
+			object? result = this.settings.GetValueOrDefault(typeof(T));
+
+			if (result == null || result == default)
+				return default(T);
 
 			return (T?)result;
 		}
 
+		public void SetSetting(Type type, object value)
+		{
+			if (value == null)
+				return;
+
+			this.settings.Remove(type);
+			this.settings.Add(type, value);
+		}
+
 		public void SetSetting<T>(object value)
 		{
-			this.settings.TryAdd(typeof(T), value);
+			if (value == null)
+				return;
+
+			this.settings.Remove(typeof(T));
+			this.settings.Add(typeof(T), value);
+		}
+
+		// NOTE: Is this actually a good idea? If this is called AFTER we set the default values,
+		// the removed setting will not be restored to its default value, but it will just start
+		// returning null.
+		public void RemoveSetting<T>()
+		{
+			this.settings.Remove(typeof(T));
 		}
 
 		public override void ResetToDefaultValues()
 		{
 			base.ResetToDefaultValues();
+
 			this.SetSetting<AudioExportFormat>(AudioExportFormat.Default);
 			this.SetSetting<ImageExportFormat>(ImageExportFormat.Png);
 			this.SetSetting<MeshExportFormat>(MeshExportFormat.Native);

--- a/AssetRipper.Library/Configuration/LibraryConfiguration.cs
+++ b/AssetRipper.Library/Configuration/LibraryConfiguration.cs
@@ -7,44 +7,6 @@ namespace AssetRipper.Library.Configuration
 {
 	public class LibraryConfiguration : CoreConfiguration
 	{
-		public Dictionary<Type, object> settings = new Dictionary<Type, object>();
-
-		public T? GetSetting<T>()
-		{
-			object? result = this.settings.GetValueOrDefault(typeof(T));
-
-			if (result == null || result == default)
-				return default(T);
-
-			return (T?)result;
-		}
-
-		public void SetSetting(Type type, object value)
-		{
-			if (value == null)
-				return;
-
-			this.settings.Remove(type);
-			this.settings.Add(type, value);
-		}
-
-		public void SetSetting<T>(object value)
-		{
-			if (value == null)
-				return;
-
-			this.settings.Remove(typeof(T));
-			this.settings.Add(typeof(T), value);
-		}
-
-		// NOTE: Is this actually a good idea? If this is called AFTER we set the default values,
-		// the removed setting will not be restored to its default value, but it will just start
-		// returning null.
-		public void RemoveSetting<T>()
-		{
-			this.settings.Remove(typeof(T));
-		}
-
 		public override void ResetToDefaultValues()
 		{
 			base.ResetToDefaultValues();

--- a/AssetRipper.Library/Configuration/LibraryConfiguration.cs
+++ b/AssetRipper.Library/Configuration/LibraryConfiguration.cs
@@ -1,10 +1,15 @@
-﻿using AssetRipper.Core.Configuration;
+﻿using System.Collections.Generic;
+
+using AssetRipper.Core.Configuration;
 using AssetRipper.Core.Logging;
 
 namespace AssetRipper.Library.Configuration
 {
 	public class LibraryConfiguration : CoreConfiguration
 	{
+		public Dictionary<Type, object> settings = new Dictionary<Type, object>();
+
+		/*
 		/// <summary>
 		/// The file format that audio clips get exported in. Recommended: Ogg
 		/// </summary>
@@ -41,33 +46,47 @@ namespace AssetRipper.Library.Configuration
 		/// How are text assets exported?
 		/// </summary>
 		public TextExportMode TextExportMode { get; set; }
+		*/
+
+		public T? GetSetting<T>()
+		{
+			this.settings.TryGetValue(typeof(T), out object? result);
+
+			return (T?)result;
+		}
+
+		public void SetSetting<T>(object value)
+		{
+			this.settings.TryAdd(typeof(T), value);
+		}
 
 		public override void ResetToDefaultValues()
 		{
 			base.ResetToDefaultValues();
-			AudioExportFormat = AudioExportFormat.Default;
-			ImageExportFormat = ImageExportFormat.Png;
-			MeshExportFormat = MeshExportFormat.Native;
-			ScriptExportMode = ScriptExportMode.Decompiled;
-			ScriptLanguageVersion = ScriptLanguageVersion.AutoSafe;
-			ShaderExportMode = ShaderExportMode.Dummy;
-			SpriteExportMode = SpriteExportMode.Yaml;
-			TerrainExportMode = TerrainExportMode.Yaml;
-			TextExportMode = TextExportMode.Parse;
+			this.SetSetting<AudioExportFormat>(AudioExportFormat.Default);
+			this.SetSetting<ImageExportFormat>(ImageExportFormat.Png);
+			this.SetSetting<MeshExportFormat>(MeshExportFormat.Native);
+			this.SetSetting<ScriptExportMode>(ScriptExportMode.Decompiled);
+			this.SetSetting<ScriptLanguageVersion>(ScriptLanguageVersion.AutoSafe);
+			this.SetSetting<ShaderExportMode>(ShaderExportMode.Dummy);
+			this.SetSetting<SpriteExportMode>(SpriteExportMode.Yaml);
+			this.SetSetting<TerrainExportMode>(TerrainExportMode.Yaml);
+			this.SetSetting<TextExportMode>(TextExportMode.Parse);
 		}
 
 		public override void LogConfigurationValues()
 		{
 			base.LogConfigurationValues();
-			Logger.Info(LogCategory.General, $"{nameof(AudioExportFormat)}: {AudioExportFormat}");
-			Logger.Info(LogCategory.General, $"{nameof(ImageExportFormat)}: {ImageExportFormat}");
-			Logger.Info(LogCategory.General, $"{nameof(MeshExportFormat)}: {MeshExportFormat}");
-			Logger.Info(LogCategory.General, $"{nameof(ScriptExportMode)}: {ScriptExportMode}");
-			Logger.Info(LogCategory.General, $"{nameof(ScriptLanguageVersion)}: {ScriptLanguageVersion}");
-			Logger.Info(LogCategory.General, $"{nameof(ShaderExportMode)}: {ShaderExportMode}");
-			Logger.Info(LogCategory.General, $"{nameof(SpriteExportMode)}: {SpriteExportMode}");
-			Logger.Info(LogCategory.General, $"{nameof(TerrainExportMode)}: {TerrainExportMode}");
-			Logger.Info(LogCategory.General, $"{nameof(TextExportMode)}: {TextExportMode}");
+
+			Logger.Info(LogCategory.General, $"{nameof(AudioExportFormat)}: {this.GetSetting<AudioExportFormat>()}");
+			Logger.Info(LogCategory.General, $"{nameof(ImageExportFormat)}: {this.GetSetting<ImageExportFormat>()}");
+			Logger.Info(LogCategory.General, $"{nameof(MeshExportFormat)}: {this.GetSetting<MeshExportFormat>()}");
+			Logger.Info(LogCategory.General, $"{nameof(ScriptExportMode)}: {this.GetSetting<ScriptExportMode>()}");
+			Logger.Info(LogCategory.General, $"{nameof(ScriptLanguageVersion)}: {this.GetSetting<ScriptLanguageVersion>()}");
+			Logger.Info(LogCategory.General, $"{nameof(ShaderExportMode)}: {this.GetSetting<ShaderExportMode>()}");
+			Logger.Info(LogCategory.General, $"{nameof(SpriteExportMode)}: {this.GetSetting<SpriteExportMode>()}");
+			Logger.Info(LogCategory.General, $"{nameof(TerrainExportMode)}: {this.GetSetting<TerrainExportMode>()}");
+			Logger.Info(LogCategory.General, $"{nameof(TextExportMode)}: {this.GetSetting<TextExportMode>()}");
 		}
 	}
 }

--- a/AssetRipper.Library/Exporters/Audio/AudioClipExporter.cs
+++ b/AssetRipper.Library/Exporters/Audio/AudioClipExporter.cs
@@ -14,7 +14,7 @@ namespace AssetRipper.Library.Exporters.Audio
 	public sealed class AudioClipExporter : BinaryAssetExporter
 	{
 		public AudioExportFormat AudioFormat { get; }
-		public AudioClipExporter(LibraryConfiguration configuration) => AudioFormat = configuration.AudioExportFormat;
+		public AudioClipExporter(LibraryConfiguration configuration) => AudioFormat = configuration.GetSetting<AudioExportFormat>();
 
 		public override bool IsHandle(IUnityObjectBase asset)
 		{

--- a/AssetRipper.Library/Exporters/Miscellaneous/TextAssetExporter.cs
+++ b/AssetRipper.Library/Exporters/Miscellaneous/TextAssetExporter.cs
@@ -16,7 +16,7 @@ namespace AssetRipper.Library.Exporters.Miscellaneous
 		public TextExportMode ExportMode { get; }
 		public TextAssetExporter(LibraryConfiguration configuration)
 		{
-			ExportMode = configuration.TextExportMode;
+			ExportMode = configuration.GetSetting<TextExportMode>();
 		}
 
 		public override bool IsHandle(IUnityObjectBase asset)

--- a/AssetRipper.Library/Exporters/Scripts/AssemblyDllExporter.cs
+++ b/AssetRipper.Library/Exporters/Scripts/AssemblyDllExporter.cs
@@ -19,7 +19,7 @@ namespace AssetRipper.Library.Exporters.Scripts
 		public AssemblyDllExporter(IAssemblyManager assemblyManager, LibraryConfiguration configuration)
 		{
 			AssemblyManager = assemblyManager;
-			ScriptExportMode = configuration.ScriptExportMode;
+			ScriptExportMode = configuration.GetSetting<ScriptExportMode>();
 		}
 
 		public bool IsHandle(IUnityObjectBase asset)

--- a/AssetRipper.Library/Exporters/Scripts/ScriptExporter.cs
+++ b/AssetRipper.Library/Exporters/Scripts/ScriptExporter.cs
@@ -24,9 +24,9 @@ namespace AssetRipper.Library.Exporters.Scripts
 		public ScriptExporter(IAssemblyManager assemblyManager, LibraryConfiguration configuration)
 		{
 			AssemblyManager = assemblyManager;
-			ScriptExportMode = configuration.ScriptExportMode;
+			ScriptExportMode = configuration.GetSetting<ScriptExportMode>();
 			Decompiler = new ScriptDecompiler(AssemblyManager);
-			LanguageVersion = configuration.ScriptLanguageVersion.ToCSharpLanguageVersion(configuration.Version);
+			LanguageVersion = configuration.GetSetting<ScriptLanguageVersion>().ToCSharpLanguageVersion(configuration.Version);
 			ScriptContentLevel = configuration.ScriptContentLevel;
 			Enabled = ScriptExportMode == ScriptExportMode.Decompiled;
 		}

--- a/AssetRipper.Library/Exporters/Terrains/TerrainHeatmapExporter.cs
+++ b/AssetRipper.Library/Exporters/Terrains/TerrainHeatmapExporter.cs
@@ -17,7 +17,7 @@ namespace AssetRipper.Library.Exporters.Terrains
 		public ImageExportFormat ImageFormat { get; }
 		public TerrainHeatmapExporter(LibraryConfiguration configuration)
 		{
-			ImageFormat = configuration.ImageExportFormat;
+			ImageFormat = configuration.GetSetting<ImageExportFormat>();
 		}
 
 		public override bool IsHandle(IUnityObjectBase asset)

--- a/AssetRipper.Library/Exporters/Textures/TextureAssetExporter.cs
+++ b/AssetRipper.Library/Exporters/Textures/TextureAssetExporter.cs
@@ -23,8 +23,8 @@ namespace AssetRipper.Library.Exporters.Textures
 
 		public TextureAssetExporter(LibraryConfiguration configuration)
 		{
-			ImageExportFormat = configuration.ImageExportFormat;
-			SpriteExportMode = configuration.SpriteExportMode;
+			ImageExportFormat = configuration.GetSetting<ImageExportFormat>();
+			SpriteExportMode = configuration.GetSetting<SpriteExportMode>();
 		}
 
 		public override bool IsHandle(IUnityObjectBase asset)

--- a/AssetRipper.Library/Ripper.cs
+++ b/AssetRipper.Library/Ripper.cs
@@ -287,20 +287,20 @@ namespace AssetRipper.Library
 			OverrideExporter<ITexture2D>(textureExporter); //Texture2D and Cubemap
 			OverrideExporter<ISprite>(textureExporter);
 			YamlSpriteExporter spriteExporter = new();
-			ConditionalOverrideExporter<ISprite>(spriteExporter, Settings.SpriteExportMode == SpriteExportMode.Yaml);
-			ConditionalOverrideExporter<ISpriteAtlas>(spriteExporter, Settings.SpriteExportMode == SpriteExportMode.Yaml);
+			ConditionalOverrideExporter<ISprite>(spriteExporter, Settings.GetSetting<SpriteExportMode>() == SpriteExportMode.Yaml);
+			ConditionalOverrideExporter<ISpriteAtlas>(spriteExporter, Settings.GetSetting<SpriteExportMode>() == SpriteExportMode.Yaml);
 
 			//Shader exporters
 			OverrideExporter<IShader>(new DummyShaderTextExporter());
-			ConditionalOverrideExporter<IShader>(new YamlShaderExporter(), Settings.ShaderExportMode == ShaderExportMode.Yaml);
-			ConditionalOverrideExporter<IShader>(new ShaderDisassemblyExporter(), Settings.ShaderExportMode == ShaderExportMode.Disassembly);
-			ConditionalOverrideExporter<IShader>(new USCShaderExporter(), Settings.ShaderExportMode == ShaderExportMode.Decompile);
+			ConditionalOverrideExporter<IShader>(new YamlShaderExporter(), Settings.GetSetting<ShaderExportMode>() == ShaderExportMode.Yaml);
+			ConditionalOverrideExporter<IShader>(new ShaderDisassemblyExporter(), Settings.GetSetting<ShaderExportMode>() == ShaderExportMode.Disassembly);
+			ConditionalOverrideExporter<IShader>(new USCShaderExporter(), Settings.GetSetting<ShaderExportMode>() == ShaderExportMode.Decompile);
 			OverrideExporter<IShader>(new SimpleShaderExporter());
 
 			//Audio exporters
 			OverrideExporter<IAudioClip>(new YamlAudioExporter());
-			ConditionalOverrideExporter<IAudioClip>(new NativeAudioExporter(), Settings.AudioExportFormat == AudioExportFormat.Native);
-			ConditionalOverrideExporter<IAudioClip>(new AudioClipExporter(Settings), AudioClipExporter.IsSupportedExportFormat(Settings.AudioExportFormat));
+			ConditionalOverrideExporter<IAudioClip>(new NativeAudioExporter(), Settings.GetSetting<AudioExportFormat>() == AudioExportFormat.Native);
+			ConditionalOverrideExporter<IAudioClip>(new AudioClipExporter(Settings), AudioClipExporter.IsSupportedExportFormat(Settings.GetSetting<AudioExportFormat>()));
 			
 			//AudioMixer exporters
 			AudioMixerExporter audioMixerExporter = new();
@@ -309,17 +309,17 @@ namespace AssetRipper.Library
 			OverrideExporter<IAudioMixerSnapshotController>(audioMixerExporter);
 
 			//Mesh exporters
-			ConditionalOverrideExporter<IMesh>(new GlbMeshExporter(), Settings.MeshExportFormat == MeshExportFormat.Glb);
+			ConditionalOverrideExporter<IMesh>(new GlbMeshExporter(), Settings.GetSetting<MeshExportFormat>() == MeshExportFormat.Glb);
 
 			//Model exporters
 			GlbModelExporter glbModelExporter = new();
-			ConditionalOverrideExporter<IComponent>(glbModelExporter, Settings.MeshExportFormat == MeshExportFormat.Glb);
-			ConditionalOverrideExporter<IGameObject>(glbModelExporter, Settings.MeshExportFormat == MeshExportFormat.Glb);
-			ConditionalOverrideExporter<ILevelGameManager>(glbModelExporter, Settings.MeshExportFormat == MeshExportFormat.Glb);
+			ConditionalOverrideExporter<IComponent>(glbModelExporter, Settings.GetSetting<MeshExportFormat>() == MeshExportFormat.Glb);
+			ConditionalOverrideExporter<IGameObject>(glbModelExporter, Settings.GetSetting<MeshExportFormat>() == MeshExportFormat.Glb);
+			ConditionalOverrideExporter<ILevelGameManager>(glbModelExporter, Settings.GetSetting<MeshExportFormat>() == MeshExportFormat.Glb);
 
 			//Terrain exporters
-			ConditionalOverrideExporter<ITerrainData>(new TerrainHeatmapExporter(Settings), Settings.TerrainExportMode == TerrainExportMode.Heatmap);
-			ConditionalOverrideExporter<ITerrainData>(new TerrainMeshExporter(), Settings.TerrainExportMode == TerrainExportMode.Mesh);
+			ConditionalOverrideExporter<ITerrainData>(new TerrainHeatmapExporter(Settings), Settings.GetSetting<TerrainExportMode>() == TerrainExportMode.Heatmap);
+			ConditionalOverrideExporter<ITerrainData>(new TerrainMeshExporter(), Settings.GetSetting<TerrainExportMode>() == TerrainExportMode.Mesh);
 
 			//Script exporters
 			OverrideExporter<IMonoScript>(new AssemblyDllExporter(GameStructure.FileCollection.AssemblyManager, Settings));


### PR DESCRIPTION
Thanks for working on this project! I recently had to write a small script that uses AssetRipper, and noticed that most of the options are missing from the CLI. This PR improves the command line interface, and brings it to feature parity with the GUI.

List of changes:
- Adds command line options for the following settings:
  - Bundled assets export mode
  - Ignore StreamingAssets folder
  - Audio export format
  - Image export format
  - Mesh export format
  - Sprite export mode
  - Terrain export mode
  - Text export mode
  - Shader export mode
  - Script export mode
  - Script export level
  - Script language version
- Inverts the `-q` logic and renames it to `-k` (`--keep-open`). It's much more likely that a command line user will expect AssetRipper to exit after it's done, as the printed logs will be available on the user's screen even after it quits, provided that AssetRipper was launched from an already open terminal. In case it's launched through a shortcut that opens its own terminal, the `-k` option is available to get the previous behaviour.
- Fixes compiler warnings, as CommandLine provides nullable types for some of its options. These values are then checked before they're used.
- Makes `-o` a required parameter, it looked like it was meant to be required, as it had no default.
- The `--help` output now has an expanded `.WithNotParsed` handler so it can print enum values. In debug builds, it also prints out the error names that caused the help screen to be printed as well.
- Makes small code style changes so the same style is used throughout `ConsoleApp.cs`.