### PR TITLE
Enable cache server upload&download

### DIFF
--- a/AssetRipper.Core/SourceGenExtensions/EditorSettingsExtensions.cs
+++ b/AssetRipper.Core/SourceGenExtensions/EditorSettingsExtensions.cs
@@ -36,8 +36,8 @@ namespace AssetRipper.Core.SourceGenExtensions
 			settings.CacheServerMode_C159 = (int)CacheServerMode.AsPreferences;
 			settings.CacheServerEndpoint_C159.TrySet(string.Empty);
 			settings.CacheServerNamespacePrefix_C159.TrySet("default");
-			settings.CacheServerEnableDownload_C159 = false;
-			settings.CacheServerEnableUpload_C159 = false;
+			settings.CacheServerEnableDownload_C159 = true;
+			settings.CacheServerEnableUpload_C159 = true;
 
 			settings.ShowLightmapResolutionOverlay_C159 = true;
 			settings.UseLegacyProbeSampleCount_C159 = true;


### PR DESCRIPTION
Cache server upload&download are enabled when a new Unity project is created from Unity Hub.
I think projects exported by AssetRipper should match the default behavior.