### PR TITLE
Filter output files by name

### DIFF
--- a/AssetRipper.GUI/ConsoleApp.cs
+++ b/AssetRipper.GUI/ConsoleApp.cs
@@ -28,6 +28,9 @@ namespace AssetRipper.GUI
 
 			[Option('q', "quit", Default = false, HelpText = "Close console after export.")]
 			public bool Quit { get; set; }
+
+			[Option('f', "filespec", HelpText = "File pattern to export, including glob wildcards * ** ?")]
+			public String FileSpec { get; set; }
 		}
 
 		public static void ParseArgumentsAndRun(string[] args)
@@ -80,6 +83,7 @@ namespace AssetRipper.GUI
 			{
 				options.LogFile ??= new FileInfo(ExecutingDirectory.Combine(DefaultLogFileName));
 				options.OutputDirectory ??= new DirectoryInfo(ExecutingDirectory.Combine("Ripped"));
+				options.FileSpec ??= "*";
 			}
 			catch (Exception ex)
 			{
@@ -105,7 +109,7 @@ namespace AssetRipper.GUI
 				ripper.Settings.LogConfigurationValues();
 				ripper.Load(options.FilesToExport);
 				PrepareExportDirectory(options.OutputDirectory.FullName);
-				ripper.ExportProject(options.OutputDirectory.FullName);
+				ripper.ExportProject(options.OutputDirectory.FullName, options.FileSpec);
 			}
 #if !DEBUG
 			catch (Exception ex)


### PR DESCRIPTION
The goal here is to filter output asset files by their full exported path/filename.extension, equivalent to passing a `list` command line parameter to `unzip`. This PR achieves filtering based on `asset.GetOriginalName()` which is a step toward that goal. Getting the final path and name and extension seems to require a significant chunk of the code path down toward the existing call to `IProjectAssetContainer.TryGetAssetPathFromAssets()` which I was not able to successfully reproduce.

My use case is to use AssetRipper from the command line to extract music files from games, to be called from my own project https://github.com/sparr/vgm-extractor. As things stand now, I'll have to extract everything then delete the files I don't want, which eats up a lot of extra cpu and i/o time and disk space along the way.