### PR TITLE
fix: macOS arm64 binary crash (fixes #551)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,3 +190,4 @@ jobs:
         name: AssetRipper_mac_arm64
         path: /home/runner/work/AssetRipper/AssetRipper/Bins/Publish/AssetRipper_mac_arm64/*
         if-no-files-found: error
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,7 +130,7 @@ jobs:
 
 
    publish_mac_x64:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -162,7 +162,7 @@ jobs:
 
 
    publish_mac_arm64:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,7 +156,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: AssetRipper_mac_x64
-        path: /home/runner/work/AssetRipper/AssetRipper/Bins/Publish/AssetRipper_mac_x64/*
+        path: /Users/runner/work/AssetRipper/AssetRipper/Bins/Publish/AssetRipper_mac_x64/*
         if-no-files-found: error
         
 
@@ -188,6 +188,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: AssetRipper_mac_arm64
-        path: /home/runner/work/AssetRipper/AssetRipper/Bins/Publish/AssetRipper_mac_arm64/*
+        path: /Users/runner/work/AssetRipper/AssetRipper/Bins/Publish/AssetRipper_mac_arm64/*
         if-no-files-found: error
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,7 +172,7 @@ jobs:
         dotnet-version: 6.0.x
         
     - name: Publish AssetRipper Mac arm64
-      run: dotnet publish /p:PublishProfile=mac_arm64 /p:EnableCompressionInSingleFile=true /p:Configuration=Release
+      run: dotnet publish /p:PublishProfile=mac_arm64 /p:Configuration=Release
       working-directory: ./AssetRipper.GUI/
         
     - name: List Files


### PR DESCRIPTION
This PR fixes #551, which is about macOS arm64 binary crashing. For signing the binary I changed the build OS to macOS, and for the bus error I removed the compression flag on arm64. (Seems like arm64 doesn't like compression for now)

And if you don't mind, please add the `hacktoberfest-accepted` label too...