### PR TITLE
Enable server garbage collection

### DIFF
--- a/AssetRipper.GUI/AssetRipper.GUI.csproj
+++ b/AssetRipper.GUI/AssetRipper.GUI.csproj
@@ -11,6 +11,8 @@
 		<Copyright>Copyright © 2022</Copyright>
 		<Authors>ds5678</Authors>
 		<ApplicationIcon>Resources\GUI_Icon.ico</ApplicationIcon>
+		<ServerGarbageCollection>true</ServerGarbageCollection>
+		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/AssetRipper.GUI/AssetRipper.GUI.csproj
+++ b/AssetRipper.GUI/AssetRipper.GUI.csproj
@@ -12,7 +12,6 @@
 		<Authors>ds5678</Authors>
 		<ApplicationIcon>Resources\GUI_Icon.ico</ApplicationIcon>
 		<ServerGarbageCollection>true</ServerGarbageCollection>
-		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/AssetRipper.Tools.SystemTester/AssetRipper.Tools.SystemTester.csproj
+++ b/AssetRipper.Tools.SystemTester/AssetRipper.Tools.SystemTester.csproj
@@ -5,6 +5,7 @@
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>..\Bins\AssetRipper.Tools.SystemTester\$(Configuration)\</OutputPath>
 		<IntermediateOutputPath>..\Bins\obj\AssetRipper.Tools.SystemTester\$(Configuration)\</IntermediateOutputPath>
+		<ServerGarbageCollection>true</ServerGarbageCollection>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Gives a decent performance boost with basically no downside. Comparison numbers (import times from dropping the folder onto the GUI window, all on the same game on the same PC):


| Configuration              | Time to Editor Format Processing | Time to finish |
--------------------------|--------------------------------------|----------------
| net6 + no server gc        | 3 min 18 sec                     | 5 min 4 sec    |
| net7 + no server gc        | 3 min 10 sec                     | 4 min 55 sec   |
| net7 + server gc           | 2 min 49 sec                     | 4 min 30 sec   |
| net6 + server gc           | 2 min 46 sec                     | 4 min 15 sec   |