### PR TITLE
Fix compilation errors

### DIFF
--- a/AssetRipper.Library/Exporters/Scripts/ScriptDecompiler.cs
+++ b/AssetRipper.Library/Exporters/Scripts/ScriptDecompiler.cs
@@ -36,6 +36,9 @@ namespace AssetRipper.Library.Exporters.Scripts
 
 			decompiler.Settings.SetLanguageVersion(LanguageVersion);
 			decompiler.Settings.UseNestedDirectoriesForNamespaces = true;
+			
+			// Use explicit namespaces (next to types) to avoid ambiguity
+			decompiler.Settings.UsingDeclarations = false;
 
 			if (ScriptContentLevel == ScriptContentLevel.Level1)
 			{

--- a/AssetRipper.Library/Exporters/Scripts/ScriptDecompiler.cs
+++ b/AssetRipper.Library/Exporters/Scripts/ScriptDecompiler.cs
@@ -52,13 +52,13 @@ namespace AssetRipper.Library.Exporters.Scripts
 				decompiler.CustomTransforms.Add(new FixOptionalParametersTransform());
 				decompiler.CustomTransforms.Add(new ValidateNullCastsTransform());
 				decompiler.CustomTransforms.Add(new FixStructLayoutAmbiguityTransform());
-				decompiler.CustomTransforms.Add(new RemoveCompilerAttributeTransform());
 				decompiler.CustomTransforms.Add(new FixGenericStructConstraintTransform());
 			}
 
 			if (ScriptContentLevel <= ScriptContentLevel.Level2)
 			{
 				decompiler.CustomTransforms.Add(new FixExplicitInterfaceImplementationTransform());
+				decompiler.CustomTransforms.Add(new RemoveCompilerAttributeTransform());
 			}
 
 			// il2cpp fixes

--- a/AssetRipper.Library/Exporters/Scripts/ScriptDecompiler.cs
+++ b/AssetRipper.Library/Exporters/Scripts/ScriptDecompiler.cs
@@ -21,7 +21,7 @@ namespace AssetRipper.Library.Exporters.Scripts
 			ScriptingBackend = scriptingBackend;
 		}
 
-		public void DecompileWholeProject(AssemblyDefinition assembly, string outputFolder)
+		public void DecompileWholeProject(AssemblyDefinition assembly, string outputFolder, UnityVersion unityVersion)
 		{
 			WholeAssemblyDecompiler decompiler = new(assemblyResolver);
 			// these settings may need to be changed later because
@@ -39,7 +39,7 @@ namespace AssetRipper.Library.Exporters.Scripts
 
 			if (ScriptContentLevel == ScriptContentLevel.Level1)
 			{
-				decompiler.CustomTransforms.Add(new MemberStubTransform());
+				decompiler.CustomTransforms.Add(new MemberStubTransform(unityVersion));
 			}
 
 			// code quality

--- a/AssetRipper.Library/Exporters/Scripts/ScriptDecompiler.cs
+++ b/AssetRipper.Library/Exporters/Scripts/ScriptDecompiler.cs
@@ -51,10 +51,14 @@ namespace AssetRipper.Library.Exporters.Scripts
 				decompiler.CustomTransforms.Add(new RemoveInvalidMemberTransform(ScriptingBackend == ScriptingBackend.IL2Cpp));
 				decompiler.CustomTransforms.Add(new FixOptionalParametersTransform());
 				decompiler.CustomTransforms.Add(new ValidateNullCastsTransform());
-				decompiler.CustomTransforms.Add(new FixExplicitInterfaceImplementationTransform());
 				decompiler.CustomTransforms.Add(new FixStructLayoutAmbiguityTransform());
 				decompiler.CustomTransforms.Add(new RemoveCompilerAttributeTransform());
 				decompiler.CustomTransforms.Add(new FixGenericStructConstraintTransform());
+			}
+
+			if (ScriptContentLevel <= ScriptContentLevel.Level2)
+			{
+				decompiler.CustomTransforms.Add(new FixExplicitInterfaceImplementationTransform());
 			}
 
 			// il2cpp fixes

--- a/AssetRipper.Library/Exporters/Scripts/ScriptExporter.cs
+++ b/AssetRipper.Library/Exporters/Scripts/ScriptExporter.cs
@@ -24,11 +24,13 @@ namespace AssetRipper.Library.Exporters.Scripts
 		{
 			AssemblyManager = assemblyManager;
 			Decompiler = new ScriptDecompiler(AssemblyManager);
+			UnityVersion = configuration.Version;
 			LanguageVersion = configuration.ScriptLanguageVersion.ToCSharpLanguageVersion(configuration.Version);
 			ScriptContentLevel = configuration.ScriptContentLevel;
 		}
 
 		public IAssemblyManager AssemblyManager { get; }
+		private UnityVersion UnityVersion { get; }
 		private ICSharpCode.Decompiler.CSharp.LanguageVersion LanguageVersion { get; }
 		private ScriptContentLevel ScriptContentLevel { get; }
 		private ScriptDecompiler Decompiler { get; set; }
@@ -91,7 +93,7 @@ namespace AssetRipper.Library.Exporters.Scripts
 					Logger.Info(LogCategory.Export, $"Decompiling {assemblyName}");
 					string outputDirectory = Path.Combine(dirPath, assemblyName);
 					Directory.CreateDirectory(outputDirectory);
-					Decompiler.DecompileWholeProject(assembly, outputDirectory);
+					Decompiler.DecompileWholeProject(assembly, outputDirectory, UnityVersion);
 
 					assemblyDefinitionDetailsDictionary.TryAdd(assemblyName, new AssemblyDefinitionDetails(assembly, outputDirectory));
 				}

--- a/AssetRipper.Library/Exporters/Scripts/Transforms/EnsureOutParamsSetTransform.cs
+++ b/AssetRipper.Library/Exporters/Scripts/Transforms/EnsureOutParamsSetTransform.cs
@@ -4,7 +4,7 @@ using ICSharpCode.Decompiler.CSharp.Transforms;
 namespace AssetRipper.Library.Exporters.Scripts.Transforms
 {
 	/// <summary>
-	/// A transformer that ensure all out parameters on methods are set.
+	/// A transformer that ensure all out parameters on methods and constructors are set.
 	/// </summary>
 	internal class EnsureOutParamsSetTransform : DepthFirstAstVisitor, IAstTransform
 	{
@@ -12,30 +12,60 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 		{
 			base.VisitMethodDeclaration(methodDeclaration);
 
-			if (methodDeclaration.Body == null || methodDeclaration.Body.IsNull)
+			VisitEntityDeclaration(
+				methodDeclaration,
+				methodDeclaration.Body,
+				methodDeclaration.Parameters
+			);
+		}
+
+		public override void VisitConstructorDeclaration(ConstructorDeclaration constructorDeclaration)
+		{
+			base.VisitConstructorDeclaration(constructorDeclaration);
+
+			VisitEntityDeclaration(
+				constructorDeclaration,
+				constructorDeclaration.Body,
+				constructorDeclaration.Parameters
+			);
+		}
+
+		private void VisitEntityDeclaration(
+			EntityDeclaration entityDeclaration,
+			BlockStatement? body,
+			AstNodeCollection<ParameterDeclaration> parameters)
+		{
+			if (body == null || body.IsNull)
 			{
 				return;
 			}
 
-			foreach (ParameterDeclaration parameter in methodDeclaration.Parameters)
+			foreach (ParameterDeclaration parameter in parameters)
 			{
-				if ((parameter.ParameterModifier & ParameterModifier.Out) != ParameterModifier.Out)
+				if (parameter.ParameterModifier != ParameterModifier.Out)
 				{
 					continue;
 				}
 
-				ExpressionStatement assignment = new(new AssignmentExpression(new IdentifierExpression(parameter.Name), new DefaultValueExpression(parameter.Type.Clone())));
-				Statement? firstStatement = methodDeclaration.Body.Statements.FirstOrNullObject();
+				ExpressionStatement assignment = new(
+					new AssignmentExpression(
+						new IdentifierExpression(parameter.Name),
+						new DefaultValueExpression(parameter.Type.Clone())
+					)
+				);
+
+				Statement? firstStatement = body.Statements.FirstOrNullObject();
 				if (firstStatement == null || firstStatement.IsNull)
 				{
-					methodDeclaration.Body.Statements.Add(assignment);
+					body.Statements.Add(assignment);
 				}
 				else
 				{
-					methodDeclaration.Body.Statements.InsertBefore(firstStatement, assignment);
+					body.Statements.InsertBefore(firstStatement, assignment);
 				}
 			}
 		}
+
 		public void Run(AstNode rootNode, TransformContext context)
 		{
 			rootNode.AcceptVisitor(this);

--- a/AssetRipper.Library/Exporters/Scripts/Transforms/EnsureValidBaseConstructorTransform.cs
+++ b/AssetRipper.Library/Exporters/Scripts/Transforms/EnsureValidBaseConstructorTransform.cs
@@ -155,6 +155,13 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 						ConstructorInitializerType = isBaseConstructor ? ConstructorInitializerType.Base : ConstructorInitializerType.This
 					};
 
+					if (initializer.ConstructorInitializerType == ConstructorInitializerType.This &&
+					    bestConstructor.Parameters.Count == 0)
+					{
+						// fix for error CS0768: Constructor '<name>' cannot call itself through another constructor
+						continue;
+					}
+					
 					foreach (IParameter parameter in bestConstructor.Parameters)
 					{
 						bool hasParameterMatch = false;

--- a/AssetRipper.Library/Exporters/Scripts/Transforms/FixExplicitInterfaceImplementationTransform.cs
+++ b/AssetRipper.Library/Exporters/Scripts/Transforms/FixExplicitInterfaceImplementationTransform.cs
@@ -5,7 +5,7 @@ using Attribute = ICSharpCode.Decompiler.CSharp.Syntax.Attribute;
 namespace AssetRipper.Library.Exporters.Scripts.Transforms
 {
 	/// <summary>
-	/// Fixes implicit interface implementations as ILSpy sometimes exports properties as seperate
+	/// Fixes implicit interface implementations as ILSpy sometimes exports properties as separate
 	/// methods which won't compile.
 	/// </summary>
 	internal class FixExplicitInterfaceImplementationTransform : DepthFirstAstVisitor, IAstTransform
@@ -22,7 +22,7 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 			{
 				foreach (Attribute attribute in attributeSection.Attributes)
 				{
-					if (attribute.Type is SimpleType attributeType && attributeType.Identifier == "SpecialName")
+					if (attribute.Type is SimpleType { Identifier: "SpecialName" } or MemberType { MemberName: "SpecialName" })
 					{
 						isSpecialName = true;
 						attribute.Remove();

--- a/AssetRipper.Library/Exporters/Scripts/Transforms/MemberStubTransform.cs
+++ b/AssetRipper.Library/Exporters/Scripts/Transforms/MemberStubTransform.cs
@@ -38,7 +38,6 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 					{
 						property.Setter.Body = new BlockStatement();
 					}
-					member.Remove();
 				}
 				else if (member is CustomEventDeclaration ev)
 				{

--- a/AssetRipper.Library/Exporters/Scripts/Transforms/MemberStubTransform.cs
+++ b/AssetRipper.Library/Exporters/Scripts/Transforms/MemberStubTransform.cs
@@ -46,6 +46,12 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 				}
 				else if (member is MethodDeclaration method)
 				{
+					// Abstract and extern methods does not have a body
+					if (method.Modifiers.HasFlag(Modifiers.Abstract) || method.Modifiers.HasFlag(Modifiers.Extern))
+					{
+						continue;
+					}
+
 					method.Body = new BlockStatement();
 					if (method.ReturnType is not PrimitiveType returnType || returnType.Keyword != "void")
 					{

--- a/AssetRipper.Library/Exporters/Scripts/Transforms/MemberStubTransform.cs
+++ b/AssetRipper.Library/Exporters/Scripts/Transforms/MemberStubTransform.cs
@@ -8,6 +8,13 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 	/// </summary>
 	internal class MemberStubTransform : DepthFirstAstVisitor, IAstTransform
 	{
+		private bool SupportsDefaultInterfaceImplementations { get; }
+		
+		public MemberStubTransform(UnityVersion unityVersion)
+		{
+			SupportsDefaultInterfaceImplementations = unityVersion.IsGreaterEqual("2021.2");
+		}
+		
 		public override void VisitTypeDeclaration(TypeDeclaration typeDeclaration)
 		{
 			foreach (EntityDeclaration? member in typeDeclaration.Members)
@@ -48,6 +55,11 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 				{
 					// Abstract and extern methods does not have a body
 					if (method.Modifiers.HasFlag(Modifiers.Abstract) || method.Modifiers.HasFlag(Modifiers.Extern))
+					{
+						continue;
+					}
+
+					if (!SupportsDefaultInterfaceImplementations && typeDeclaration.ClassType == ClassType.Interface)
 					{
 						continue;
 					}

--- a/AssetRipper.Library/Exporters/Scripts/Transforms/RemoveCompilerAttributeTransform.cs
+++ b/AssetRipper.Library/Exporters/Scripts/Transforms/RemoveCompilerAttributeTransform.cs
@@ -17,20 +17,18 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 		{
 			RemoveCompilerGeneratedAttributes(entity.Attributes);
 		}
+
 		private static void RemoveCompilerGeneratedAttributes(AstNodeCollection<AttributeSection> attributes)
 		{
 			foreach (AttributeSection attributeSection in attributes)
 			{
 				foreach (Attribute attribute in attributeSection.Attributes)
 				{
-					if (attribute.Type is SimpleType simpleType)
+					if (attribute.Type
+					    is SimpleType { Identifier: "AsyncStateMachine" or "IteratorStateMachine" or "IsReadOnly" }
+					    or MemberType { MemberName: "AsyncStateMachine" or "IteratorStateMachine" or "IsReadOnly" })
 					{
-						if (simpleType.Identifier == "AsyncStateMachine" ||
-							simpleType.Identifier == "IteratorStateMachine" ||
-							simpleType.Identifier == "IsReadOnly")
-						{
-							attribute.Remove();
-						}
+						attribute.Remove();
 					}
 				}
 

--- a/AssetRipper.Library/Exporters/Scripts/Transforms/RemoveCompilerAttributeTransform.cs
+++ b/AssetRipper.Library/Exporters/Scripts/Transforms/RemoveCompilerAttributeTransform.cs
@@ -74,6 +74,8 @@ namespace AssetRipper.Library.Exporters.Scripts.Transforms
 		{
 			base.VisitPropertyDeclaration(propertyDeclaration);
 			RemoveCompilerGeneratedAttributes(propertyDeclaration);
+			RemoveCompilerGeneratedAttributes(propertyDeclaration.Getter);
+			RemoveCompilerGeneratedAttributes(propertyDeclaration.Setter);
 		}
 
 		public override void VisitEnumMemberDeclaration(EnumMemberDeclaration enumMemberDeclaration)

--- a/AssetRipper.Library/Processors/PlayerSettingsProcessor.cs
+++ b/AssetRipper.Library/Processors/PlayerSettingsProcessor.cs
@@ -1,0 +1,36 @@
+using AssetRipper.Assets;
+using AssetRipper.Assets.Bundles;
+using AssetRipper.Core.Structure.GameStructure;
+using AssetRipper.SourceGenerated.Classes.ClassID_129;
+using System.Linq;
+using System.Reflection;
+
+namespace AssetRipper.Library.Processors
+{
+	public sealed class PlayerSettingsProcessor : IAssetProcessor
+	{
+		public void Process(GameBundle gameBundle, UnityVersion projectVersion)
+		{
+			IUnityObjectBase? asset = gameBundle.Collections
+				.FirstOrDefault(collection => collection.Name == "globalgamemanagers")?
+				.Assets
+				.Values
+				.FirstOrDefault(asset => asset.ClassName == "PlayerSettings");
+
+			if (asset == null)
+			{
+				return;
+			}
+
+			SetAllowUnsafeCode(asset, true);
+		}
+
+		private static void SetAllowUnsafeCode(IUnityObjectBase asset, bool value)
+		{
+			FieldInfo? allowUnsafeCodeField = asset.GetType()
+				.GetField("m_AllowUnsafeCode", BindingFlags.Instance | BindingFlags.Public);
+
+			allowUnsafeCodeField?.SetValue(asset, value);
+		}
+	}
+}

--- a/AssetRipper.Library/Ripper.cs
+++ b/AssetRipper.Library/Ripper.cs
@@ -96,7 +96,7 @@ namespace AssetRipper.Library
 			TaskManager.WaitUntilAllCompleted();
 
 			Logger.Info(LogCategory.General, "Processing loaded assets...");
-			List<IAssetProcessor> AssetProcessors = new()
+			List<IAssetProcessor> assetProcessors = new()
 			{
 				new SceneGuidProcessor(),
 				new TerrainTextureProcessor(),
@@ -106,8 +106,9 @@ namespace AssetRipper.Library
 				new StaticMeshProcessor(),
 				new PrefabOutliningProcessor(),
 				new SpriteProcessor(),
+				new PlayerSettingsProcessor(),
 			};
-			GameStructure.Process(AssetProcessors);
+			GameStructure.Process(assetProcessors);
 			TaskManager.WaitUntilAllCompleted();
 			Logger.Info(LogCategory.General, "Finished processing assets");
 


### PR DESCRIPTION
This PR fixes almost all compilation errors that my project (Mono) had with script export level 1. What is not fixed is that I have to manually add the `global::` keyword in 2 places and select the .NET 4.x compatibility level.

Better to review commits one by one.
