### PR TITLE
Revert "Remove sprite configuration option from the gui"

### DIFF
--- a/AssetRipper.GUI/MainWindow.axaml
+++ b/AssetRipper.GUI/MainWindow.axaml
@@ -5,7 +5,7 @@
         xmlns:ar="using:AssetRipper.GUI"
         xmlns:cc="using:AssetRipper.GUI.Components"
         xmlns:i18n="clr-namespace:AssetRipper.GUI" 
-        mc:Ignorable="d" d:DesignWidth="1400" d:DesignHeight="800"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="AssetRipper.GUI.MainWindow"
         Icon="/Resources/GUI_Icon.ico"
         Title="AssetRipper"
@@ -35,7 +35,6 @@
             </ExperimentalAcrylicBorder.Material>
         </ExperimentalAcrylicBorder>
         <Grid RowDefinitions="35,20,*">
-            <!--Title-->
             <TextBlock Grid.Row="0"
                        IsHitTestVisible="False"
                        FontSize="18"
@@ -168,8 +167,15 @@
                         SelectedValue="{Binding ImageExportFormat, Mode=TwoWay}"
                         Margin="0, 0, 10, 0">
                     </cc:ImageExportConfigDropdown>
-                    <cc:BundledAssetsExportConfigDropdown
+                    <cc:SpriteExportConfigDropdown
                         Grid.Column="2"
+                        Grid.Row="2"
+                        OptionTitle="{i18n:Localize sprite_export_title}"
+                        SelectedValue="{Binding SpriteExportMode, Mode=TwoWay}"
+                        Margin="10, 0, 10, 0">
+                    </cc:SpriteExportConfigDropdown>
+                    <cc:BundledAssetsExportConfigDropdown
+                        Grid.Column="3"
                         Grid.Row="2"
                         OptionTitle="{i18n:Localize bundled_assets_export_title}"
                         SelectedValue="{Binding BundledAssetsExportMode, Mode=TwoWay}"


### PR DESCRIPTION
This reverts commit f8b811ed47157f978de19aee7679fc56d5ad50a7.

This was decided as a temporary solution while a better solution is figured out, but basically, the Unity sprite export format preserve the file paths which the Resources api needs so if a game uses it heavily, this is crucial to have the code work correctly. Yaml exports sprites separately which does not honor how the game assumes files to be arranged in the resources folder.