### PR TITLE
unchecked on SHDR operandData uint cast

### DIFF
--- a/Source/AssetRipper.Export.Modules.Shader/UltraShaderConverter/DirectXDisassembler/Blocks/SHDR.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/UltraShaderConverter/DirectXDisassembler/Blocks/SHDR.cs
@@ -423,7 +423,7 @@
 					components = 4;
 					break;
 			}
-			extended = ((uint)operandData & 0x80000000) >> 31 == 1;
+			extended = (unchecked((uint)operandData) & 0x80000000) >> 31 == 1;
 			if (extended)
 			{
 				extendedData = reader.ReadInt32();


### PR DESCRIPTION
Prevents arithmetic overflow issue people have been getting (I think, tested outside of the project).