### PR TITLE
Bump Avalonia to Preview 6

### DIFF
--- a/Source/AssetRipper.GUI/AssetRipper.GUI.csproj
+++ b/Source/AssetRipper.GUI/AssetRipper.GUI.csproj
@@ -24,7 +24,6 @@
 		<PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
 		<PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.18" />
 		<PackageReference Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" />
-		<PackageReference Include="XamlNameReferenceGenerator" Version="1.6.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/AssetRipper.GUI/AssetRipper.GUI.csproj
+++ b/Source/AssetRipper.GUI/AssetRipper.GUI.csproj
@@ -8,6 +8,9 @@
 		<RootNamespace>AssetRipper.GUI</RootNamespace>
 		<ApplicationIcon>Resources\GUI_Icon.ico</ApplicationIcon>
 		<ServerGarbageCollection>true</ServerGarbageCollection>
+		
+		<!-- Because 'av_libglesv2.dll' is not being included, we need to set the runtime identifier to Windows 7 -->
+		<RuntimeIdentifier>win7-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/AssetRipper.GUI/AssetRipper.GUI.csproj
+++ b/Source/AssetRipper.GUI/AssetRipper.GUI.csproj
@@ -8,19 +8,16 @@
 		<RootNamespace>AssetRipper.GUI</RootNamespace>
 		<ApplicationIcon>Resources\GUI_Icon.ico</ApplicationIcon>
 		<ServerGarbageCollection>true</ServerGarbageCollection>
-		
-		<!-- Because 'av_libglesv2.dll' is not being included, we need to set the runtime identifier to Windows 7 -->
-		<RuntimeIdentifier>win7-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.0-preview5" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview5" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview5" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview5" />
+		<PackageReference Include="Avalonia" Version="11.0.0-preview6" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview6" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview6" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview6" />
 		<PackageReference Include="LibVLCSharp" Version="3.6.8" />
 		<PackageReference Include="LibVLCSharp.Avalonia" Version="3.6.8" />
-		<PackageReference Include="MessageBox.Avalonia" Version="2.3.1-prev5" />
+		<PackageReference Include="MessageBox.Avalonia" Version="2.3.1-prev6" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 		<PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
 		<PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />


### PR DESCRIPTION
See https://github.com/AvaloniaUI/Avalonia/issues/6028

This fixes the acrylic issue, where some platforms would not get acrylic.
Because 'av_libglesv2.dll' would not be included with the output.
Specifically in Windows 11 (if not Windows 10).

### Example
![image](https://user-images.githubusercontent.com/104068185/228982838-84000d05-3e5f-4f60-af3f-d8fb6c199872.png)
