### PR TITLE
Fix slow down issue in ProcessDenses

### DIFF
--- a/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
@@ -139,6 +139,7 @@ namespace AssetRipper.Processing.AnimationClips
 		private void ProcessDenses(IClip clip, IAnimationClipBindingConstant bindings, IReadOnlyDictionary<uint, string> tos)
 		{
 			DenseClip dense = clip.DenseClip;
+			float[] denseSampleArray = dense.SampleArray.ToArray();
 			int streamCount = (int)clip.StreamedClip.CurveCount;
 			ReadOnlySpan<float> slopeValues = stackalloc float[4] { 0, 0, 0, 0 }; // no slopes - 0 values
 			for (int frameIndex = 0; frameIndex < dense.FrameCount; frameIndex++)
@@ -153,7 +154,7 @@ namespace AssetRipper.Processing.AnimationClips
 					int framePosition = frameOffset + curveIndex;
 					if (binding.IsTransform())
 					{
-						AddTransformCurve(time, binding.TransformType(), dense.SampleArray.ToArray(), slopeValues, slopeValues, framePosition, path);
+						AddTransformCurve(time, binding.TransformType(), denseSampleArray, slopeValues, slopeValues, framePosition, path);
 						curveIndex += binding.TransformType().GetDimension();
 					}
 					else if (binding.CustomType == (byte)BindingCustomType.None)


### PR DESCRIPTION
The conversion with `ToArray` is taking a lot of time, especially since it's repeated often in the loops. The fix is just to initialize the value out of the loops. With this change, I can load my test folder in ~2m, while before I couldn't in 2 hours before.