### PR TITLE
only use NPOTScale on cubemaps

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/Textures/ImporterFactory.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Textures/ImporterFactory.cs
@@ -35,7 +35,11 @@ namespace AssetRipper.Export.UnityProjects.Textures
 			instance.Format_C1006 = (int)data.Format;
 			instance.MaxTextureSize_C1006 = data.MaxTextureSize;
 			instance.TextureSettings_C1006.CopyValues(data.TextureSettings);
-			instance.NPOTScale_C1006E = TextureImporterNPOTScale.ToNearest; // Default texture importer settings uses this value, and cubemaps appear to not work when it's None
+			// cubemaps break when they aren't scaled, while sprites break if they ARE scaled
+			// everything else works with no scaling, so we just only scale for cubemaps
+			instance.NPOTScale_C1006E = origin is ICubemap
+				? TextureImporterNPOTScale.ToNearest
+				: TextureImporterNPOTScale.None;
 			instance.CompressionQuality_C1006 = 50;
 
 			instance.SetSwizzle(TextureImporterSwizzle.R, TextureImporterSwizzle.G, TextureImporterSwizzle.B, TextureImporterSwizzle.A);


### PR DESCRIPTION
it turns out that sprites dont like NPOTScale. everything else works with TextureImporterNPOTScale.None, so lets just use that as the default and then only use TextureImporterNPOTScale.ToNearest for cubemaps

cubemap arrays may also need it, but they also may need no FlipY and i currently dont do that, so im just leaving it for now.