### PR TITLE
Bump Cpp2IL version to build 886

### DIFF
--- a/Source/AssetRipper.Import/AssetRipper.Import.csproj
+++ b/Source/AssetRipper.Import/AssetRipper.Import.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="AsmResolver.DotNet" Version="5.3.0" />
 		<PackageReference Include="AsmResolver.PE.File" Version="5.3.0" />
 		<PackageReference Include="AssetRipper.VersionUtilities" Version="1.5.0" />
-		<PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.872" />
+		<PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-development.886" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This version increases the sanity limit on metadata registration count fields, because at least one game in the wild has now exceeded the limits that were in place and therefore was failing to load - this fixes it.