### PR TITLE
Bundle Mac release as .app

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,9 +163,9 @@ jobs:
           date -u > ./Source/Bins/Publish/AssetRipper_mac_x64/compile_time.txt
           ls -R ./Source/Bins/Publish/AssetRipper_mac_x64
           chmod +x ./Source/Bins/Publish/AssetRipper_mac_x64/AssetRipper
-          mkdir -p AssetRipper.app/Contents/MacOS
-          mkdir -p AssetRipper.app/Contents/Resources
-          cp -r Source/Bins/Publish/AssetRipper_mac_x64/* AssetRipper.app/Contents/MacOS/
+          mkdir -p upload/AssetRipper.app/Contents/MacOS
+          mkdir -p upload/AssetRipper.app/Contents/Resources
+          cp -r Source/Bins/Publish/AssetRipper_mac_x64/* upload/AssetRipper.app/Contents/MacOS/
 
           logo=Media/Images/LogoReimagined/LogoReimaginedTransparent.png
           mkdir AssetRipper.iconset
@@ -180,11 +180,11 @@ jobs:
           sips -z 512 512   $logo --out AssetRipper.iconset/icon_512x512.png
           sips -z 1024 1024 $logo --out AssetRipper.iconset/icon_512x512@2x.png
           iconutil -c icns AssetRipper.iconset
-          mv AssetRipper.icns AssetRipper.app/Contents/Resources/
+          mv AssetRipper.icns upload/AssetRipper.app/Contents/Resources/
 
           version=$(cat Source/Directory.Build.props | sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p')
 
-          cat << EOF > AssetRipper.app/Contents/Info.plist
+          cat << EOF > upload/AssetRipper.app/Contents/Info.plist
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -204,7 +204,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: AssetRipper_mac_x64
-          path: ./AssetRipper.app
+          path: ./upload/
           if-no-files-found: error
 
   publish_mac_arm64:
@@ -232,9 +232,9 @@ jobs:
           date -u > ./Source/Bins/Publish/AssetRipper_mac_arm64/compile_time.txt
           ls -R ./Source/Bins/Publish/AssetRipper_mac_arm64
           chmod +x ./Source/Bins/Publish/AssetRipper_mac_arm64/AssetRipper
-          mkdir -p AssetRipper.app/Contents/MacOS
-          mkdir -p AssetRipper.app/Contents/Resources
-          cp -r Source/Bins/Publish/AssetRipper_mac_arm64/* AssetRipper.app/Contents/MacOS/
+          mkdir -p upload/AssetRipper.app/Contents/MacOS
+          mkdir -p upload/AssetRipper.app/Contents/Resources
+          cp -r Source/Bins/Publish/AssetRipper_mac_arm64/* upload/AssetRipper.app/Contents/MacOS/
 
           logo=Media/Images/LogoReimagined/LogoReimaginedTransparent.png
           mkdir AssetRipper.iconset
@@ -249,11 +249,11 @@ jobs:
           sips -z 512 512   $logo --out AssetRipper.iconset/icon_512x512.png
           sips -z 1024 1024 $logo --out AssetRipper.iconset/icon_512x512@2x.png
           iconutil -c icns AssetRipper.iconset
-          mv AssetRipper.icns AssetRipper.app/Contents/Resources/
+          mv AssetRipper.icns upload/AssetRipper.app/Contents/Resources/
 
           version=$(cat Source/Directory.Build.props | sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p')
 
-          cat << EOF > AssetRipper.app/Contents/Info.plist
+          cat << EOF > upload/AssetRipper.app/Contents/Info.plist
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -273,5 +273,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: AssetRipper_mac_arm64
-          path: ./AssetRipper.app
+          path: ./upload/
           if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,12 +163,47 @@ jobs:
           date -u > ./Source/Bins/Publish/AssetRipper_mac_x64/compile_time.txt
           ls -R ./Source/Bins/Publish/AssetRipper_mac_x64
           chmod +x ./Source/Bins/Publish/AssetRipper_mac_x64/AssetRipper
+          mkdir -p AssetRipper.app/Contents/MacOS
+          mkdir -p AssetRipper.app/Contents/Resources
+          cp Source/Bins/Publish/AssetRipper_mac_x64/* AssetRipper.app/Contents/MacOS/
+
+          mkdir AssetRipper.iconset
+          sips -z 16 16     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_16x16.png
+          sips -z 32 32     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_16x16@2x.png
+          sips -z 32 32     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_32x32.png
+          sips -z 64 64     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_32x32@2x.png
+          sips -z 128 128   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_128x128.png
+          sips -z 256 256   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_128x128@2x.png
+          sips -z 256 256   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_256x256.png
+          sips -z 512 512   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_256x256@2x.png
+          sips -z 512 512   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_512x512.png
+          sips -z 1024 1024 Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_512x512@2x.png
+          iconutil -c icns AssetRipper.iconset
+          mv AssetRipper.icns AssetRipper.app/Contents/Resources/
+
+          version=$(cat Source/Directory.Build.props | sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p')
+
+          cat << EOF > AssetRipper.app/Contents/Info.plist
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+              <dict>
+                  <key>CFBundleName</key>               <string>AssetRipper</string>
+                  <key>CFBundleExecutable</key>         <string>AssetRipper</string>
+                  <key>CFBundleIdentifier</key>         <string>assetripper</string>
+                  <key>CFBundleIconFile</key>           <string>AssetRipper.icns</string>
+                  <key>CFBundleVersion</key>            <string>$version</string>
+                  <key>CFBundleShortVersionString</key> <string>$version</string>
+                  <key>NSHighResolutionCapable</key>    <string>True</string>
+              </dict>
+          </plist>
+          EOF
 
       - name: Upload AssetRipper Mac x64
         uses: actions/upload-artifact@v3
         with:
           name: AssetRipper_mac_x64
-          path: ./Source/Bins/Publish/AssetRipper_mac_x64/*
+          path: ./AssetRipper.app
           if-no-files-found: error
 
   publish_mac_arm64:
@@ -196,10 +231,45 @@ jobs:
           date -u > ./Source/Bins/Publish/AssetRipper_mac_arm64/compile_time.txt
           ls -R ./Source/Bins/Publish/AssetRipper_mac_arm64
           chmod +x ./Source/Bins/Publish/AssetRipper_mac_arm64/AssetRipper
+          mkdir -p AssetRipper.app/Contents/MacOS
+          mkdir -p AssetRipper.app/Contents/Resources
+          cp Source/Bins/Publish/AssetRipper_mac_arm64/* AssetRipper.app/Contents/MacOS/
+
+          mkdir AssetRipper.iconset
+          sips -z 16 16     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_16x16.png
+          sips -z 32 32     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_16x16@2x.png
+          sips -z 32 32     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_32x32.png
+          sips -z 64 64     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_32x32@2x.png
+          sips -z 128 128   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_128x128.png
+          sips -z 256 256   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_128x128@2x.png
+          sips -z 256 256   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_256x256.png
+          sips -z 512 512   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_256x256@2x.png
+          sips -z 512 512   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_512x512.png
+          sips -z 1024 1024 Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_512x512@2x.png
+          iconutil -c icns AssetRipper.iconset
+          mv AssetRipper.icns AssetRipper.app/Contents/Resources/
+
+          version=$(cat Source/Directory.Build.props | sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p')
+
+          cat << EOF > AssetRipper.app/Contents/Info.plist
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+              <dict>
+                  <key>CFBundleName</key>               <string>AssetRipper</string>
+                  <key>CFBundleExecutable</key>         <string>AssetRipper</string>
+                  <key>CFBundleIdentifier</key>         <string>assetripper</string>
+                  <key>CFBundleIconFile</key>           <string>AssetRipper.icns</string>
+                  <key>CFBundleVersion</key>            <string>$version</string>
+                  <key>CFBundleShortVersionString</key> <string>$version</string>
+                  <key>NSHighResolutionCapable</key>    <string>True</string>
+              </dict>
+          </plist>
+          EOF
 
       - name: Upload AssetRipper Mac arm64
         uses: actions/upload-artifact@v3
         with:
           name: AssetRipper_mac_arm64
-          path: ./Source/Bins/Publish/AssetRipper_mac_arm64/*
+          path: ./AssetRipper.app
           if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,7 +165,7 @@ jobs:
           chmod +x ./Source/Bins/Publish/AssetRipper_mac_x64/AssetRipper
           mkdir -p AssetRipper.app/Contents/MacOS
           mkdir -p AssetRipper.app/Contents/Resources
-          cp Source/Bins/Publish/AssetRipper_mac_x64/* AssetRipper.app/Contents/MacOS/
+          cp -r Source/Bins/Publish/AssetRipper_mac_x64/* AssetRipper.app/Contents/MacOS/
 
           logo=Media/Images/LogoReimagined/LogoReimaginedTransparent.png
           mkdir AssetRipper.iconset
@@ -234,7 +234,7 @@ jobs:
           chmod +x ./Source/Bins/Publish/AssetRipper_mac_arm64/AssetRipper
           mkdir -p AssetRipper.app/Contents/MacOS
           mkdir -p AssetRipper.app/Contents/Resources
-          cp Source/Bins/Publish/AssetRipper_mac_arm64/* AssetRipper.app/Contents/MacOS/
+          cp -r Source/Bins/Publish/AssetRipper_mac_arm64/* AssetRipper.app/Contents/MacOS/
 
           logo=Media/Images/LogoReimagined/LogoReimaginedTransparent.png
           mkdir AssetRipper.iconset

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -167,17 +167,18 @@ jobs:
           mkdir -p AssetRipper.app/Contents/Resources
           cp Source/Bins/Publish/AssetRipper_mac_x64/* AssetRipper.app/Contents/MacOS/
 
+          logo=Media/Images/LogoReimagined/LogoReimaginedTransparent.png
           mkdir AssetRipper.iconset
-          sips -z 16 16     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_16x16.png
-          sips -z 32 32     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_16x16@2x.png
-          sips -z 32 32     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_32x32.png
-          sips -z 64 64     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_32x32@2x.png
-          sips -z 128 128   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_128x128.png
-          sips -z 256 256   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_128x128@2x.png
-          sips -z 256 256   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_256x256.png
-          sips -z 512 512   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_256x256@2x.png
-          sips -z 512 512   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_512x512.png
-          sips -z 1024 1024 Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_512x512@2x.png
+          sips -z 16 16     $logo --out AssetRipper.iconset/icon_16x16.png
+          sips -z 32 32     $logo --out AssetRipper.iconset/icon_16x16@2x.png
+          sips -z 32 32     $logo --out AssetRipper.iconset/icon_32x32.png
+          sips -z 64 64     $logo --out AssetRipper.iconset/icon_32x32@2x.png
+          sips -z 128 128   $logo --out AssetRipper.iconset/icon_128x128.png
+          sips -z 256 256   $logo --out AssetRipper.iconset/icon_128x128@2x.png
+          sips -z 256 256   $logo --out AssetRipper.iconset/icon_256x256.png
+          sips -z 512 512   $logo --out AssetRipper.iconset/icon_256x256@2x.png
+          sips -z 512 512   $logo --out AssetRipper.iconset/icon_512x512.png
+          sips -z 1024 1024 $logo --out AssetRipper.iconset/icon_512x512@2x.png
           iconutil -c icns AssetRipper.iconset
           mv AssetRipper.icns AssetRipper.app/Contents/Resources/
 
@@ -235,17 +236,18 @@ jobs:
           mkdir -p AssetRipper.app/Contents/Resources
           cp Source/Bins/Publish/AssetRipper_mac_arm64/* AssetRipper.app/Contents/MacOS/
 
+          logo=Media/Images/LogoReimagined/LogoReimaginedTransparent.png
           mkdir AssetRipper.iconset
-          sips -z 16 16     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_16x16.png
-          sips -z 32 32     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_16x16@2x.png
-          sips -z 32 32     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_32x32.png
-          sips -z 64 64     Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_32x32@2x.png
-          sips -z 128 128   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_128x128.png
-          sips -z 256 256   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_128x128@2x.png
-          sips -z 256 256   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_256x256.png
-          sips -z 512 512   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_256x256@2x.png
-          sips -z 512 512   Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_512x512.png
-          sips -z 1024 1024 Media/Images/LogoReimagined/LogoReimaginedTransparent.png --out AssetRipper.iconset/icon_512x512@2x.png
+          sips -z 16 16     $logo --out AssetRipper.iconset/icon_16x16.png
+          sips -z 32 32     $logo --out AssetRipper.iconset/icon_16x16@2x.png
+          sips -z 32 32     $logo --out AssetRipper.iconset/icon_32x32.png
+          sips -z 64 64     $logo --out AssetRipper.iconset/icon_32x32@2x.png
+          sips -z 128 128   $logo --out AssetRipper.iconset/icon_128x128.png
+          sips -z 256 256   $logo --out AssetRipper.iconset/icon_128x128@2x.png
+          sips -z 256 256   $logo --out AssetRipper.iconset/icon_256x256.png
+          sips -z 512 512   $logo --out AssetRipper.iconset/icon_256x256@2x.png
+          sips -z 512 512   $logo --out AssetRipper.iconset/icon_512x512.png
+          sips -z 1024 1024 $logo --out AssetRipper.iconset/icon_512x512@2x.png
           iconutil -c icns AssetRipper.iconset
           mv AssetRipper.icns AssetRipper.app/Contents/Resources/
 


### PR DESCRIPTION
Based on the guide from the Avalonia docs: https://docs.avaloniaui.net/docs/distribution-publishing/macos

Basically, it just creates the `AssetRipper.app` directory (which is all that .app bundles on MacOS are), copies the release artifacts inside, creates an icon based on the logo, and an `Info.plist` file with the necessary metadata.

This makes AssetRipper a bit nicer to use over having a directory with a bunch of .dlls and also enables me to easily publish it on homebrew (the unofficial MacOS package manager).
