### PR TITLE
Improve the animation attributes string recovery

### DIFF
--- a/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
@@ -433,9 +433,9 @@ namespace AssetRipper.Processing.AnimationClips
 
 		private void AddGameObjectCurve(IGenericBinding binding, string path, float time, float value)
 		{
-			if (binding.Attribute == Crc32Algorithm.HashAscii("m_IsActive"))
+			if (FieldHashes.TryGetPath(ClassIDType.GameObject, binding.Attribute, out string? propertyName))
 			{
-				CurveData curve = new CurveData(path, "m_IsActive", ClassIDType.GameObject);
+				CurveData curve = new CurveData(path, propertyName, ClassIDType.GameObject);
 				AddFloatKeyframe(curve, time, value);
 				return;
 			}
@@ -466,12 +466,16 @@ namespace AssetRipper.Processing.AnimationClips
 
 		private void AddEngineCurve(IGenericBinding binding, string path, float time, float value)
 		{
-#warning TODO:
-			// We need a way to access unity object fields
-			// by classid.
-
-			CurveData curve = new CurveData(path, TypeTreePropertyPrefix + binding.Attribute, binding.GetClassID());
-			AddFloatKeyframe(curve, time, value);
+			if (!FieldHashes.TryGetPath(binding.GetClassID(), binding.Attribute, out string? propertyName))
+			{
+				CurveData curve = new(path, TypeTreePropertyPrefix + binding.Attribute, binding.GetClassID());
+				AddFloatKeyframe(curve, time, value);
+			}
+			else
+			{
+				CurveData curve = new(path, propertyName, binding.GetClassID());
+				AddFloatKeyframe(curve, time, value);
+			}
 		}
 
 		private void AddAnimatorMuscleCurve(IGenericBinding binding, float time, float value)

--- a/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
@@ -1,8 +1,8 @@
 using AssetRipper.Assets.Cloning;
 using AssetRipper.Assets.IO.Reading;
-using AssetRipper.Checksum;
 using AssetRipper.Processing.AnimationClips.Editor;
 using AssetRipper.SourceGenerated;
+using AssetRipper.SourceGenerated.Classes.ClassID_1;
 using AssetRipper.SourceGenerated.Classes.ClassID_115;
 using AssetRipper.SourceGenerated.Classes.ClassID_74;
 using AssetRipper.SourceGenerated.Enums;
@@ -433,7 +433,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 		private void AddGameObjectCurve(IGenericBinding binding, string path, float time, float value)
 		{
-			if (FieldHashes.TryGetPath(ClassIDType.GameObject, binding.Attribute, out string? propertyName))
+			if (GameObject.TryGetPath(binding.Attribute, out string? propertyName))
 			{
 				CurveData curve = new CurveData(path, propertyName, ClassIDType.GameObject);
 				AddFloatKeyframe(curve, time, value);

--- a/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
@@ -2,13 +2,8 @@ using AssetRipper.Checksum;
 using AssetRipper.SourceGenerated.Classes.ClassID_1;
 using AssetRipper.SourceGenerated.Classes.ClassID_108;
 using AssetRipper.SourceGenerated.Classes.ClassID_114;
-using AssetRipper.SourceGenerated.Classes.ClassID_1183024399;
 using AssetRipper.SourceGenerated.Classes.ClassID_120;
 using AssetRipper.SourceGenerated.Classes.ClassID_137;
-using AssetRipper.SourceGenerated.Classes.ClassID_1773428102;
-using AssetRipper.SourceGenerated.Classes.ClassID_1818360608;
-using AssetRipper.SourceGenerated.Classes.ClassID_1818360609;
-using AssetRipper.SourceGenerated.Classes.ClassID_1818360610;
 using AssetRipper.SourceGenerated.Classes.ClassID_198;
 using AssetRipper.SourceGenerated.Classes.ClassID_20;
 using AssetRipper.SourceGenerated.Classes.ClassID_2083052967;
@@ -19,7 +14,6 @@ using AssetRipper.SourceGenerated.Classes.ClassID_330;
 using AssetRipper.SourceGenerated.Classes.ClassID_4;
 using AssetRipper.SourceGenerated.Classes.ClassID_43;
 using AssetRipper.SourceGenerated.Classes.ClassID_74;
-using AssetRipper.SourceGenerated.Classes.ClassID_895512359;
 using AssetRipper.SourceGenerated.Classes.ClassID_96;
 using AssetRipper.SourceGenerated.Extensions;
 using AssetRipper.SourceGenerated.Extensions.Enums.AnimationClip.GenericBinding;
@@ -354,7 +348,7 @@ namespace AssetRipper.Processing.AnimationClips
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.UserDefined:
-					return "UserDefined_" + Crc32Algorithm.ReverseAscii(attribute);
+					return Crc32Algorithm.ReverseAscii(attribute, $"UserDefined_0x{attribute:X}_");
 				
 				// TryGetPath may not work here
 				case BindingCustomType.MeshFilter:

--- a/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
@@ -1,10 +1,16 @@
-using AssetRipper.SourceGenerated;
 using AssetRipper.SourceGenerated.Classes.ClassID_1;
+using AssetRipper.SourceGenerated.Classes.ClassID_108;
+using AssetRipper.SourceGenerated.Classes.ClassID_114;
+using AssetRipper.SourceGenerated.Classes.ClassID_120;
 using AssetRipper.SourceGenerated.Classes.ClassID_137;
+using AssetRipper.SourceGenerated.Classes.ClassID_198;
+using AssetRipper.SourceGenerated.Classes.ClassID_20;
+using AssetRipper.SourceGenerated.Classes.ClassID_224;
 using AssetRipper.SourceGenerated.Classes.ClassID_25;
 using AssetRipper.SourceGenerated.Classes.ClassID_4;
 using AssetRipper.SourceGenerated.Classes.ClassID_43;
 using AssetRipper.SourceGenerated.Classes.ClassID_74;
+using AssetRipper.SourceGenerated.Classes.ClassID_96;
 using AssetRipper.SourceGenerated.Extensions;
 using AssetRipper.SourceGenerated.Extensions.Enums.AnimationClip.GenericBinding;
 using System.Text.RegularExpressions;
@@ -124,7 +130,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.MonoBehaviour:
 					{
-						if (FieldHashes.TryGetPath(ClassIDType.MonoBehaviour, attribute, out string? foundPath))
+						if (MonoBehaviour.TryGetPath(attribute, out string? foundPath))
 						{
 							return foundPath;
 						}
@@ -133,7 +139,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.Light:
 					{
-						if (FieldHashes.TryGetPath(ClassIDType.Light, attribute, out string? foundPath))
+						if (Light.TryGetPath(attribute, out string? foundPath))
 						{
 							return foundPath;
 						}
@@ -142,7 +148,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.RendererShadows:
 					{
-						if (FieldHashes.TryGetPath(ClassIDType.Renderer, attribute, out string? foundPath))
+						if (Renderer.TryGetPath(attribute, out string? foundPath))
 						{
 							return foundPath;
 						}
@@ -151,7 +157,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.ParticleSystem:
 					{
-						if (FieldHashes.TryGetPath(ClassIDType.ParticleSystem, attribute, out string? foundPath))
+						if (ParticleSystem.TryGetPath(attribute, out string? foundPath))
 						{
 							return foundPath;
 						}
@@ -160,7 +166,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.RectTransform:
 					{
-						if (FieldHashes.TryGetPath(ClassIDType.RectTransform, attribute, out string? foundPath))	
+						if (RectTransform.TryGetPath(attribute, out string? foundPath))	
 						{
 							return foundPath;
 						}
@@ -169,7 +175,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.LineRenderer:
 					{
-						if (FieldHashes.TryGetPath(ClassIDType.LineRenderer, attribute, out string? foundPath))
+						if (LineRenderer.TryGetPath(attribute, out string? foundPath))
 						{
 							return foundPath;
 						}
@@ -178,7 +184,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.TrailRenderer:
 					{
-						if (FieldHashes.TryGetPath(ClassIDType.TrailRenderer, attribute, out string? foundPath))
+						if (TrailRenderer.TryGetPath(attribute, out string? foundPath))
 						{
 							return foundPath;
 						}
@@ -268,7 +274,6 @@ namespace AssetRipper.Processing.AnimationClips
 						};
 					}
 
-#warning TODO:
 				case BindingCustomType.ParentConstraint:
 					{
 						uint property = attribute & 0xF;
@@ -311,7 +316,7 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.Camera:
 					{
-						if (FieldHashes.TryGetPath(ClassIDType.Camera, attribute, out string? foundPath))
+						if (Camera.TryGetPath(attribute, out string? foundPath))
 						{
 							return foundPath;
 						}

--- a/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
@@ -201,7 +201,6 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-				// TryGetPath may not work here
 				case BindingCustomType.PositionConstraint:
 					{
 						if (PositionConstraint.TryGetPath(attribute, out string? foundPath))
@@ -211,7 +210,6 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-				// TryGetPath may not work here
 				case BindingCustomType.RotationConstraint:
 					{
 						if (RotationConstraint.TryGetPath(attribute, out string? foundPath))
@@ -221,7 +219,6 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-				// TryGetPath may not work here
 				case BindingCustomType.ScaleConstraint:
 					{
 						if (ScaleConstraint.TryGetPath(attribute, out string? foundPath))
@@ -231,7 +228,6 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-				// TryGetPath may not work here
 				case BindingCustomType.AimConstraint:
 					{
 						if (AimConstraint.TryGetPath(attribute, out string? foundPath))
@@ -241,7 +237,6 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-				// TryGetPath may not work here
 				case BindingCustomType.ParentConstraint:
 					{
 						if (ParentConstraint.TryGetPath(attribute, out string? foundPath))
@@ -251,7 +246,6 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-				// TryGetPath may not work here
 				case BindingCustomType.LookAtConstraint:
 					{
 						if (LookAtConstraint.TryGetPath(attribute, out string? foundPath))
@@ -270,6 +264,7 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
+				// TryGetPath may not work here
 				case BindingCustomType.VisualEffect:
 					{
 						if (VisualEffect.TryGetPath(attribute, out string? foundPath))
@@ -279,6 +274,7 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
+				// TryGetPath may not work here
 				case BindingCustomType.ParticleForceField:
 					{
 						if (ParticleSystemForceField.TryGetPath(attribute, out string? foundPath))
@@ -290,7 +286,8 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.UserDefined:
 					return "UserDefined_" + Crc32Algorithm.ReverseAscii(attribute);
-
+				
+				// TryGetPath may not work here
 				case BindingCustomType.MeshFilter:
 					{
 						if (MeshFilter.TryGetPath(attribute, out string? foundPath))

--- a/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
@@ -203,57 +203,126 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.PositionConstraint:
 					{
-						if (PositionConstraint.TryGetPath(attribute, out string? foundPath))
+						uint property = attribute & 0xF;
+						return property switch
 						{
-							return foundPath;
-						}
+							0 => "m_RestTranslation.x",
+							1 => "m_RestTranslation.y",
+							2 => "m_RestTranslation.z",
+							3 => "m_Weight",
+							4 => "m_TranslationOffset.x",
+							5 => "m_TranslationOffset.y",
+							6 => "m_TranslationOffset.z",
+							7 => "m_AffectTranslationX",
+							8 => "m_AffectTranslationY",
+							9 => "m_AffectTranslationZ",
+							10 => "m_Active",
+							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.RotationConstraint:
 					{
-						if (RotationConstraint.TryGetPath(attribute, out string? foundPath))
+						uint property = attribute & 0xF;
+						return property switch
 						{
-							return foundPath;
-						}
+							0 => "m_RestRotation.x",
+							1 => "m_RestRotation.y",
+							2 => "m_RestRotation.z",
+							3 => "m_Weight",
+							4 => "m_RotationOffset.x",
+							5 => "m_RotationOffset.y",
+							6 => "m_RotationOffset.z",
+							7 => "m_AffectRotationX",
+							8 => "m_AffectRotationY",
+							9 => "m_AffectRotationZ",
+							10 => "m_Active",
+							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.ScaleConstraint:
 					{
-						if (ScaleConstraint.TryGetPath(attribute, out string? foundPath))
+						uint property = attribute & 0xF;
+						return property switch
 						{
-							return foundPath;
-						}
+							0 => "m_ScaleAtRest.x",
+							1 => "m_ScaleAtRest.y",
+							2 => "m_ScaleAtRest.z",
+							3 => "m_Weight",
+							4 => "m_ScalingOffset.x",
+							5 => "m_ScalingOffset.y",
+							6 => "m_ScalingOffset.z",
+							7 => "m_AffectScalingX",
+							8 => "m_AffectScalingY",
+							9 => "m_AffectScalingZ",
+							10 => "m_Active",
+							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.AimConstraint:
 					{
-						if (AimConstraint.TryGetPath(attribute, out string? foundPath))
+						uint property = attribute & 0xF;
+						return property switch
 						{
-							return foundPath;
-						}
+							0 => "m_Weight",
+							1 => "m_AffectRotationX",
+							2 => "m_AffectRotationY",
+							3 => "m_AffectRotationZ",
+							4 => "m_Active",
+							5 => "m_WorldUpObject",
+							6 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							7 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.ParentConstraint:
 					{
-						if (ParentConstraint.TryGetPath(attribute, out string? foundPath))
+						uint property = attribute & 0xF;
+						return property switch
 						{
-							return foundPath;
-						}
+							0 => "m_Weight",
+							1 => "m_AffectTranslationX",
+							2 => "m_AffectTranslationY",
+							3 => "m_AffectTranslationZ",
+							4 => "m_AffectRotationX",
+							5 => "m_AffectRotationY",
+							6 => "m_AffectRotationZ",
+							7 => "m_Active",
+							8 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].x",
+							9 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].y",
+							10 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].z",
+							11 => $"m_RotationOffsets.Array.data[{attribute >> 8}].x",
+							12 => $"m_RotationOffsets.Array.data[{attribute >> 8}].y",
+							13 => $"m_RotationOffsets.Array.data[{attribute >> 8}].z",
+							14 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							15 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.LookAtConstraint:
 					{
-						if (LookAtConstraint.TryGetPath(attribute, out string? foundPath))
+						uint property = attribute & 0xF;
+						return property switch
 						{
-							return foundPath;
-						}
+							0 => "m_Weight",
+							1 => "m_Active",
+							2 => "m_WorldUpObject",
+							3 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							4 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							5 => "m_Roll",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 				
 				case BindingCustomType.Camera:
 					{

--- a/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
@@ -1,15 +1,25 @@
+using AssetRipper.Checksum;
 using AssetRipper.SourceGenerated.Classes.ClassID_1;
 using AssetRipper.SourceGenerated.Classes.ClassID_108;
 using AssetRipper.SourceGenerated.Classes.ClassID_114;
+using AssetRipper.SourceGenerated.Classes.ClassID_1183024399;
 using AssetRipper.SourceGenerated.Classes.ClassID_120;
 using AssetRipper.SourceGenerated.Classes.ClassID_137;
+using AssetRipper.SourceGenerated.Classes.ClassID_1773428102;
+using AssetRipper.SourceGenerated.Classes.ClassID_1818360608;
+using AssetRipper.SourceGenerated.Classes.ClassID_1818360609;
+using AssetRipper.SourceGenerated.Classes.ClassID_1818360610;
 using AssetRipper.SourceGenerated.Classes.ClassID_198;
 using AssetRipper.SourceGenerated.Classes.ClassID_20;
+using AssetRipper.SourceGenerated.Classes.ClassID_2083052967;
 using AssetRipper.SourceGenerated.Classes.ClassID_224;
 using AssetRipper.SourceGenerated.Classes.ClassID_25;
+using AssetRipper.SourceGenerated.Classes.ClassID_33;
+using AssetRipper.SourceGenerated.Classes.ClassID_330;
 using AssetRipper.SourceGenerated.Classes.ClassID_4;
 using AssetRipper.SourceGenerated.Classes.ClassID_43;
 using AssetRipper.SourceGenerated.Classes.ClassID_74;
+using AssetRipper.SourceGenerated.Classes.ClassID_895512359;
 using AssetRipper.SourceGenerated.Classes.ClassID_96;
 using AssetRipper.SourceGenerated.Extensions;
 using AssetRipper.SourceGenerated.Extensions.Enums.AnimationClip.GenericBinding;
@@ -191,129 +201,66 @@ namespace AssetRipper.Processing.AnimationClips
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
+				// TryGetPath may not work here
 				case BindingCustomType.PositionConstraint:
 					{
-						uint property = attribute & 0xF;
-						return property switch
+						if (PositionConstraint.TryGetPath(attribute, out string? foundPath))
 						{
-							0 => "m_RestTranslation.x",
-							1 => "m_RestTranslation.y",
-							2 => "m_RestTranslation.z",
-							3 => "m_Weight",
-							4 => "m_TranslationOffset.x",
-							5 => "m_TranslationOffset.y",
-							6 => "m_TranslationOffset.z",
-							7 => "m_AffectTranslationX",
-							8 => "m_AffectTranslationY",
-							9 => "m_AffectTranslationZ",
-							10 => "m_Active",
-							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
-							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
-							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
-						};
+							return foundPath;
+						}
 					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
+				// TryGetPath may not work here
 				case BindingCustomType.RotationConstraint:
 					{
-						uint property = attribute & 0xF;
-						return property switch
+						if (RotationConstraint.TryGetPath(attribute, out string? foundPath))
 						{
-							0 => "m_RestRotation.x",
-							1 => "m_RestRotation.y",
-							2 => "m_RestRotation.z",
-							3 => "m_Weight",
-							4 => "m_RotationOffset.x",
-							5 => "m_RotationOffset.y",
-							6 => "m_RotationOffset.z",
-							7 => "m_AffectRotationX",
-							8 => "m_AffectRotationY",
-							9 => "m_AffectRotationZ",
-							10 => "m_Active",
-							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
-							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
-							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
-						};
+							return foundPath;
+						}
 					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
+				// TryGetPath may not work here
 				case BindingCustomType.ScaleConstraint:
 					{
-						uint property = attribute & 0xF;
-						return property switch
+						if (ScaleConstraint.TryGetPath(attribute, out string? foundPath))
 						{
-							0 => "m_ScaleAtRest.x",
-							1 => "m_ScaleAtRest.y",
-							2 => "m_ScaleAtRest.z",
-							3 => "m_Weight",
-							4 => "m_ScalingOffset.x",
-							5 => "m_ScalingOffset.y",
-							6 => "m_ScalingOffset.z",
-							7 => "m_AffectScalingX",
-							8 => "m_AffectScalingY",
-							9 => "m_AffectScalingZ",
-							10 => "m_Active",
-							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
-							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
-							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
-						};
+							return foundPath;
+						}
 					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
+				// TryGetPath may not work here
 				case BindingCustomType.AimConstraint:
 					{
-						uint property = attribute & 0xF;
-						return property switch
+						if (AimConstraint.TryGetPath(attribute, out string? foundPath))
 						{
-							0 => "m_Weight",
-							1 => "m_AffectRotationX",
-							2 => "m_AffectRotationY",
-							3 => "m_AffectRotationZ",
-							4 => "m_Active",
-							5 => "m_WorldUpObject",
-							6 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
-							7 => $"m_Sources.Array.data[{attribute >> 8}].weight",
-							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
-						};
+							return foundPath;
+						}
 					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
+				// TryGetPath may not work here
 				case BindingCustomType.ParentConstraint:
 					{
-						uint property = attribute & 0xF;
-						return property switch
+						if (ParentConstraint.TryGetPath(attribute, out string? foundPath))
 						{
-							0 => "m_Weight",
-							1 => "m_AffectTranslationX",
-							2 => "m_AffectTranslationY",
-							3 => "m_AffectTranslationZ",
-							4 => "m_AffectRotationX",
-							5 => "m_AffectRotationY",
-							6 => "m_AffectRotationZ",
-							7 => "m_Active",
-							8 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].x",
-							9 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].y",
-							10 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].z",
-							11 => $"m_RotationOffsets.Array.data[{attribute >> 8}].x",
-							12 => $"m_RotationOffsets.Array.data[{attribute >> 8}].y",
-							13 => $"m_RotationOffsets.Array.data[{attribute >> 8}].z",
-							14 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
-							15 => $"m_Sources.Array.data[{attribute >> 8}].weight",
-							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
-						};
+							return foundPath;
+						}
 					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
+				// TryGetPath may not work here
 				case BindingCustomType.LookAtConstraint:
 					{
-						uint property = attribute & 0xF;
-						return property switch
+						if (LookAtConstraint.TryGetPath(attribute, out string? foundPath))
 						{
-							0 => "m_Weight",
-							1 => "m_Active",
-							2 => "m_WorldUpObject",
-							3 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
-							4 => $"m_Sources.Array.data[{attribute >> 8}].weight",
-							5 => "m_Roll",
-							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
-						};
+							return foundPath;
+						}
 					}
-
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
+				
 				case BindingCustomType.Camera:
 					{
 						if (Camera.TryGetPath(attribute, out string? foundPath))
@@ -324,16 +271,34 @@ namespace AssetRipper.Processing.AnimationClips
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.VisualEffect:
-					return "VisualEffect_" + attribute;
+					{
+						if (VisualEffect.TryGetPath(attribute, out string? foundPath))
+						{
+							return foundPath;
+						}
+					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.ParticleForceField:
-					return "ParticleForceField_" + attribute;
+					{
+						if (ParticleSystemForceField.TryGetPath(attribute, out string? foundPath))
+						{
+							return foundPath;
+						}
+					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.UserDefined:
-					return "UserDefined_" + attribute;
+					return "UserDefined_" + Crc32Algorithm.ReverseAscii(attribute);
 
 				case BindingCustomType.MeshFilter:
-					return "MeshFilter_" + attribute;
+					{
+						if (MeshFilter.TryGetPath(attribute, out string? foundPath))
+						{
+							return foundPath;
+						}
+					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				default:
 					throw new ArgumentException($"Binding type {type} not implemented", nameof(type));

--- a/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/CustomCurveResolver.cs
@@ -1,4 +1,4 @@
-using AssetRipper.Checksum;
+using AssetRipper.SourceGenerated;
 using AssetRipper.SourceGenerated.Classes.ClassID_1;
 using AssetRipper.SourceGenerated.Classes.ClassID_137;
 using AssetRipper.SourceGenerated.Classes.ClassID_25;
@@ -124,398 +124,196 @@ namespace AssetRipper.Processing.AnimationClips
 
 				case BindingCustomType.MonoBehaviour:
 					{
-						if (attribute == Crc32Algorithm.HashAscii("m_Enabled"))
+						if (FieldHashes.TryGetPath(ClassIDType.MonoBehaviour, attribute, out string? foundPath))
 						{
-							return "m_Enabled";
+							return foundPath;
 						}
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.Light:
 					{
-						const string ColorR = "m_Color" + "." + "r";
-						if (attribute == Crc32Algorithm.HashAscii(ColorR))
+						if (FieldHashes.TryGetPath(ClassIDType.Light, attribute, out string? foundPath))
 						{
-							return ColorR;
-						}
-						const string ColorG = "m_Color" + "." + "g";
-						if (attribute == Crc32Algorithm.HashAscii(ColorG))
-						{
-							return ColorG;
-						}
-						const string ColorB = "m_Color" + "." + "b";
-						if (attribute == Crc32Algorithm.HashAscii(ColorB))
-						{
-							return ColorB;
-						}
-						const string ColorA = "m_Color" + "." + "a";
-						if (attribute == Crc32Algorithm.HashAscii(ColorA))
-						{
-							return ColorA;
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_CookieSize"))
-						{
-							return "m_CookieSize";
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_DrawHalo"))
-						{
-							return "m_DrawHalo";
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_Intensity"))
-						{
-							return "m_Intensity";
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_Range"))
-						{
-							return "m_Range";
-						}
-						const string ShadowsStrength = "m_Shadows" + "." + "m_Strength";
-						if (attribute == Crc32Algorithm.HashAscii(ShadowsStrength))
-						{
-							return ShadowsStrength;
-						}
-						const string ShadowsBias = "m_Shadows" + "." + "m_Bias";
-						if (attribute == Crc32Algorithm.HashAscii(ShadowsBias))
-						{
-							return ShadowsBias;
-						}
-						const string ShadowsNormalBias = "m_Shadows" + "." + "m_NormalBias";
-						if (attribute == Crc32Algorithm.HashAscii(ShadowsNormalBias))
-						{
-							return ShadowsNormalBias;
-						}
-						const string ShadowsNearPlane = "m_Shadows" + "." + "m_NearPlane";
-						if (attribute == Crc32Algorithm.HashAscii(ShadowsNearPlane))
-						{
-							return ShadowsNearPlane;
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_SpotAngle"))
-						{
-							return "m_SpotAngle";
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_InnerSpotAngle"))
-						{
-							return "m_InnerSpotAngle";
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_ColorTemperature"))
-						{
-							return "m_ColorTemperature";
+							return foundPath;
 						}
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.RendererShadows:
 					{
-						if (attribute == Crc32Algorithm.HashAscii("m_ReceiveShadows"))
+						if (FieldHashes.TryGetPath(ClassIDType.Renderer, attribute, out string? foundPath))
 						{
-							return "m_ReceiveShadows";
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_SortingOrder"))
-						{
-							return "m_SortingOrder";
+							return foundPath;
 						}
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-#warning TODO:
 				case BindingCustomType.ParticleSystem:
-					return "ParticleSystem_" + attribute;
-				/*{
-#warning TODO: ordinal propertyName
-				}
-				throw new ArgumentException($"Unknown attribute {attribute} for {_this}");*/
+					{
+						if (FieldHashes.TryGetPath(ClassIDType.ParticleSystem, attribute, out string? foundPath))
+						{
+							return foundPath;
+						}
+					}
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.RectTransform:
 					{
-						string LocalPositionZ = "m_LocalPosition" + "." + "z";
-						if (attribute == Crc32Algorithm.HashAscii(LocalPositionZ))
+						if (FieldHashes.TryGetPath(ClassIDType.RectTransform, attribute, out string? foundPath))	
 						{
-							return LocalPositionZ;
-						}
-						string AnchoredPositionX = "m_AnchoredPosition" + "." + "x";
-						if (attribute == Crc32Algorithm.HashAscii(AnchoredPositionX))
-						{
-							return AnchoredPositionX;
-						}
-						string AnchoredPositionY = "m_AnchoredPosition" + "." + "y";
-						if (attribute == Crc32Algorithm.HashAscii(AnchoredPositionY))
-						{
-							return AnchoredPositionY;
-						}
-						string AnchorMinX = "m_AnchorMin" + "." + "x";
-						if (attribute == Crc32Algorithm.HashAscii(AnchorMinX))
-						{
-							return AnchorMinX;
-						}
-						string AnchorMinY = "m_AnchorMin" + "." + "y";
-						if (attribute == Crc32Algorithm.HashAscii(AnchorMinY))
-						{
-							return AnchorMinY;
-						}
-						string AnchorMaxX = "m_AnchorMax" + "." + "x";
-						if (attribute == Crc32Algorithm.HashAscii(AnchorMaxX))
-						{
-							return AnchorMaxX;
-						}
-						string AnchorMaxY = "m_AnchorMax" + "." + "y";
-						if (attribute == Crc32Algorithm.HashAscii(AnchorMaxY))
-						{
-							return AnchorMaxY;
-						}
-						string SizeDeltaX = "m_SizeDelta" + "." + "x";
-						if (attribute == Crc32Algorithm.HashAscii(SizeDeltaX))
-						{
-							return SizeDeltaX;
-						}
-						string SizeDeltaY = "m_SizeDelta" + "." + "y";
-						if (attribute == Crc32Algorithm.HashAscii(SizeDeltaY))
-						{
-							return SizeDeltaY;
-						}
-						string PivotX = "m_Pivot" + "." + "x";
-						if (attribute == Crc32Algorithm.HashAscii(PivotX))
-						{
-							return PivotX;
-						}
-						string PivotY = "m_Pivot" + "." + "y";
-						if (attribute == Crc32Algorithm.HashAscii(PivotY))
-						{
-							return PivotY;
+							return foundPath;
 						}
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-#warning TODO:
 				case BindingCustomType.LineRenderer:
 					{
-						const string ParametersWidthMultiplier = "m_Parameters" + "." + "widthMultiplier";
-						if (attribute == Crc32Algorithm.HashAscii(ParametersWidthMultiplier))
+						if (FieldHashes.TryGetPath(ClassIDType.LineRenderer, attribute, out string? foundPath))
 						{
-							return ParametersWidthMultiplier;
+							return foundPath;
 						}
 					}
-#warning TODO: old versions animate all properties as custom curves
-					return "LineRenderer_" + attribute;
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-#warning TODO:
 				case BindingCustomType.TrailRenderer:
 					{
-						const string ParametersWidthMultiplier = "m_Parameters" + "." + "widthMultiplier";
-						if (attribute == Crc32Algorithm.HashAscii(ParametersWidthMultiplier))
+						if (FieldHashes.TryGetPath(ClassIDType.TrailRenderer, attribute, out string? foundPath))
 						{
-							return ParametersWidthMultiplier;
+							return foundPath;
 						}
 					}
-#warning TODO: old versions animate all properties as custom curves
-					return "TrailRenderer_" + attribute;
+					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-#warning TODO:
 				case BindingCustomType.PositionConstraint:
 					{
 						uint property = attribute & 0xF;
-						switch (property)
+						return property switch
 						{
-							case 0:
-								return "m_RestTranslation.x";
-							case 1:
-								return "m_RestTranslation.y";
-							case 2:
-								return "m_RestTranslation.z";
-							case 3:
-								return "m_Weight";
-							case 4:
-								return "m_TranslationOffset.x";
-							case 5:
-								return "m_TranslationOffset.y";
-							case 6:
-								return "m_TranslationOffset.z";
-							case 7:
-								return "m_AffectTranslationX";
-							case 8:
-								return "m_AffectTranslationY";
-							case 9:
-								return "m_AffectTranslationZ";
-							case 10:
-								return "m_Active";
-							case 11:
-								return $"m_Sources.Array.data[{attribute >> 8}].sourceTransform";
-							case 12:
-								return $"m_Sources.Array.data[{attribute >> 8}].weight";
-						}
+							0 => "m_RestTranslation.x",
+							1 => "m_RestTranslation.y",
+							2 => "m_RestTranslation.z",
+							3 => "m_Weight",
+							4 => "m_TranslationOffset.x",
+							5 => "m_TranslationOffset.y",
+							6 => "m_TranslationOffset.z",
+							7 => "m_AffectTranslationX",
+							8 => "m_AffectTranslationY",
+							9 => "m_AffectTranslationZ",
+							10 => "m_Active",
+							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-#warning TODO:
 				case BindingCustomType.RotationConstraint:
 					{
 						uint property = attribute & 0xF;
-						switch (property)
+						return property switch
 						{
-							case 0:
-								return "m_RestRotation.x";
-							case 1:
-								return "m_RestRotation.y";
-							case 2:
-								return "m_RestRotation.z";
-							case 3:
-								return "m_Weight";
-							case 4:
-								return "m_RotationOffset.x";
-							case 5:
-								return "m_RotationOffset.y";
-							case 6:
-								return "m_RotationOffset.z";
-							case 7:
-								return "m_AffectRotationX";
-							case 8:
-								return "m_AffectRotationY";
-							case 9:
-								return "m_AffectRotationZ";
-							case 10:
-								return "m_Active";
-							case 11:
-								return $"m_Sources.Array.data[{attribute >> 8}].sourceTransform";
-							case 12:
-								return $"m_Sources.Array.data[{attribute >> 8}].weight";
-						}
+							0 => "m_RestRotation.x",
+							1 => "m_RestRotation.y",
+							2 => "m_RestRotation.z",
+							3 => "m_Weight",
+							4 => "m_RotationOffset.x",
+							5 => "m_RotationOffset.y",
+							6 => "m_RotationOffset.z",
+							7 => "m_AffectRotationX",
+							8 => "m_AffectRotationY",
+							9 => "m_AffectRotationZ",
+							10 => "m_Active",
+							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-#warning TODO:
 				case BindingCustomType.ScaleConstraint:
 					{
 						uint property = attribute & 0xF;
-						switch (property)
+						return property switch
 						{
-							case 0:
-								return "m_ScaleAtRest.x";
-							case 1:
-								return "m_ScaleAtRest.y";
-							case 2:
-								return "m_ScaleAtRest.z";
-							case 3:
-								return "m_Weight";
-							case 4:
-								return "m_ScalingOffset.x";
-							case 5:
-								return "m_ScalingOffset.y";
-							case 6:
-								return "m_ScalingOffset.z";
-							case 7:
-								return "m_AffectScalingX";
-							case 8:
-								return "m_AffectScalingY";
-							case 9:
-								return "m_AffectScalingZ";
-							case 10:
-								return "m_Active";
-							case 11:
-								return $"m_Sources.Array.data[{attribute >> 8}].sourceTransform";
-							case 12:
-								return $"m_Sources.Array.data[{attribute >> 8}].weight";
-						}
+							0 => "m_ScaleAtRest.x",
+							1 => "m_ScaleAtRest.y",
+							2 => "m_ScaleAtRest.z",
+							3 => "m_Weight",
+							4 => "m_ScalingOffset.x",
+							5 => "m_ScalingOffset.y",
+							6 => "m_ScalingOffset.z",
+							7 => "m_AffectScalingX",
+							8 => "m_AffectScalingY",
+							9 => "m_AffectScalingZ",
+							10 => "m_Active",
+							11 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							12 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-#warning TODO:
 				case BindingCustomType.AimConstraint:
 					{
 						uint property = attribute & 0xF;
-						switch (property)
+						return property switch
 						{
-							case 0:
-								return "m_Weight";
-							case 1:
-								return "m_AffectRotationX";
-							case 2:
-								return "m_AffectRotationY";
-							case 3:
-								return "m_AffectRotationZ";
-							case 4:
-								return "m_Active";
-							case 5:
-								return "m_WorldUpObject";
-							case 6:
-								return $"m_Sources.Array.data[{attribute >> 8}].sourceTransform";
-							case 7:
-								return $"m_Sources.Array.data[{attribute >> 8}].weight";
-						}
+							0 => "m_Weight",
+							1 => "m_AffectRotationX",
+							2 => "m_AffectRotationY",
+							3 => "m_AffectRotationZ",
+							4 => "m_Active",
+							5 => "m_WorldUpObject",
+							6 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							7 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 #warning TODO:
 				case BindingCustomType.ParentConstraint:
 					{
 						uint property = attribute & 0xF;
-						switch (property)
+						return property switch
 						{
-							case 0:
-								return "m_Weight";
-							case 1:
-								return "m_AffectTranslationX";
-							case 2:
-								return "m_AffectTranslationY";
-							case 3:
-								return "m_AffectTranslationZ";
-							case 4:
-								return "m_AffectRotationX";
-							case 5:
-								return "m_AffectRotationY";
-							case 6:
-								return "m_AffectRotationZ";
-							case 7:
-								return "m_Active";
-							case 8:
-								return $"m_TranslationOffsets.Array.data[{attribute >> 8}].x";
-							case 9:
-								return $"m_TranslationOffsets.Array.data[{attribute >> 8}].y";
-							case 10:
-								return $"m_TranslationOffsets.Array.data[{attribute >> 8}].z";
-							case 11:
-								return $"m_RotationOffsets.Array.data[{attribute >> 8}].x";
-							case 12:
-								return $"m_RotationOffsets.Array.data[{attribute >> 8}].y";
-							case 13:
-								return $"m_RotationOffsets.Array.data[{attribute >> 8}].z";
-							case 14:
-								return $"m_Sources.Array.data[{attribute >> 8}].sourceTransform";
-							case 15:
-								return $"m_Sources.Array.data[{attribute >> 8}].weight";
-						}
+							0 => "m_Weight",
+							1 => "m_AffectTranslationX",
+							2 => "m_AffectTranslationY",
+							3 => "m_AffectTranslationZ",
+							4 => "m_AffectRotationX",
+							5 => "m_AffectRotationY",
+							6 => "m_AffectRotationZ",
+							7 => "m_Active",
+							8 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].x",
+							9 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].y",
+							10 => $"m_TranslationOffsets.Array.data[{attribute >> 8}].z",
+							11 => $"m_RotationOffsets.Array.data[{attribute >> 8}].x",
+							12 => $"m_RotationOffsets.Array.data[{attribute >> 8}].y",
+							13 => $"m_RotationOffsets.Array.data[{attribute >> 8}].z",
+							14 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							15 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
-#warning TODO:
 				case BindingCustomType.LookAtConstraint:
 					{
 						uint property = attribute & 0xF;
-						switch (property)
+						return property switch
 						{
-							case 0:
-								return "m_Weight";
-							case 1:
-								return "m_Active";
-							case 2:
-								return "m_WorldUpObject";
-							case 3:
-								return $"m_Sources.Array.data[{attribute >> 8}].sourceTransform";
-							case 4:
-								return $"m_Sources.Array.data[{attribute >> 8}].weight";
-							case 5:
-								return "m_Roll";
-						}
+							0 => "m_Weight",
+							1 => "m_Active",
+							2 => "m_WorldUpObject",
+							3 => $"m_Sources.Array.data[{attribute >> 8}].sourceTransform",
+							4 => $"m_Sources.Array.data[{attribute >> 8}].weight",
+							5 => "m_Roll",
+							_ => throw new ArgumentException($"Unknown attribute {attribute} for {type}")
+						};
 					}
-					throw new ArgumentException($"Unknown attribute {attribute} for {type}");
 
 				case BindingCustomType.Camera:
 					{
-						if (attribute == Crc32Algorithm.HashAscii("field of view"))
+						if (FieldHashes.TryGetPath(ClassIDType.Camera, attribute, out string? foundPath))
 						{
-							return "field of view";
-						}
-						if (attribute == Crc32Algorithm.HashAscii("m_FocalLength"))
-						{
-							return "m_FocalLength";
+							return foundPath;
 						}
 					}
 					throw new ArgumentException($"Unknown attribute {attribute} for {type}");


### PR DESCRIPTION
This implements parts of #856 , but done to address the review concerns. Since most of it is unmodified, I left them as co author in the commit.

The main things to mention is most of this is no longer assuming the attributes strings and instead look them up using source generated utilities.

Fixes
Maybe #962 (would need to be tested)
Parts of #954 (the other part is fixed by #973 
An unmentioned part of #853 

cc: @o5zereth 
