### PR TITLE
fix UnityVersion missing type and TypeNumber

### DIFF
--- a/Source/AssetRipper.Import/Structure/Assembly/Managers/IL2CppManager.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Managers/IL2CppManager.cs
@@ -65,7 +65,7 @@ namespace AssetRipper.Import.Structure.Assembly.Managers
 
 			if (gameStructure.Version is not null)
 			{
-				UnityVersion = new UnityVersion((ushort)gameStructure.Version[0], (ushort)gameStructure.Version[1], (ushort)gameStructure.Version[2]);
+				UnityVersion = new UnityVersion((ushort)gameStructure.Version[0], (ushort)gameStructure.Version[1], (ushort)gameStructure.Version[2], (UnityVersionType)gameStructure.Version[3], (byte)gameStructure.Version[4]);
 			}
 			else
 			{

--- a/Source/AssetRipper.Import/Structure/GameStructure.cs
+++ b/Source/AssetRipper.Import/Structure/GameStructure.cs
@@ -36,7 +36,18 @@ namespace AssetRipper.Import.Structure
 
 			Logger.SendStatusChange("loading_step_begin_scheme_processing");
 
-			InitializeGameCollection(configuration.DefaultVersion);
+
+
+			if (platformStructure?.Version is not null)
+			{
+				UnityVersion = new UnityVersion((ushort)platformStructure.Version[0], (ushort)platformStructure.Version[1], (ushort)platformStructure.Version[2], (UnityVersionType)platformStructure.Version[3], (byte)platformStructure.Version[4]);
+			}
+			else
+			{
+				UnityVersion = default;
+			}
+
+			InitializeGameCollection(UnityVersion);
 
 			if (!FileCollection.HasAnyAssetCollections())
 			{

--- a/Source/AssetRipper.Import/Structure/Platforms/PlatformGameStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Platforms/PlatformGameStructure.cs
@@ -333,7 +333,7 @@ namespace AssetRipper.Import.Structure.Platforms
 
 		private static int[] ToArray(UnityVersion version)
 		{
-			return new int[] { version.Major, version.Minor, version.Build };
+			return new int[] { version.Major, version.Minor, version.Build, (int)version.Type, version.TypeNumber };
 		}
 
 		protected static int[]? GetUnityVersionFromDataDirectory(string dataDirectoryPath)


### PR DESCRIPTION
This resolves parsing errors when AssetBundle is striped version 