### PR TITLE
cli: Add config-file flag

### DIFF
--- a/Source/AssetRipper.GUI/README.md
+++ b/Source/AssetRipper.GUI/README.md
@@ -7,15 +7,17 @@ This is a cross-platform gui and command line application for extracting game as
 Double click on the executable to open the graphical user interface.
 
 Alternatively, use the command prompt / terminal to execute it. For example, on linux:
+
 ```
 ./AssetRipper
 ```
 
 ## Command Line Usage
 
-Drag and drop resource file(s) or/and folder(s) onto the executable to retrieve the assets. 
+Drag and drop resource file(s) or/and folder(s) onto the executable to retrieve the assets.
 
 Alternatively, use the command prompt / terminal to execute it. For example, on linux:
+
 ```
 ./AssetRipper yourBundle.unity3d
 ```
@@ -23,10 +25,11 @@ Alternatively, use the command prompt / terminal to execute it. For example, on 
 While running, it will automaticly try to find resource dependencies, create a 'Ripped' folder, and extract all supported assets into the created directory.
 
 ## Command Line Arguments
+
 ```
   -o, --output    Directory to export to. Will be cleared if already exists.
 
-  --logFile       (Default: AssetRipperConsole.log) File to log to.
+  --log-file       (Default: AssetRipperConsole.log) File to log to.
 
   -q, --quit      (Default: false) Close console after export.
 
@@ -34,5 +37,27 @@ While running, it will automaticly try to find resource dependencies, create a '
 
   --version       Display version information.
 
+  --config-file   Config file to use.
+
   value pos. 0    Required. Input files or directory to export.
 ```
+
+## Configuration File
+
+> [!WARNING]
+> This is intended for advanced users only.
+
+You may create a configuration file to configure the CLI, similar to how you
+would set configuration in the GUI. The configuration file is a simple JSON
+file with the following format:
+
+```json
+{
+  "DefaultVersion": "2021.3.9f1",
+  "SpriteExportMode": "Yaml",
+  "TextureExportMode": "Png",
+}
+```
+
+Options available in the configuration file are documented in the source code.
+See [LibraryConfiguration.cs](../AssetRipper.Export.UnityProjects/Configuration/LibraryConfiguration.cs)

--- a/Source/AssetRipper.Import/Configuration/UnityVersionJsonConverter.cs
+++ b/Source/AssetRipper.Import/Configuration/UnityVersionJsonConverter.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AssetRipper.Import.Configuration
+{
+    public class UnityVersionJsonConverter : JsonConverter<UnityVersion>
+    {
+        public override UnityVersion Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            string? input = reader.GetString();
+            return input != null ? UnityVersion.Parse(input) : new UnityVersion();
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            UnityVersion unityVersion,
+            JsonSerializerOptions options) =>
+                writer.WriteStringValue(unityVersion.ToString());
+    }
+}


### PR DESCRIPTION
This allows the CLI to toggle all of the config options that are available for the GUI. The use-case I have is to set DefaultVersion, TextureExportFormat and SpriteExportFormat. This was less code than adding each option to the CLI and will cover more use-cases.