### PR TITLE
Scriptable Object Improvements

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/Project/ScriptableObjectExporter.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Project/ScriptableObjectExporter.cs
@@ -25,7 +25,7 @@ namespace AssetRipper.Export.UnityProjects.Project
 		{
 			exportCollection = asset switch
 			{
-				IMonoBehaviour monoBehaviour => CreateCollection(monoBehaviour),
+				IMonoBehaviour monoBehaviour => monoBehaviour.IsSceneObject() ? null : CreateCollection(monoBehaviour),
 				_ => null,
 			};
 			return exportCollection is not null;

--- a/Source/AssetRipper.SourceGenerated.Extensions/MonoBehaviourExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/MonoBehaviourExtensions.cs
@@ -7,7 +7,7 @@ namespace AssetRipper.SourceGenerated.Extensions
 		/// <summary>
 		/// Does this MonoBehaviour belongs to scene/prefab hierarchy? In other words, is <see cref="IMonoBehaviour.GameObject"/> a non-null pptr?
 		/// </summary>
-		public static bool IsSceneObject(this IMonoBehaviour monoBehaviour) => !monoBehaviour.GameObject.IsNull();
+		public static bool IsSceneObject(this IMonoBehaviour monoBehaviour) => monoBehaviour.Collection.IsScene || !monoBehaviour.GameObject.IsNull();
 		/// <summary>
 		/// Does this MonoBehaviour have a name?
 		/// </summary>


### PR DESCRIPTION
- The Asset Export Collection didn't account for nested scriptable objects. This is an attempt to fix that by adding scriptable objects with no names that are referenced by their pathid by another top level scriptable object
- Some scene components were written into scriptable asset, this commit fixes that, largely avoiding the "Do not use ReadObjectThreaded on scene objects" which caused a huge log and out of memory
- IsSceneObject checks for both condition either gameobject is not null or having the collection as scene. It happens sometimes that the gameobject is null but the monobehaivour is referenced by another monobehaviour that is a part of gameobject
- Overall the commit fixes some "Do not use ReadObjectThreaded on scene objects" and fixes a bunch of deadbeef generated guids

Related: #831