### PR TITLE
FIX: Single script decompilation failure causes half-baked result

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptDecompiler.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptDecompiler.cs
@@ -1,5 +1,6 @@
 ﻿using AsmResolver.DotNet;
 using AssetRipper.Import.Configuration;
+using AssetRipper.Import.Logging;
 using AssetRipper.Import.Structure.Assembly;
 using AssetRipper.Import.Structure.Assembly.Managers;
 using ICSharpCode.Decompiler;
@@ -41,7 +42,14 @@ namespace AssetRipper.Export.UnityProjects.Scripts
 
 		private void DecompileWholeProject(WholeProjectDecompiler decompiler, AssemblyDefinition assembly, string outputFolder)
 		{
-			decompiler.DecompileProject(assemblyResolver.Resolve(assembly), outputFolder, new StringWriter());
+			try
+			{
+				decompiler.DecompileProject(assemblyResolver.Resolve(assembly), outputFolder, new StringWriter());
+			}
+			catch (Exception exception)
+			{
+				Logger.Error(LogCategory.Export, exception.ToString());
+			}
 		}
 	}
 }

--- a/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptDecompiler.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptDecompiler.cs
@@ -48,7 +48,7 @@ namespace AssetRipper.Export.UnityProjects.Scripts
 			}
 			catch (Exception exception)
 			{
-				Logger.Error(LogCategory.Export, exception.ToString());
+				Logger.Error(LogCategory.Export, exception);
 			}
 		}
 	}

--- a/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptDecompiler.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptDecompiler.cs
@@ -48,7 +48,7 @@ namespace AssetRipper.Export.UnityProjects.Scripts
 			}
 			catch (Exception exception)
 			{
-				Logger.Error(LogCategory.Export, exception);
+				Logger.Error(exception);
 			}
 		}
 	}

--- a/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptExportCollection.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptExportCollection.cs
@@ -72,16 +72,7 @@ public sealed class ScriptExportCollection : ScriptExportCollectionBase
 				Logger.Info(LogCategory.Export, $"Decompiling {assemblyName}");
 				string outputDirectory = Path.Combine(assetsDirectoryPath, GetScriptsFolderName(assemblyName), assemblyName);
 				Directory.CreateDirectory(outputDirectory);
-
-				try
-				{
-					AssetExporter.Decompiler.DecompileWholeProject(assembly, outputDirectory);
-				}
-				catch (Exception exception)
-				{
-					Logger.Error(LogCategory.Export, exception.ToString());
-					continue;
-				}
+				AssetExporter.Decompiler.DecompileWholeProject(assembly, outputDirectory);
 
 				assemblyDefinitionDetailsDictionary.TryAdd(assemblyName, new AssemblyDefinitionDetails(assembly, outputDirectory));
 			}

--- a/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptExportCollection.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Scripts/ScriptExportCollection.cs
@@ -72,7 +72,16 @@ public sealed class ScriptExportCollection : ScriptExportCollectionBase
 				Logger.Info(LogCategory.Export, $"Decompiling {assemblyName}");
 				string outputDirectory = Path.Combine(assetsDirectoryPath, GetScriptsFolderName(assemblyName), assemblyName);
 				Directory.CreateDirectory(outputDirectory);
-				AssetExporter.Decompiler.DecompileWholeProject(assembly, outputDirectory);
+
+				try
+				{
+					AssetExporter.Decompiler.DecompileWholeProject(assembly, outputDirectory);
+				}
+				catch (Exception exception)
+				{
+					Logger.Error(LogCategory.Export, exception.ToString());
+					continue;
+				}
 
 				assemblyDefinitionDetailsDictionary.TryAdd(assemblyName, new AssemblyDefinitionDetails(assembly, outputDirectory));
 			}


### PR DESCRIPTION
**Premise:**
When a single script assembly will not decompile the decompilation is left partial: all the assets and code processed prior to that script will be created, however, everything afterwards will not be created or even attempted to decompile.

I ran into this issue when testing the project, a problem-script was causing it to fail, but I could not just recreate it or work around it since everything else was broken as a result.

**Proposed Solution:**
Try/Catch block is used while attempting to decompile the script assembly. This means that the script itself may fail and the error is logged, but we recover and continue to the next assembly. This also allows for future addition of more specific exception catching, in case we want to handle the cases where it is a catastrophic/chain failure that will affect other assemblies.

Simple fix, but for the time being it seems like the best solution in my opinion. This error is present in the parent repository too.