### PR TITLE
Fixed some properties in BlendTree's ChildMotion

### DIFF
--- a/Source/AssetRipper.Processing/AnimatorControllers/VirtualAnimationFactory.cs
+++ b/Source/AssetRipper.Processing/AnimatorControllers/VirtualAnimationFactory.cs
@@ -136,8 +136,8 @@ namespace AssetRipper.Processing.AnimatorControllers
 			if (childNode.IsBlendTree())
 			{
 				// BlendTree ChildMotions are not allowed to use TimeScale or Mirror
-				// https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/Inspector/BlendTreeInspector.cs#L1469
-				// https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/Inspector/BlendTreeInspector.cs#L1488
+				// https://github.com/Unity-Technologies/UnityCsReference/blob/4e215c07ca8e9a32a589043202fd919bdfc0a26d/Editor/Mono/Inspector/BlendTreeInspector.cs#L1469
+				// https://github.com/Unity-Technologies/UnityCsReference/blob/4e215c07ca8e9a32a589043202fd919bdfc0a26d/Editor/Mono/Inspector/BlendTreeInspector.cs#L1488
 				childMotion.TimeScale = 1;
 				childMotion.Mirror = false;
 			}

--- a/Source/AssetRipper.Processing/AnimatorControllers/VirtualAnimationFactory.cs
+++ b/Source/AssetRipper.Processing/AnimatorControllers/VirtualAnimationFactory.cs
@@ -35,6 +35,8 @@ namespace AssetRipper.Processing.AnimatorControllers
 {
 	public static class VirtualAnimationFactory
 	{
+		// Example of default BlendTree Name:
+		// https://github.com/ds5678/Binoculars/blob/d6702ed3a1db39b1a2788956ff195b2590c3d08b/Unity/Assets/Models/binoculars_animator.controller#L106
 		private static Utf8String BlendTreeName { get; } = new Utf8String("Blend Tree");
 
 		private static IMotion? CreateMotion(this IStateConstant stateConstant, ProcessedAssetCollection file, IAnimatorController controller, int nodeIndex)
@@ -130,23 +132,24 @@ namespace AssetRipper.Processing.AnimatorControllers
 			IMotion? motion = state.CreateMotion(file, controller, childNodeIndex);
 			childMotion.Motion.SetAsset(tree.Collection, motion);
 
-			IBlendTreeNodeConstant targetNode = treeConstant.NodeArray[childNodeIndex].Data;
-			if (targetNode.IsBlendTree())
+			IBlendTreeNodeConstant childNode = treeConstant.NodeArray[childNodeIndex].Data;
+			if (childNode.IsBlendTree())
 			{
-				//BlendTree ChildMotions are not allowed to use TimeScale or Mirror
+				// BlendTree ChildMotions are not allowed to use TimeScale or Mirror
+				// https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/Inspector/BlendTreeInspector.cs#L1469
+				// https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/Inspector/BlendTreeInspector.cs#L1488
 				childMotion.TimeScale = 1;
 				childMotion.Mirror = false;
 			}
 			else
 			{
-				childMotion.TimeScale = targetNode.Duration == 0 ? 0.01f : 1/targetNode.Duration;
-				childMotion.Mirror = targetNode.Mirror;
+				childMotion.TimeScale = 1 / childNode.Duration;
+				childMotion.Mirror = childNode.Mirror;
 			}
-			childMotion.CycleOffset = targetNode.CycleOffset;
+			childMotion.CycleOffset = childNode.CycleOffset;
 
 			childMotion.Threshold = node.GetThreshold(childIndex);
 			childMotion.Position?.CopyValues(node.GetPosition(childIndex));
-
 			if (node.TryGetDirectBlendParameter(childIndex, out uint directID))
 			{
 				childMotion.DirectBlendParameter = controller.TOS[directID];

--- a/Source/AssetRipper.Processing/AnimatorControllers/VirtualAnimationFactory.cs
+++ b/Source/AssetRipper.Processing/AnimatorControllers/VirtualAnimationFactory.cs
@@ -35,7 +35,7 @@ namespace AssetRipper.Processing.AnimatorControllers
 {
 	public static class VirtualAnimationFactory
 	{
-		private static Utf8String BlendTreeName { get; } = new Utf8String("BlendTree");
+		private static Utf8String BlendTreeName { get; } = new Utf8String("Blend Tree");
 
 		private static IMotion? CreateMotion(this IStateConstant stateConstant, ProcessedAssetCollection file, IAnimatorController controller, int nodeIndex)
 		{
@@ -130,17 +130,27 @@ namespace AssetRipper.Processing.AnimatorControllers
 			IMotion? motion = state.CreateMotion(file, controller, childNodeIndex);
 			childMotion.Motion.SetAsset(tree.Collection, motion);
 
+			IBlendTreeNodeConstant targetNode = treeConstant.NodeArray[childNodeIndex].Data;
+			if (targetNode.IsBlendTree())
+			{
+				//BlendTree ChildMotions are not allowed to use TimeScale or Mirror
+				childMotion.TimeScale = 1;
+				childMotion.Mirror = false;
+			}
+			else
+			{
+				childMotion.TimeScale = targetNode.Duration == 0 ? 0.01f : 1/targetNode.Duration;
+				childMotion.Mirror = targetNode.Mirror;
+			}
+			childMotion.CycleOffset = targetNode.CycleOffset;
+
 			childMotion.Threshold = node.GetThreshold(childIndex);
 			childMotion.Position?.CopyValues(node.GetPosition(childIndex));
-			childMotion.TimeScale = 1.0f;
-			childMotion.CycleOffset = node.CycleOffset;
 
 			if (node.TryGetDirectBlendParameter(childIndex, out uint directID))
 			{
 				childMotion.DirectBlendParameter = controller.TOS[directID];
 			}
-
-			childMotion.Mirror = node.Mirror;
 
 			return childMotion;
 		}


### PR DESCRIPTION
- Fixed Mirror, TimeScale and CycleOffset for BlendTree's ChildMotions
- Tweaked BlendTree's default name to replicate the one used in Unity Editor