### PR TITLE
GameBundle: skip failed files

### DIFF
--- a/Source/AssetRipper.Assets/Bundles/GameBundle.FromPaths.cs
+++ b/Source/AssetRipper.Assets/Bundles/GameBundle.FromPaths.cs
@@ -63,8 +63,14 @@ partial class GameBundle
 		HashSet<string> serializedFileNames = new();//Includes missing dependencies
 		foreach (string path in paths)
 		{
-			FileBase? file = SchemeReader.LoadFile(path);
-			file?.ReadContentsRecursively();
+			FileBase? file;
+			try {
+				file = SchemeReader.LoadFile(path);
+				file?.ReadContentsRecursively();
+			} catch (Exception e) {
+				Console.WriteLine("Failed to read '{0}' file, skipping! Exception: {1}", path, e);
+				continue;
+			}
 			while (file is CompressedFile compressedFile)
 			{
 				file = compressedFile.UncompressedFile;


### PR DESCRIPTION
Parsing some files might fail due to various reasons in such case still proceed with remaining files.
