### PR TITLE
remove the washi source in csproj files

### DIFF
--- a/Source/AssetRipper.Decompilation.CSharp/AssetRipper.Decompilation.CSharp.csproj
+++ b/Source/AssetRipper.Decompilation.CSharp/AssetRipper.Decompilation.CSharp.csproj
@@ -4,10 +4,6 @@
 		<IsTrimmable>true</IsTrimmable>
 		<OutputPath>..\0Bins\Other\AssetRipper.Decompilation.CSharp\$(Configuration)\</OutputPath>
 		<IntermediateOutputPath>..\0Bins\obj\AssetRipper.Decompilation.CSharp\$(Configuration)\</IntermediateOutputPath>
-
-		<RestoreAdditionalProjectSources>
-			https://nuget.washi.dev/v3/index.json
-		</RestoreAdditionalProjectSources>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Specifying the Washi source in csproj files is no longer necessary due to the nuget.config file added by #1244. This is important because the sources specified in csproj files are forced to be loaded and cannot be avoided even with the `--source` flag in `dotnet build` command etc., in contrary to sources specified in nuget.config file. I should have committed this change in #1244, but I did not notice this problem until I got a build failure lately. Sorry for the complication.