### PR TITLE
Fix exported shaders filename bug in Unity 5.5.0+ Resources/AssetBundles

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/ExportCollection.cs
+++ b/Source/AssetRipper.Export.UnityProjects/ExportCollection.cs
@@ -70,6 +70,7 @@ namespace AssetRipper.Export.UnityProjects
 			string fileName = asset switch
 			{
 				IPrefabInstance prefab => prefab.GetName(),
+				IShader shader when !string.IsNullOrEmpty(shader.OriginalName) => shader.OriginalName,
 				_ => asset.GetBestName(),
 			};
 			fileName = FileUtils.RemoveCloneSuffixes(fileName);


### PR DESCRIPTION
Fixes #1269 