### PR TITLE
AnimationClip Slope Fixes

### DIFF
--- a/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
@@ -77,6 +77,7 @@ namespace AssetRipper.Processing.AnimationClips
 			Span<float> curveValues = [0, 0, 0, 0];
 			Span<float> inSlopeValues = [0, 0, 0, 0];
 			Span<float> outSlopeValues = [0, 0, 0, 0];
+			bool UseNegInfSlopes = m_clip.SupportsNegativeInfinitySlopes();
 
 			if (streamedFrames.Count > 1)
 			{
@@ -111,7 +112,7 @@ namespace AssetRipper.Processing.AnimationClips
 								if (TryGetNextFrame(streamedFrames, frameIdx, curveID, out StreamedFrame? nextFrame, out int nextCurveIdx))
 								{
 									StreamedCurveKey nextCurve = nextFrame.Curves[nextCurveIdx + offset];
-									curve.CalculateSlopes(frame.Time, nextFrame.Time, nextCurve);
+									curve.CalculateSlopes(frame.Time, nextFrame.Time, nextCurve, UseNegInfSlopes);
 								}
 							}
 							curveValues[offset] = curve.Value;
@@ -135,7 +136,7 @@ namespace AssetRipper.Processing.AnimationClips
 							if (TryGetNextFrame(streamedFrames, frameIdx, curveID, out StreamedFrame? nextFrame, out int nextCurveIdx))
 							{
 								StreamedCurveKey nextCurve = nextFrame.Curves[nextCurveIdx];
-								curve.CalculateSlopes(frame.Time, nextFrame.Time, nextCurve);
+								curve.CalculateSlopes(frame.Time, nextFrame.Time, nextCurve, UseNegInfSlopes);
 							}
 						}
 					}

--- a/Source/AssetRipper.Processing/AnimationClips/Editor/StreamedCurveKey.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/Editor/StreamedCurveKey.cs
@@ -10,7 +10,8 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 		{
 			Index = index;
 			Coefficient = coefficient;
-			RightSidedLimit = LeftSidedLimit = value;
+			RightSidedLimit = value;
+			LeftSidedLimit = RightSidedLimit;
 		}
 
 		public void Read(ref EndianSpanReader reader)
@@ -26,11 +27,11 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 			if (Coefficient != default) // != (0,0,0) => regular slopes
 			{
 				double deltaTime = (double)nextTime - time;
-				CalculateRegularSlopes(deltaTime, nextKey, out double _CoeffX, out double _CoeffY);
+				SetRegularSlopes(deltaTime, nextKey, out double _CoeffX, out double _CoeffY);
 
-				if (UseNegInfSlopes && nextKey.Coefficient == default) // calculate LSL only if next slope calculation needs it
+				if (UseNegInfSlopes && nextKey.Coefficient == default) // calculate next LSL only if next slope calculation needs it
 				{
-					nextKey.LeftSidedLimit = (float)((_CoeffX + _CoeffY + Coefficient.Z) * deltaTime + RightSidedLimit);
+					nextKey.LeftSidedLimit = (_CoeffX + _CoeffY + Coefficient.Z) * deltaTime + RightSidedLimit;
 					nextKey.ExactLeftSidedLimit = false;
 				}
 			}
@@ -40,15 +41,17 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 
 			else if (UseNegInfSlopes)
 			{
+				// * there is one curve configuration that can fail and set incorrect slopes
 				CalculateSpecialSlopes(nextKey); // Infinity, -Infinity or Zero
 			}
 			else
 			{
-				CalculateNonNegSpecialSlopes(nextKey); // Infinity or Zero
+				// should be a perfect reconstruction
+				SetNonNegSpecialSlopes(nextKey); // Infinity or Zero
 			}
 		}
 
-		private void CalculateRegularSlopes(double deltaX, StreamedCurveKey nextKey, out double _CoeffX, out double _CoeffY)
+		private void SetRegularSlopes(double deltaX, StreamedCurveKey nextKey, out double _CoeffX, out double _CoeffY)
 		{
 			OutSlope = Coefficient.Z;
 			_CoeffX = Coefficient.X * deltaX * deltaX;
@@ -56,7 +59,7 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 			nextKey.InSlope = (float)(3 * _CoeffX + 2 * _CoeffY + Coefficient.Z); // may need some kind of rounding if wanting to get an inSlope of exactly 0
 		}
 
-		private void CalculateNonNegSpecialSlopes(StreamedCurveKey nextKey)
+		private void SetNonNegSpecialSlopes(StreamedCurveKey nextKey)
 		{
 			if (RightSidedLimit != nextKey.RightSidedLimit)
 			{
@@ -68,56 +71,84 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 
 		private void CalculateSpecialSlopes(StreamedCurveKey nextKey)
 		{
+			bool isDiscontinuous = HasDifferentLimits();
+			if (RightSidedLimit == nextKey.RightSidedLimit)
+			{
+				// OutSlope IS Zero or -Infinity
+				// but -Inf can also recreate Zero curves, so that will be used
+				SetNegInfSlope(nextKey, isDiscontinuous);
+				return;
+			}
+
+			if (isDiscontinuous) // * this estimation can be source of error
+			{
+				// OutSlope SHOULD be -Infinity
+				SetNegInfSlope(nextKey, true);
+				return;
+			}
+
+			// OutSlope SHOULD be Zero or +Infinity
+			// but +Inf can also recreate Zero curves, so that will be used
+			SetPosInfSlope(nextKey);
+		}
+
+		private void SetNegInfSlope(StreamedCurveKey nextKey, bool isDiscontinuous)
+		{
+			OutSlope = float.NegativeInfinity;
+			// nextKey.InSlope is already 0
+
+			// set next LSL only if next slope calculation needs it
+			if (nextKey.Coefficient == default)
+			{
+				nextKey.LeftSidedLimit = RightSidedLimit;
+			}
+
+			// fix Value for true -Infinity slopes
+			if (isDiscontinuous)
+			{
+				RightSidedLimit = (float)LeftSidedLimit;
+			}
+		}
+
+		private void SetPosInfSlope(StreamedCurveKey nextKey)
+		{
+			OutSlope = float.PositiveInfinity;
+			// nextKey.InSlope is already 0
+
+			/// Don't modify nextKey.LeftSidedLimit here!
+			/// If nextKey.LeftSidedLimit is kept equal to nextKey.RightSidedLimit,
+			/// then nextKey can't produce OutSlope of -Infinity
+			/// +Inf outslope followed by -Inf outslope is an "illegal configuration".
+			/*
+			// set next LSL only if next slope calculation needs it
+			if (nextKey.Coefficient == default)
+			{
+				nextKey.LeftSidedLimit = RightSidedLimit;
+			}
+			*/
+		}
+
+		private bool HasDifferentLimits()
+		{
 			if (RightSidedLimit != LeftSidedLimit)
 			{
 				if (ExactLeftSidedLimit)
 				{
-					SetNegInfSlope(nextKey);
-					return;
+					return true;
 				}
 
-				// check percentage difference
-				float diff = float.Abs(RightSidedLimit - LeftSidedLimit);
-				float div = float.Max(float.Abs(LeftSidedLimit), float.Abs(RightSidedLimit));
-				const float ROUNDING_ERROR = 1e-5f; // arbitrary small value
-				
-				// normally the difference between Right and Left Sided Limits should be "big"/much greater than a rounding error.
-				// if the check fails and INCORRECTLY skips this condition, the next statement
-				// should still produce a good approximation for the expected curve
-				if (diff/div > ROUNDING_ERROR)
+				// check percentage difference. this estimation can be source of error
+				double diff = double.Abs((double)RightSidedLimit - LeftSidedLimit);
+				double div = double.Max(double.Abs(LeftSidedLimit), float.Abs(RightSidedLimit));
+				const double ROUNDING_ERROR = 1e-5; // arbitrary small value
+				/// normally the difference between Right and Left Sided Limits
+				/// should be "big"/much greater than a rounding error.
+				if (diff / div > ROUNDING_ERROR)
 				{
-					SetNegInfSlope(nextKey);
-					return;
+					return true;
 				}
 			}
-			if (RightSidedLimit == nextKey.RightSidedLimit)
-			{
-				SetZeroSlope(nextKey);
-				return;
-			}
-			OutSlope = float.PositiveInfinity;
-			// nextKey.InSlope is already 0
-		}
-
-		private void SetNegInfSlope(StreamedCurveKey nextKey)
-		{
-			OutSlope = float.NegativeInfinity;
-			// nextKey.InSlope is already 0
-			if (nextKey.Coefficient == default) // set LSL only if next slope calculation needs it 
-			{
-				nextKey.LeftSidedLimit = RightSidedLimit;
-			}
-			RightSidedLimit = LeftSidedLimit;
-		}
-
-		private void SetZeroSlope(StreamedCurveKey nextKey)
-		{
-			// this.OutSlope is already 0
-			// nextKey.InSlope is already 0
-			if (nextKey.Coefficient == default) // set LSL only if next slope calculation needs it 
-			{
-				nextKey.LeftSidedLimit = RightSidedLimit;
-			}
+			return false;
 		}
 
 		/// <summary>
@@ -150,7 +181,7 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 		/// outSlope=-Infinity creates a discontinuity on the curve,
 		/// making the CurveKey value differ from its right side.
 		/// </remarks>
-		private float LeftSidedLimit { get; set; }
+		private double LeftSidedLimit { get; set; }
 		/// <summary>
 		/// Used only to calculate slopes.
 		/// </summary>

--- a/Source/AssetRipper.Processing/AnimationClips/Editor/StreamedCurveKey.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/Editor/StreamedCurveKey.cs
@@ -21,53 +21,103 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 			LeftSidedLimit = RightSidedLimit;
 		}
 
-		public void CalculateSlopes(float time, float nextTime, StreamedCurveKey nextKey)
+		public void CalculateSlopes(float time, float nextTime, StreamedCurveKey nextKey, bool UseNegInfSlopes)
 		{
 			if (Coefficient != default) // != (0,0,0) => regular slopes
 			{
-				OutSlope = Coefficient.Z;
-				float deltaX = nextTime - time;
-				float _CoeffX = Coefficient.X * deltaX * deltaX;
-				float _CoeffY = Coefficient.Y * deltaX;
-				nextKey.InSlope = 3 * _CoeffX + 2 * _CoeffY + Coefficient.Z; // may need some kind of rounding if wanting to get an inSlope of exactly 0
-				//nextKey.inSlope = float.Round(nextKey.inSlope, 4); // amount of decimal places may be more dynamic
-				if (nextKey.Coefficient == default) // calculate LSL only if next slope calculation needs it
+				double deltaTime = (double)nextTime - time;
+				CalculateRegularSlopes(deltaTime, nextKey, out double _CoeffX, out double _CoeffY);
+
+				if (UseNegInfSlopes && nextKey.Coefficient == default) // calculate LSL only if next slope calculation needs it
 				{
-					nextKey.LeftSidedLimit = (_CoeffX + _CoeffY + Coefficient.Z) * deltaX + RightSidedLimit;
+					nextKey.LeftSidedLimit = (float)((_CoeffX + _CoeffY + Coefficient.Z) * deltaTime + RightSidedLimit);
+					nextKey.ExactLeftSidedLimit = false;
 				}
-				return;
 			}
+
+			// set Special slope to this.OutSlope, because has priority over nextKey.InSlope on shaping the curve
+			// nextKey.InSlope can stay Zero
+
+			else if (UseNegInfSlopes)
+			{
+				CalculateSpecialSlopes(nextKey); // Infinity, -Infinity or Zero
+			}
+			else
+			{
+				CalculateNonNegSpecialSlopes(nextKey); // Infinity or Zero
+			}
+		}
+
+		private void CalculateRegularSlopes(double deltaX, StreamedCurveKey nextKey, out double _CoeffX, out double _CoeffY)
+		{
+			OutSlope = Coefficient.Z;
+			_CoeffX = Coefficient.X * deltaX * deltaX;
+			_CoeffY = Coefficient.Y * deltaX;
+			nextKey.InSlope = (float)(3 * _CoeffX + 2 * _CoeffY + Coefficient.Z); // may need some kind of rounding if wanting to get an inSlope of exactly 0
+		}
+
+		private void CalculateNonNegSpecialSlopes(StreamedCurveKey nextKey)
+		{
+			if (RightSidedLimit != nextKey.RightSidedLimit)
+			{
+				OutSlope = float.PositiveInfinity;
+				// nextKey.InSlope is already 0
+			}
+			// else { this.OutSlope and nextKey.InSlope are already 0 }
+		}
+
+		private void CalculateSpecialSlopes(StreamedCurveKey nextKey)
+		{
 			if (RightSidedLimit != LeftSidedLimit)
 			{
+				if (ExactLeftSidedLimit)
+				{
+					SetNegInfSlope(nextKey);
+					return;
+				}
+
 				// check percentage difference
-				float diff = RightSidedLimit > LeftSidedLimit ? RightSidedLimit - LeftSidedLimit : LeftSidedLimit - RightSidedLimit;
-				float AbsVal = RightSidedLimit < 0 ? -RightSidedLimit : RightSidedLimit;
-				float AbsLSV = LeftSidedLimit < 0 ? -LeftSidedLimit : LeftSidedLimit;
-				float div = AbsVal > AbsLSV ? AbsVal : AbsLSV;
+				float diff = float.Abs(RightSidedLimit - LeftSidedLimit);
+				float div = float.Max(float.Abs(LeftSidedLimit), float.Abs(RightSidedLimit));
 				const float ROUNDING_ERROR = 1e-5f; // arbitrary small value
+				
 				// normally the difference between Right and Left Sided Limits should be "big"/much greater than a rounding error.
-				// if the check fails and INCORRECTLY skips this IF block, the next statements
-				// will still produce a good approximation for the expected curve
+				// if the check fails and INCORRECTLY skips this condition, the next statement
+				// should still produce a good approximation for the expected curve
 				if (diff/div > ROUNDING_ERROR)
 				{
-					OutSlope = float.NegativeInfinity;
-					nextKey.InSlope = 0f;
-					nextKey.LeftSidedLimit = RightSidedLimit;
-					RightSidedLimit = LeftSidedLimit;
+					SetNegInfSlope(nextKey);
 					return;
 				}
 			}
 			if (RightSidedLimit == nextKey.RightSidedLimit)
 			{
-				OutSlope = 0f;
-				nextKey.InSlope = 0f;
-				nextKey.LeftSidedLimit = RightSidedLimit;
+				SetZeroSlope(nextKey);
 				return;
 			}
 			OutSlope = float.PositiveInfinity;
-			nextKey.InSlope = 0f;
-			// don't do nextKey.LeftSidedLimit=RightSidedLimit here, because having 2 consecutive keys
-			// with outSlope +Inf and -Inf is illegal (Editor corrects it)
+			// nextKey.InSlope is already 0
+		}
+
+		private void SetNegInfSlope(StreamedCurveKey nextKey)
+		{
+			OutSlope = float.NegativeInfinity;
+			// nextKey.InSlope is already 0
+			if (nextKey.Coefficient == default) // set LSL only if next slope calculation needs it 
+			{
+				nextKey.LeftSidedLimit = RightSidedLimit;
+			}
+			RightSidedLimit = LeftSidedLimit;
+		}
+
+		private void SetZeroSlope(StreamedCurveKey nextKey)
+		{
+			// this.OutSlope is already 0
+			// nextKey.InSlope is already 0
+			if (nextKey.Coefficient == default) // set LSL only if next slope calculation needs it 
+			{
+				nextKey.LeftSidedLimit = RightSidedLimit;
+			}
 		}
 
 		/// <summary>
@@ -101,6 +151,14 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 		/// making the CurveKey value differ from its right side.
 		/// </remarks>
 		private float LeftSidedLimit { get; set; }
+		/// <summary>
+		/// Used only to calculate slopes.
+		/// </summary>
+		/// <remarks>
+		/// Should be <c>true</c> if <c>LeftSidedLimit</c> was set from an arithmetic calculation
+		/// instead of from <c>Read()</c>, meaning its not 100% reliable for equality comparison.
+		/// </remarks>
+		private bool ExactLeftSidedLimit { get; set; } = true;
 		public float InSlope { get; private set; }
 		public float OutSlope { get; private set; }
 	}

--- a/Source/AssetRipper.Processing/AnimationClips/Editor/StreamedCurveKey.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/Editor/StreamedCurveKey.cs
@@ -89,7 +89,7 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 
 			// OutSlope SHOULD be Zero or +Infinity
 			// but +Inf can also recreate Zero curves, so that will be used
-			SetPosInfSlope(nextKey);
+			SetPosInfSlope();
 		}
 
 		private void SetNegInfSlope(StreamedCurveKey nextKey, bool isDiscontinuous)
@@ -110,7 +110,7 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 			}
 		}
 
-		private void SetPosInfSlope(StreamedCurveKey nextKey)
+		private void SetPosInfSlope()
 		{
 			OutSlope = float.PositiveInfinity;
 			// nextKey.InSlope is already 0
@@ -119,13 +119,6 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 			/// If nextKey.LeftSidedLimit is kept equal to nextKey.RightSidedLimit,
 			/// then nextKey can't produce OutSlope of -Infinity
 			/// +Inf outslope followed by -Inf outslope is an "illegal configuration".
-			/*
-			// set next LSL only if next slope calculation needs it
-			if (nextKey.Coefficient == default)
-			{
-				nextKey.LeftSidedLimit = RightSidedLimit;
-			}
-			*/
 		}
 
 		private bool HasDifferentLimits()
@@ -140,7 +133,7 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 				// check percentage difference. this estimation can be source of error
 				double diff = double.Abs((double)RightSidedLimit - LeftSidedLimit);
 				double div = double.Max(double.Abs(LeftSidedLimit), float.Abs(RightSidedLimit));
-				const double ROUNDING_ERROR = 1e-5; // arbitrary small value
+				const float ROUNDING_ERROR = 5e-7f; // arbitrary small value
 				/// normally the difference between Right and Left Sided Limits
 				/// should be "big"/much greater than a rounding error.
 				if (diff / div > ROUNDING_ERROR)

--- a/Source/AssetRipper.Processing/AnimationClips/Editor/StreamedCurveKey.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/Editor/StreamedCurveKey.cs
@@ -155,7 +155,7 @@ namespace AssetRipper.Processing.AnimationClips.Editor
 		/// Used only to calculate slopes.
 		/// </summary>
 		/// <remarks>
-		/// Should be <c>true</c> if <c>LeftSidedLimit</c> was set from an arithmetic calculation
+		/// Should be <c>false</c> if <c>LeftSidedLimit</c> was set from an arithmetic calculation
 		/// instead of from <c>Read()</c>, meaning its not 100% reliable for equality comparison.
 		/// </remarks>
 		private bool ExactLeftSidedLimit { get; set; } = true;

--- a/Source/AssetRipper.SourceGenerated.Extensions/AnimationClipExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/AnimationClipExtensions.cs
@@ -49,5 +49,7 @@ namespace AssetRipper.SourceGenerated.Extensions
 
 			yield break;
 		}
+
+		public static bool SupportsNegativeInfinitySlopes(this IAnimationClip clip) => clip.Collection.Version.GreaterThan(2021);
 	}
 }


### PR DESCRIPTION
- only use Negative Infinity slopes on Unity > 2021
- stricter rounding error
- code cleanup