### PR TITLE
AnimationClipConverter Fixes

### DIFF
--- a/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/AnimationClipConverter.cs
@@ -413,7 +413,7 @@ namespace AssetRipper.Processing.AnimationClips
 			switch (binding.GetClassID())
 			{
 				case ClassIDType.GameObject:
-					AddGameObjectCurve(binding, path, time, value);
+					AddGameObjectCurve(binding, path, time, value, inTangent, outTangent);
 					break;
 
 				case ClassIDType.MonoBehaviour:
@@ -426,18 +426,18 @@ namespace AssetRipper.Processing.AnimationClips
 			}
 		}
 
-		private void AddGameObjectCurve(IGenericBinding binding, string path, float time, float value)
+		private void AddGameObjectCurve(IGenericBinding binding, string path, float time, float value, float inTangent, float outTangent)
 		{
 			if (GameObject.TryGetPath(binding.Attribute, out string? propertyName))
 			{
 				CurveData curve = new(path, propertyName, ClassIDType.GameObject);
-				AddFloatKeyframe(curve, time, value, 0, 0);
+				AddFloatKeyframe(curve, time, value, inTangent, outTangent);
 			}
 			else
 			{
 				// that means that dev exported animation clip with missing component
 				CurveData curve = new(path, GetReversedPath(MissedPropertyPrefix, binding.Attribute), ClassIDType.GameObject);
-				AddFloatKeyframe(curve, time, value, 0, 0);
+				AddFloatKeyframe(curve, time, value, inTangent, outTangent);
 			}
 		}
 

--- a/Source/AssetRipper.SourceGenerated.Extensions/StreamedClipExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/StreamedClipExtensions.cs
@@ -8,7 +8,7 @@ namespace AssetRipper.SourceGenerated.Extensions
 
 		public static int CurveCount(this IStreamedClip clip)
 		{
-			return clip.Has_CurveCount_UInt32() ? (int)clip.CurveCount_UInt32 : clip.CurveCount_UInt16;
+			return clip.Has_CurveCount_UInt32() ? (int)clip.CurveCount_UInt32 : clip.CurveCount_UInt16 + clip.DiscreteCurveCount;
 		}
 	}
 }


### PR DESCRIPTION
- fixed IStreamedClip.CurveCount() being incorrect for some Unity versions
- fixed GameObject Curves not using the calculated Slopes