### PR TITLE
Fix Incorrect Pass Export Name in Shader Disassembly Mode

### DIFF
--- a/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
@@ -27,7 +27,7 @@ namespace AssetRipper.Export.Modules.Shaders.IO
 		public static void Export(this ISerializedPass _this, ShaderWriter writer)
 		{
 			writer.WriteIndent(2);
-			writer.Write($"{_this.Type.ToString()} ");
+			writer.Write($"{((SerializedPassType)_this.Type).ToString()} ");
 
 			if (_this.Type == (int)SerializedPassType.UsePass)
 			{


### PR DESCRIPTION
In Disassembly mode, the exported name for the Pass is incorrect because the type is converted to a string directly from an integer, which results in the name being incorrectly displayed as "0". 

**Incorrect Configuration:**
```plaintext
SubShader {
	Tags { "CanUseSpriteAtlas" = "true" "IGNOREPROJECTOR" = "true" "PreviewType" = "Plane" "QUEUE" = "Transparent" "RenderType" = "Transparent" }
	0 {
		Name "Normal"
}
```
**Corrected Configuration:**
```plaintext
SubShader {
	Tags { "CanUseSpriteAtlas" = "true" "IGNOREPROJECTOR" = "true" "PreviewType" = "Plane" "QUEUE" = "Transparent" "RenderType" = "Transparent" }
	Pass {
		Name "Normal"
}
```