### PR TITLE
Fix output error in Disassembly Mode

### DIFF
--- a/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
@@ -333,7 +333,10 @@ namespace AssetRipper.Export.Modules.Shaders.IO
 						writer.Write('A');
 					}
 				}
-				writer.Write($" {index}\n");
+				if (index != -1) { 
+					writer.Write($" {index}");
+				}
+				writer.Write($"\n");
 			}
 		}
 

--- a/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
@@ -472,8 +472,8 @@ namespace AssetRipper.Export.Modules.Shaders.IO
 			writer.WriteIndent(4);
 			if (_this.CompValue() == StencilComp.Disabled)
 			{
-				writer.Write($"// When the value is set to 'Disabled', it indicates that this is the default value defined using Properties.\n");
-				writer.Write($"// https://github.com/AssetRipper/AssetRipper/pull/1337\n");
+				// When the value is set to 'Disabled', it indicates that this is the default value defined using Properties.
+				// https://github.com/AssetRipper/AssetRipper/pull/1337
 				writer.Write($"Comp{type.ToSuffixString()} [{_this.CompValue()}]\n");
 			}
 			else 

--- a/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
@@ -472,10 +472,9 @@ namespace AssetRipper.Export.Modules.Shaders.IO
 			writer.WriteIndent(4);
 			if (_this.CompValue() == StencilComp.Disabled)
 			{
-				writer.Write($"Comp{type.ToSuffixString()} [{_this.CompValue()}]\n");
 				writer.Write($"// When the value is set to 'Disabled', it indicates that this is the default value defined using Properties.\n");
-				writer.Write($"// Unity Shader Manual on CompareFunction: https://docs.unity3d.com/Manual/SL-Stencil.html#comparison-operation-values\n");
-				writer.Write($"// Unity Scripting API on CompareFunction: https://docs.unity3d.com/ScriptReference/Rendering.CompareFunction.html\n");
+				writer.Write($"// https://github.com/AssetRipper/AssetRipper/pull/1337\n");
+				writer.Write($"Comp{type.ToSuffixString()} [{_this.CompValue()}]\n");
 			}
 			else 
 			{ 

--- a/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
@@ -470,9 +470,12 @@ namespace AssetRipper.Export.Modules.Shaders.IO
 		public static void Export(this ISerializedStencilOp _this, TextWriter writer, StencilType type)
 		{
 			writer.WriteIndent(4);
-			if (_this.Comp.Val == 0)
+			if (_this.CompValue() == StencilComp.Disabled)
 			{
-				writer.Write($"Comp{type.ToSuffixString()} [{_this.CompValue()}] // When the value is set to 'Disabled', it indicates that this is the default value defined using Properties.\n");
+				writer.Write($"Comp{type.ToSuffixString()} [{_this.CompValue()}]\n");
+				writer.Write($"// When the value is set to 'Disabled', it indicates that this is the default value defined using Properties.\n");
+				writer.Write($"// Unity Shader Manual on CompareFunction: https://docs.unity3d.com/Manual/SL-Stencil.html#comparison-operation-values\n");
+				writer.Write($"// Unity Scripting API on CompareFunction: https://docs.unity3d.com/ScriptReference/Rendering.CompareFunction.html\n");
 			}
 			else 
 			{ 

--- a/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
@@ -470,7 +470,14 @@ namespace AssetRipper.Export.Modules.Shaders.IO
 		public static void Export(this ISerializedStencilOp _this, TextWriter writer, StencilType type)
 		{
 			writer.WriteIndent(4);
-			writer.Write($"Comp{type.ToSuffixString()} {_this.CompValue()}\n");
+			if (_this.Comp.Val == 0)
+			{
+				writer.Write($"Comp{type.ToSuffixString()} [{_this.CompValue()}] // When the value is set to 'Disabled', it indicates that this is the default value defined using Properties.\n");
+			}
+			else 
+			{ 
+				writer.Write($"Comp{type.ToSuffixString()} {_this.CompValue()}\n");
+			}
 			writer.WriteIndent(4);
 			writer.Write($"Pass{type.ToSuffixString()} {_this.PassValue()}\n");
 			writer.WriteIndent(4);


### PR DESCRIPTION
## Description

1. **Default Value for ColorMask without MRT**: The default value of ColorMask index when MRT is not used is -1, but this does not need to be output. [Just like the above code](https://github.com/AssetRipper/AssetRipper/blob/master/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs#L297), I think the original author forgot to write it.

2. **Inconsistency in Stencil CompareFunction Definitions**: The `CompareFunction` enumeration in the [shader definition](https://docs.unity3d.com/Manual/SL-Stencil.html#comparison-operation-values) is missing the `Disabled` option that is available in [C# definition](https://docs.unity3d.com/ScriptReference/Rendering.CompareFunction.html). This omission leads to compiler errors. In fact, when CompareFunction is set to Disabled, it implies that the source code is compiled with the following settings:

```shaderlab
_StencilRef("Stencil Reference Value", Int) = 0
_StencilReadMask("Stencil Fail Operation", Float) = 0 
_StencilWriteMask("Stencil Fail Operation", Float) = 0 
_StencilComp("Stencil Comparison Function", Float) = 0 
_StencilPass("Stencil Pass Operation", Float) = 0 
_StencilFail("Stencil Fail Operation", Float) = 0 
_StencilZFail("Stencil Depth Fail Operation", Float) = 0 
Stencil {
    Ref [_StencilRef]
    ReadMask [_StencilReadMask]
    WriteMask [_StencilWriteMask]
    Comp [_StencilComp]
    Pass [_StencilPass]
    Fail [_StencilFail]
    ZFail [_StencilZFail]
}
