### PR TITLE
Fix color definition in Shader Properties

### DIFF
--- a/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
@@ -175,6 +175,9 @@ namespace AssetRipper.Export.Modules.Shaders.IO
 			switch (_this.GetType_())
 			{
 				case SerializedPropertyType.Color:
+					writer.Write("Color");
+					break;
+
 				case SerializedPropertyType.Vector:
 					writer.Write("Vector");
 					break;


### PR DESCRIPTION
Sorry for always pulling requests for small issues
I recently used hlslccwrapper to restore the shader in my personal project. I noticed that the clr dll compiled by .net formwork can be read by .net 8 so I modified the hlclcc output to match the unity format.
Therefore, problems are always found intermittently.
![image](https://github.com/AssetRipper/AssetRipper/assets/102138304/ab5e73c2-2c67-4e6e-a72e-0ec92b8d53b6)

I originally thought the issue was due to color and vector being treated as the same value after compilation, which prevented the restoration of the Color definition in the Shader. But when I researched this issue, I realized it was entirely due to the original author's oversight. Color should be directly outputted as Color for it to be recognized in the Material panel.