### PR TITLE
Sanitize filenames to exclude commas, brackets, and control characters

### DIFF
--- a/Source/AssetRipper.IO.Files/Utils/FileUtils.cs
+++ b/Source/AssetRipper.IO.Files/Utils/FileUtils.cs
@@ -90,7 +90,8 @@ namespace AssetRipper.IO.Files.Utils
 		{
 			string invalidChars = GetInvalidFileNameChars();
 			string escapedChars = Regex.Escape(invalidChars);
-			return new Regex($"[{escapedChars}]");
+			// Updated regex to include commas, square brackets, and ASCII control characters
+			return new Regex($"[{escapedChars},\\[\\]\\x00-\\x1F]");
 		}
 
 		/// <summary>


### PR DESCRIPTION
Related to #1334

Updates the filename sanitization process in AssetRipper to include commas, square brackets, and ASCII control characters.

- Modifies the `GenerateFileNameRegex` method in `FileUtils.cs` to enhance the filename sanitization regex. This update specifically targets and removes commas, square brackets, and ASCII control characters from filenames, replacing them with an underscore.
- Ensures filenames generated or processed by AssetRipper adhere to Windows and Linux file naming conventions, preventing errors related to invalid characters in file paths.