### PR TITLE
 Consider the aabb in the mesh engine assets key

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/AssetRipper.Export.UnityProjects.csproj
+++ b/Source/AssetRipper.Export.UnityProjects/AssetRipper.Export.UnityProjects.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AssetRipper.HashAlgorithms" Version="1.0.0" />
-		<PackageReference Include="AssetRipper.Mining.PredefinedAssets" Version="1.2.1" />
+		<PackageReference Include="AssetRipper.Mining.PredefinedAssets" Version="1.3.2" />
 		<PackageReference Include="AssetRipper.SharpGLTF.Toolkit" Version="1.0.2" />
 		<PackageReference Include="AssetRipper.TextureDecoder" Version="2.2.0" />
 		<PackageReference Include="AssetRipper.Tpk" Version="1.0.0" />

--- a/Source/AssetRipper.Export.UnityProjects/EngineAssets/EngineAssetsFactory.cs
+++ b/Source/AssetRipper.Export.UnityProjects/EngineAssets/EngineAssetsFactory.cs
@@ -156,6 +156,11 @@ public static class EngineAssetsFactory
 			Name = mesh.Name,
 			VertexCount = (int)mesh.VertexData.VertexCount,
 			SubMeshCount = mesh.SubMeshes.Count,
+			LocalAABB = new()
+			{
+				Center = mesh.LocalAABB.Center,
+				Extent = mesh.LocalAABB.Extent
+			}
 		};
 	}
 

--- a/Source/AssetRipper.Export.UnityProjects/EngineAssets/PredefinedAssetCache.cs
+++ b/Source/AssetRipper.Export.UnityProjects/EngineAssets/PredefinedAssetCache.cs
@@ -61,7 +61,7 @@ public sealed class PredefinedAssetCache
 	private readonly record struct MonoBehaviourKey(Utf8String Name, bool Enabled, Utf8String AssemblyName, Utf8String Namespace, Utf8String ClassName, Utf8String? GameObjectName);
 	private readonly record struct MonoScriptKey(Utf8String AssemblyName, Utf8String Namespace, Utf8String ClassName);
 	private readonly record struct AudioClipKey(Utf8String Name, int Channels, int Frequency, float Length);
-	private readonly record struct MeshKey(Utf8String Name, int VertexCount, int SubMeshCount);
+	private readonly record struct MeshKey(Utf8String Name, int VertexCount, int SubMeshCount, AxisAlignedBoundingBox localAABB);
 	private readonly record struct CubeMapKey(Utf8String Name, int Width, int Height);
 	private readonly record struct Texture2DKey(Utf8String Name, int Width, int Height);
 	private readonly record struct ShaderKey(Utf8String Name, int PropertyNamesHash);
@@ -295,7 +295,11 @@ public sealed class PredefinedAssetCache
 
 	public bool Contains(IMesh mesh, out long fileID, out UnityGuid guid, out AssetType assetType)
 	{
-		if (meshDictionary.TryGetValue(new MeshKey(mesh.Name, (int)mesh.VertexData.VertexCount, mesh.SubMeshes.Count), out AssetMetaPtr assetMetaPtr))
+		if (meshDictionary.TryGetValue(new MeshKey(mesh.Name, (int)mesh.VertexData.VertexCount, mesh.SubMeshes.Count, new()
+		    {
+			    Center = mesh.LocalAABB.Center,
+			    Extent = mesh.LocalAABB.Extent
+		    }), out AssetMetaPtr assetMetaPtr))
 		{
 			(fileID, guid, assetType) = assetMetaPtr;
 			return true;
@@ -527,7 +531,11 @@ public sealed class PredefinedAssetCache
 
 	public bool TryAdd(Mesh mesh, long fileID, UnityGuid guid, AssetType assetType)
 	{
-		return meshDictionary.TryAdd(new MeshKey(mesh.Name, mesh.VertexCount, mesh.SubMeshCount), new AssetMetaPtr(fileID, guid, assetType));
+		return meshDictionary.TryAdd(new MeshKey(mesh.Name, mesh.VertexCount, mesh.SubMeshCount, new()
+		{
+			Center = mesh.LocalAABB.Center,
+			Extent = mesh.LocalAABB.Extent
+		}), new AssetMetaPtr(fileID, guid, assetType));
 	}
 
 	public bool TryAdd(AudioClip audioClip, long fileID, UnityGuid guid, AssetType assetType)

--- a/Source/AssetRipper.Import/AssetRipper.Import.csproj
+++ b/Source/AssetRipper.Import/AssetRipper.Import.csproj
@@ -9,8 +9,8 @@
 	<ItemGroup>
 		<PackageReference Include="AsmResolver.DotNet" Version="5.5.1" />
 		<PackageReference Include="AssetRipper.Gee.External.Capstone" Version="2.3.2" />
-		<PackageReference Include="AssetRipper.Mining.PredefinedAssets" Version="1.2.1" />
-		<PackageReference Include="AssetRipper.Primitives" Version="3.1.1" />
+		<PackageReference Include="AssetRipper.Mining.PredefinedAssets" Version="1.3.2" />
+		<PackageReference Include="AssetRipper.Primitives" Version="3.1.2" />
 		<PackageReference Include="AssetRipper.Tpk" Version="1.0.0" />
 		<PackageReference Include="Samboy063.Cpp2IL.Core" Version="2022.1.0-pre-release.14" />
 	</ItemGroup>


### PR DESCRIPTION
This is the AssetRipper portion to add the aabb key in the mesh engine assets