### PR TITLE
Fix special characters handling in file paths

### DIFF
--- a/Source/AssetRipper.GUI.Web/GameFileLoader.cs
+++ b/Source/AssetRipper.GUI.Web/GameFileLoader.cs
@@ -4,6 +4,7 @@ using AssetRipper.Export.UnityProjects.Configuration;
 using AssetRipper.Import.Logging;
 using AssetRipper.Import.Structure.Assembly.Managers;
 using AssetRipper.Processing;
+using AssetRipper.IO.Files.Utils;
 
 namespace AssetRipper.GUI.Web;
 
@@ -44,7 +45,8 @@ public static class GameFileLoader
 	{
 		Reset();
 		Settings.LogConfigurationValues();
-		GameData = ExportHandler.LoadAndProcess(paths);
+		var fixedPaths = paths.Select(DirectoryUtils.FixInvalidPathCharacters).ToList();
+		GameData = ExportHandler.LoadAndProcess(fixedPaths);
 	}
 
 	public static void Export(string path)

--- a/Source/AssetRipper.Import/Structure/Platforms/MixedGameStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Platforms/MixedGameStructure.cs
@@ -1,7 +1,8 @@
-﻿using AssetRipper.Import.Logging;
+using AssetRipper.Import.Logging;
 using AssetRipper.Import.Structure.Assembly;
 using AssetRipper.Import.Structure.Assembly.Managers;
 using AssetRipper.IO.Files.Streams.MultiFile;
+using AssetRipper.IO.Files.Utils;
 
 namespace AssetRipper.Import.Structure.Platforms
 {
@@ -10,7 +11,7 @@ namespace AssetRipper.Import.Structure.Platforms
 		public MixedGameStructure(IEnumerable<string> paths)
 		{
 			HashSet<string> dataPaths = new HashSet<string>();
-			foreach (string path in SelectUniquePaths(paths))
+			foreach (string path in SelectUniquePaths(paths.Select(DirectoryUtils.FixInvalidPathCharacters)))
 			{
 				if (MultiFileStream.Exists(path))
 				{

--- a/Source/AssetRipper.Import/Structure/Platforms/PlatformChecker.cs
+++ b/Source/AssetRipper.Import/Structure/Platforms/PlatformChecker.cs
@@ -1,4 +1,5 @@
-﻿using AssetRipper.Import.Logging;
+using AssetRipper.Import.Logging;
+using AssetRipper.IO.Files.Utils;
 
 namespace AssetRipper.Import.Structure.Platforms
 {
@@ -8,6 +9,8 @@ namespace AssetRipper.Import.Structure.Platforms
 		{
 			platformStructure = null;
 			mixedStructure = null;
+
+			paths = paths.Select(DirectoryUtils.FixInvalidPathCharacters).ToList();
 
 			if (CheckPC(paths, out PCGameStructure? pcGameStructure))
 			{


### PR DESCRIPTION
Related to #1407

Fix special character handling in file paths.

* Update `Source/AssetRipper.GUI.Web/GameFileLoader.cs` to use `DirectoryUtils.FixInvalidPathCharacters` method to handle special characters in file paths.
* Modify `Source/AssetRipper.Import/Structure/Platforms/MixedGameStructure.cs` to correctly process paths with special characters by using `DirectoryUtils.FixInvalidPathCharacters`.
* Update `Source/AssetRipper.Import/Structure/Platforms/PlatformChecker.cs` to correctly identify and process paths with special characters.