### PR TITLE
CLI Unity project Export

### DIFF
--- a/AssetRipper.sln
+++ b/AssetRipper.sln
@@ -158,6 +158,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssetRipper.GUI.Web.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssetRipper.GUI.Localizations.SourceGenerator", "Source\AssetRipper.GUI.Localizations.SourceGenerator\AssetRipper.GUI.Localizations.SourceGenerator.csproj", "{ADE822A6-9D1E-98B1-696F-25D37BFCF7CA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssetRipper.CLI", "Source\AssetRipper.CLI\AssetRipper.CLI.csproj", "{4A818613-3950-2A65-61A3-251E55333896}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -328,6 +330,10 @@ Global
 		{ADE822A6-9D1E-98B1-696F-25D37BFCF7CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADE822A6-9D1E-98B1-696F-25D37BFCF7CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADE822A6-9D1E-98B1-696F-25D37BFCF7CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A818613-3950-2A65-61A3-251E55333896}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A818613-3950-2A65-61A3-251E55333896}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A818613-3950-2A65-61A3-251E55333896}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A818613-3950-2A65-61A3-251E55333896}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/AssetRipper.CLI/AssetRipper.CLI.csproj
+++ b/Source/AssetRipper.CLI/AssetRipper.CLI.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+		<LangVersion>13.0</LangVersion>
+		<PublishSingleFile>true</PublishSingleFile>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<SelfContained>true</SelfContained>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\AssetRipper.GUI.Web\AssetRipper.GUI.Web.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Source/AssetRipper.CLI/Program.cs
+++ b/Source/AssetRipper.CLI/Program.cs
@@ -1,0 +1,40 @@
+﻿using AssetRipper.GUI.Web;
+
+namespace UnityAssetExtractor
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: UnityAssetExtractor <inputBundlePath> <outputProjectPath>");
+                return;
+            }
+
+            string inputBundlePath = args[0];
+            string outputProjectPath = args[1];
+
+            if (!File.Exists(inputBundlePath))
+            {
+                Console.WriteLine($"Input bundle file not found: {inputBundlePath}");
+                return;
+            }
+
+            try
+            {
+                // Load and process the Unity bundle
+                GameFileLoader.LoadAndProcess(new[] { inputBundlePath });
+
+                // Export the data to a Unity project
+                GameFileLoader.ExportUnityProject(outputProjectPath);
+
+                Console.WriteLine($"Data extracted and Unity project created at: {outputProjectPath}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error occurred: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Source/AssetRipper.Export.UnityProjects/AssetRipper.Export.UnityProjects.csproj
+++ b/Source/AssetRipper.Export.UnityProjects/AssetRipper.Export.UnityProjects.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<OutputType>Library</OutputType>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<IsTrimmable>true</IsTrimmable>
 		<OutputPath>..\0Bins\Other\AssetRipper.Export.UnityProjects\$(Configuration)\</OutputPath>
@@ -12,6 +13,7 @@
 		<PackageReference Include="AssetRipper.Mining.PredefinedAssets" Version="1.4.0" />
 		<PackageReference Include="AssetRipper.Tpk" Version="1.0.1" />
 		<PackageReference Include="ICSharpCode.Decompiler" Version="9.0.0.7889" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/AssetRipper.Export.UnityProjects/AssetRipper.Export.UnityProjects.csproj
+++ b/Source/AssetRipper.Export.UnityProjects/AssetRipper.Export.UnityProjects.csproj
@@ -12,7 +12,6 @@
 		<PackageReference Include="AssetRipper.Mining.PredefinedAssets" Version="1.4.0" />
 		<PackageReference Include="AssetRipper.Tpk" Version="1.0.1" />
 		<PackageReference Include="ICSharpCode.Decompiler" Version="9.0.0.7889" />
-		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/AssetRipper.Export.UnityProjects/AssetRipper.Export.UnityProjects.csproj
+++ b/Source/AssetRipper.Export.UnityProjects/AssetRipper.Export.UnityProjects.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<OutputType>Library</OutputType>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<IsTrimmable>true</IsTrimmable>
 		<OutputPath>..\0Bins\Other\AssetRipper.Export.UnityProjects\$(Configuration)\</OutputPath>


### PR DESCRIPTION
Added a simple CLI project for Unity Project content export.

The compiled program takes 2 command line arguments:

1. A path to **"<GameName>.exe"** file
2. A path for exported files

Which looks like this:
> AssetRipper.CLI.exe "D:\Games\UnityGame\Game.exe" "C:\UnityGameOutput"

_I hope I didn't break something by mistake..._