### PR TITLE
Fix `PropertyName` reading (#1667)

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/ExportHandler.cs
+++ b/Source/AssetRipper.Export.UnityProjects/ExportHandler.cs
@@ -83,6 +83,7 @@ public class ExportHandler
 		Settings.ExportRootPath = outputPath;
 		Settings.SetProjectSettings(gameData.ProjectVersion, BuildTarget.NoTarget, TransferInstructionFlags.NoTransferInstructionFlags);
 
+		gameData.AssemblyManager.UnityVersion = gameData.ProjectVersion;
 		ProjectExporter projectExporter = new(Settings, gameData.AssemblyManager);
 		BeforeExport(projectExporter);
 		projectExporter.DoFinalOverrides(Settings);

--- a/Source/AssetRipper.Import/Structure/Assembly/Managers/BaseManager.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Managers/BaseManager.cs
@@ -12,7 +12,7 @@ namespace AssetRipper.Import.Structure.Assembly.Managers
 	{
 		public bool IsSet => ScriptingBackend != ScriptingBackend.Unknown;
 		public virtual ScriptingBackend ScriptingBackend => ScriptingBackend.Unknown;
-
+		public virtual UnityVersion UnityVersion { get; set; }
 		protected readonly Dictionary<string, AssemblyDefinition?> m_assemblies = new();
 		protected readonly Dictionary<AssemblyDefinition, Stream> m_assemblyStreams = new();
 		protected readonly Dictionary<string, bool> m_validTypes = new();
@@ -195,7 +195,7 @@ namespace AssetRipper.Import.Structure.Assembly.Managers
 				return false;
 			}
 			else if (monoTypeCache.TryGetValue(type, out MonoType? monoType)
-				|| MonoType.TryCreate(type, monoTypeCache, out monoType, out failureReason))
+				|| MonoType.TryCreate(type, monoTypeCache, out monoType, out failureReason, UnityVersion))
 			{
 				scriptType = monoType;
 				failureReason = null;

--- a/Source/AssetRipper.Import/Structure/Assembly/Managers/IAssemblyManager.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Managers/IAssemblyManager.cs
@@ -26,6 +26,7 @@ namespace AssetRipper.Import.Structure.Assembly.Managers
 
 		bool IsSet { get; }
 		ScriptingBackend ScriptingBackend { get; }
+		UnityVersion UnityVersion { get; set; }
 	}
 	public static class AssemblyManagerExtensions
 	{

--- a/Source/AssetRipper.Import/Structure/Assembly/Managers/IL2CppManager.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Managers/IL2CppManager.cs
@@ -49,8 +49,7 @@ namespace AssetRipper.Import.Structure.Assembly.Managers
 		public string? GameAssemblyPath { get; private set; }
 		public string? UnityPlayerPath { get; private set; }
 		public string? GameDataPath { get; private set; }
-		public string? MetaDataPath { get; private set; }
-		public UnityVersion UnityVersion { get; private set; }
+		public string? MetaDataPath { get; private set; }		
 		/// <summary>
 		/// For when analysis is reimplimented in Cpp2IL.
 		/// </summary>
@@ -91,7 +90,7 @@ namespace AssetRipper.Import.Structure.Assembly.Managers
 
 			ClearStaticState?.Invoke();
 
-			Cpp2IlApi.InitializeLibCpp2Il(GameAssemblyPath!, MetaDataPath!, UnityVersion, false);
+			Cpp2IlApi.InitializeLibCpp2Il(GameAssemblyPath!, MetaDataPath!, (UnityVersion)UnityVersion, false);
 
 			Logger.SendStatusChange("loading_step_generate_dummy_dll");
 

--- a/Source/AssetRipper.Import/Structure/Assembly/Mono/MonoType.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Mono/MonoType.cs
@@ -155,7 +155,11 @@ namespace AssetRipper.Import.Structure.Assembly.Mono
 						//In the managed editor code, PropertyName is only backed by an int ID field.
 						//However, in yaml and release binaries, it appears identical to Utf8String.
 						//Presumably, editor binaries are the same, but this was not verified.
-						fieldType = SerializablePrimitiveType.GetOrCreate(PrimitiveType.String);
+						//
+						//https://github.com/Unity-Technologies/UnityCsReference/blob/b42ec0031fc505c35aff00b6a36c25e67d81e59e/Runtime/Export/PropertyName/PropertyName.cs						
+						//shows only the id int is serialized.
+						//This works with how AssetRipper.Processing\Editor\EditorFormatConverterAsync.cs dealt with these IDs
+						fieldType = SerializablePrimitiveType.GetOrCreate(PrimitiveType.Int);						
 					}
 					else if (typeCache.TryGetValue(typeDefinition, out MonoType? cachedMonoType))
 					{


### PR DESCRIPTION
This PR addresses OOB access due to treating release build's `PropertyName` field as string instead of an integer
The produced readout will align with the ones from preprocessed [PlayableDirector](https://github.com/AssetRipper/AssetRipper/blob/master/Source/AssetRipper.Processing/Editor/EditorFormatConverterAsync.cs#L66) objects as shown here.
Test assets are from:
- https://github.com/AssetRipper/AssetRipper/issues/1667
![Image](https://github.com/user-attachments/assets/b20323aa-de74-4f71-b00c-b64a6aa902e7)

Only tested on assets built with 2018.4.7f1 Unity editor.