### PR TITLE
Convert `m_ExposedReferences` into a Sequence instead of a Mapping

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/YamlWalker.cs
+++ b/Source/AssetRipper.Export.UnityProjects/YamlWalker.cs
@@ -4,6 +4,7 @@ using AssetRipper.Assets.Traversal;
 using AssetRipper.SourceGenerated;
 using AssetRipper.SourceGenerated.Classes.ClassID_114;
 using AssetRipper.SourceGenerated.Extensions;
+using AssetRipper.SourceGenerated.Subclasses.ExposedReferenceTable;
 using AssetRipper.SourceGenerated.Subclasses.GUID;
 using AssetRipper.SourceGenerated.Subclasses.Hash128;
 using AssetRipper.SourceGenerated.Subclasses.PropertyName;
@@ -147,14 +148,25 @@ public class YamlWalker : AssetWalker
 		Debug.Assert(CurrentFieldName is null);
 		if (name is "m_Structure" && asset is IMonoBehaviour)
 		{
-			YamlMappingNode structureNode = PopStructureNode(CurrentMappingNode.Children);
+			YamlMappingNode structureNode = PopNode(CurrentMappingNode.Children, "m_Structure");
 			CurrentMappingNode.Append(structureNode);
 		}
-
-		static YamlMappingNode PopStructureNode(List<KeyValuePair<YamlNode, YamlNode>> children)
+		if (name is "m_References" && asset is IExposedReferenceTable)
+		{		
+			YamlMappingNode referencesNode = PopNode(CurrentMappingNode.Children, "m_References");
+			YamlSequenceNode sequenceNode = new();			
+			foreach (KeyValuePair<YamlNode, YamlNode> child in referencesNode.Children)
+			{
+				YamlMappingNode childNode = new YamlMappingNode();
+				childNode.Add(child.Key, child.Value);
+				sequenceNode.Add(childNode);
+			}
+			CurrentMappingNode.Add("m_References", sequenceNode);			
+		}
+		static YamlMappingNode PopNode(List<KeyValuePair<YamlNode, YamlNode>> children, string key)
 		{
 			KeyValuePair<YamlNode, YamlNode> pair = children[^1];
-			Debug.Assert(pair.Key.ToString() == "m_Structure");
+			Debug.Assert(pair.Key.ToString() == key);
 			children.RemoveAt(children.Count - 1);
 			return (YamlMappingNode)pair.Value;
 		}


### PR DESCRIPTION
This is needed to conform to Editor YAML deserialization, which seems like one of the many cases of #821 where the Typetree dump mismatches how Editor serializes certain structs.

In this case (with 2022 symbols), in `YAMLWrite::Transfer<ExposedReferenceTable>`, `m_References` is written with `YAMLWrite::StartSequence` whilist the type itself is considered a `map` in its Editor TypeTree.

With this PR the produced output will align with the Editor's version and allows it to load. Tested with Unity 2022.3.59f1.

Related issues:
- https://github.com/AssetRipper/AssetRipper/issues/1667#issuecomment-2646056403
- https://github.com/AssetRipper/AssetRipper/issues/821