### PR TITLE
Add “Create Subfolder” export option

### DIFF
--- a/Localizations/en_US.json
+++ b/Localizations/en_US.json
@@ -90,6 +90,7 @@
     "export_preparing": "Preparing for Export...\nThis might take a minute.",
     "export_primary_content": "Export Primary Content",
     "export_unity_project": "Export Unity Project",
+    "create_subfolder": "Create Subfolder",
     "failed_files": "Failed Files",
     "format": "Format",
     "frequency": "Frequency",

--- a/Source/AssetRipper.GUI.Web/GameFileLoader.cs
+++ b/Source/AssetRipper.GUI.Web/GameFileLoader.cs
@@ -49,33 +49,29 @@ public static class GameFileLoader
 		GameData = ExportHandler.LoadAndProcess(paths);
 	}
 
-	public static void ExportUnityProject(string path, bool createSubfolder)
+	public static void ExportUnityProject(string path)
 	{
-		path = AdjustPathForSubfolder(path, createSubfolder);
-
 		if (IsLoaded && IsValidExportDirectory(path))
 		{
-			if (!createSubfolder)
+			if (Directory.Exists(path))
 			{
 				Directory.Delete(path, true);
 			}
-
+			
 			Directory.CreateDirectory(path);
 			ExportHandler.Export(GameData, path);
 		}
 	}
 
-	public static void ExportPrimaryContent(string path, bool createSubfolder)
+	public static void ExportPrimaryContent(string path)
 	{
-		path = AdjustPathForSubfolder(path, createSubfolder);
-
 		if (IsLoaded && IsValidExportDirectory(path))
 		{
-			if (!createSubfolder)
+			if (Directory.Exists(path))
 			{
 				Directory.Delete(path, true);
 			}
-
+			
 			Directory.CreateDirectory(path);
 			Logger.Info(LogCategory.Export, "Starting primary content export");
 			Logger.Info(LogCategory.Export, $"Attempting to export assets to {path}...");
@@ -90,17 +86,6 @@ public static class GameFileLoader
 		LibraryConfiguration settings = new();
 		settings.LoadFromDefaultPath();
 		return settings;
-	}
-
-	private static string AdjustPathForSubfolder(string path, bool createSubfolder)
-	{
-		if (createSubfolder)
-		{
-			string timestamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss");
-			string subfolder = $"AssetRipper_export_{timestamp}";
-			return Path.Combine(path, subfolder);
-		}
-		return path;
 	}
 
 	private static bool IsValidExportDirectory(string path)

--- a/Source/AssetRipper.GUI.Web/GameFileLoader.cs
+++ b/Source/AssetRipper.GUI.Web/GameFileLoader.cs
@@ -49,27 +49,39 @@ public static class GameFileLoader
 		GameData = ExportHandler.LoadAndProcess(paths);
 	}
 
-	public static void ExportUnityProject(string path)
+	public static void ExportUnityProject(string path, bool createSubfolder)
 	{
+		path = AdjustPathForSubfolder(path, createSubfolder);
+
 		if (IsLoaded && IsValidExportDirectory(path))
 		{
-			Directory.Delete(path, true);
+			if (!createSubfolder)
+			{
+				Directory.Delete(path, true);
+			}
+
 			Directory.CreateDirectory(path);
 			ExportHandler.Export(GameData, path);
 		}
 	}
 
-	public static void ExportPrimaryContent(string path)
+	public static void ExportPrimaryContent(string path, bool createSubfolder)
 	{
+		path = AdjustPathForSubfolder(path, createSubfolder);
+
 		if (IsLoaded && IsValidExportDirectory(path))
 		{
-			Directory.Delete(path, true);
+			if (!createSubfolder)
+			{
+				Directory.Delete(path, true);
+			}
+
 			Directory.CreateDirectory(path);
-			Logger.Info(LogCategory.Export, "Starting export");
+			Logger.Info(LogCategory.Export, "Starting primary content export");
 			Logger.Info(LogCategory.Export, $"Attempting to export assets to {path}...");
 			Settings.ExportRootPath = path;
 			PrimaryContentExporter.CreateDefault(GameData).Export(GameBundle, Settings, LocalFileSystem.Instance);
-			Logger.Info(LogCategory.Export, "Finished exporting assets");
+			Logger.Info(LogCategory.Export, "Finished exporting primary content.");
 		}
 	}
 
@@ -78,6 +90,17 @@ public static class GameFileLoader
 		LibraryConfiguration settings = new();
 		settings.LoadFromDefaultPath();
 		return settings;
+	}
+
+	private static string AdjustPathForSubfolder(string path, bool createSubfolder)
+	{
+		if (createSubfolder)
+		{
+			string timestamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss");
+			string subfolder = $"AssetRipper_export_{timestamp}";
+			return Path.Combine(path, subfolder);
+		}
+		return path;
 	}
 
 	private static bool IsValidExportDirectory(string path)

--- a/Source/AssetRipper.GUI.Web/Pages/Commands.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/Commands.cs
@@ -17,7 +17,16 @@ public static class Commands
 
 	internal static RouteHandlerBuilder AcceptsFormDataContainingPath(this RouteHandlerBuilder builder)
 	{
-		return builder.Accepts<PathFormData>("application/x-www-form-urlencoded");
+	    return builder.Accepts<PathFormData>("application/x-www-form-urlencoded");
+	}
+
+	private static bool TryGetCreateSubfolder(IFormCollection form)
+	{
+	    if (form.TryGetValue("CreateSubfolder", out StringValues values))
+	    {
+		    return values == "true";
+	    }
+	    return false;
 	}
 
 	public readonly struct LoadFile : ICommand
@@ -92,9 +101,11 @@ public static class Commands
 				return CommandsPath;
 			}
 
+			var createSubfolder = TryGetCreateSubfolder(form);
+
 			if (!string.IsNullOrEmpty(path))
 			{
-				GameFileLoader.ExportUnityProject(path);
+				GameFileLoader.ExportUnityProject(path, createSubfolder);
 			}
 			return null;
 		}
@@ -116,9 +127,11 @@ public static class Commands
 				return CommandsPath;
 			}
 
+			bool createSubfolder = TryGetCreateSubfolder(form);
+
 			if (!string.IsNullOrEmpty(path))
 			{
-				GameFileLoader.ExportPrimaryContent(path);
+				GameFileLoader.ExportPrimaryContent(path, createSubfolder);
 			}
 			return null;
 		}

--- a/Source/AssetRipper.GUI.Web/Pages/Commands.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/Commands.cs
@@ -17,16 +17,17 @@ public static class Commands
 
 	internal static RouteHandlerBuilder AcceptsFormDataContainingPath(this RouteHandlerBuilder builder)
 	{
-	    return builder.Accepts<PathFormData>("application/x-www-form-urlencoded");
+		return builder.Accepts<PathFormData>("application/x-www-form-urlencoded");
 	}
 
 	private static bool TryGetCreateSubfolder(IFormCollection form)
 	{
-	    if (form.TryGetValue("CreateSubfolder", out StringValues values))
-	    {
-		    return values == "true";
-	    }
-	    return false;
+		if (form.TryGetValue("CreateSubfolder", out StringValues values))
+		{
+			return values == "true";
+		}
+
+		return false;
 	}
 
 	public readonly struct LoadFile : ICommand
@@ -101,11 +102,11 @@ public static class Commands
 				return CommandsPath;
 			}
 
-			var createSubfolder = TryGetCreateSubfolder(form);
-
 			if (!string.IsNullOrEmpty(path))
 			{
-				GameFileLoader.ExportUnityProject(path, createSubfolder);
+				bool createSubfolder = TryGetCreateSubfolder(form);
+				path = MaybeAppendTimestampedSubfolder(path, createSubfolder);
+				GameFileLoader.ExportUnityProject(path);
 			}
 			return null;
 		}
@@ -127,14 +128,26 @@ public static class Commands
 				return CommandsPath;
 			}
 
-			bool createSubfolder = TryGetCreateSubfolder(form);
-
 			if (!string.IsNullOrEmpty(path))
 			{
-				GameFileLoader.ExportPrimaryContent(path, createSubfolder);
+				bool createSubfolder = TryGetCreateSubfolder(form);
+				path = MaybeAppendTimestampedSubfolder(path, createSubfolder);
+				GameFileLoader.ExportPrimaryContent(path);
 			}
 			return null;
 		}
+	}
+
+	private static string MaybeAppendTimestampedSubfolder(string path, bool append)
+	{
+		if (append)
+		{
+			string timestamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss");
+			string subfolder = $"AssetRipper_export_{timestamp}";
+			return Path.Combine(path, subfolder);
+		}
+
+		return path;
 	}
 
 	public readonly struct Reset : ICommand

--- a/Source/AssetRipper.GUI.Web/Pages/CommandsPage.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/CommandsPage.cs
@@ -51,12 +51,13 @@ public sealed class CommandsPage : VuePage
 						.WithType("checkbox")
 						.WithClass("form-check-input")
 						.WithCustomAttribute("v-model", "create_subfolder")
+						.WithCustomAttribute("@input", "handleExportPathChange")
 						.WithId("createSubfolder")
 						.Close();
 					new Label(writer)
 						.WithClass("form-check-label")
 						.WithCustomAttribute("for", "createSubfolder")
-						.Close("Create Subfolder");
+						.Close(Localization.CreateSubfolder);
 				}
 
 				using (new Form(writer).WithAction("/Export/UnityProject").WithMethod("post").End())
@@ -65,7 +66,7 @@ public sealed class CommandsPage : VuePage
 					new Input(writer).WithType("hidden").WithName("CreateSubfolder").WithCustomAttribute("v-model", "create_subfolder").Close();
 
 					new Button(writer).WithCustomAttribute("v-if", "export_path === '' || export_path !== export_path.trim()").WithClass("btn btn-primary").WithCustomAttribute("disabled").Close(Localization.ExportUnityProject);
-					new Input(writer).WithCustomAttribute("v-else-if", "export_path_has_files && !create_subfolder").WithType("submit").WithClass("btn btn-danger").WithValue(Localization.ExportUnityProject).Close();
+					new Input(writer).WithCustomAttribute("v-else-if", "export_path_has_files").WithType("submit").WithClass("btn btn-danger").WithValue(Localization.ExportUnityProject).Close();
 					new Input(writer).WithCustomAttribute("v-else").WithType("submit").WithClass("btn btn-primary").WithValue(Localization.ExportUnityProject).Close();
 				}
 
@@ -75,7 +76,7 @@ public sealed class CommandsPage : VuePage
 					new Input(writer).WithType("hidden").WithName("CreateSubfolder").WithCustomAttribute("v-model", "create_subfolder").Close();
 
 					new Button(writer).WithCustomAttribute("v-if", "export_path === '' || export_path !== export_path.trim()").WithClass("btn btn-primary").WithCustomAttribute("disabled").Close(Localization.ExportPrimaryContent);
-					new Input(writer).WithCustomAttribute("v-else-if", "export_path_has_files && !create_subfolder").WithType("submit").WithClass("btn btn-danger").WithValue(Localization.ExportPrimaryContent).Close();
+					new Input(writer).WithCustomAttribute("v-else-if", "export_path_has_files").WithType("submit").WithClass("btn btn-danger").WithValue(Localization.ExportPrimaryContent).Close();
 					new Input(writer).WithCustomAttribute("v-else").WithType("submit").WithClass("btn btn-primary").WithValue(Localization.ExportPrimaryContent).Close();
 				}
 
@@ -84,7 +85,7 @@ public sealed class CommandsPage : VuePage
 					new Button(writer).WithCustomAttribute("@click", "handleSelectExportFolder").WithClass("btn btn-success").Close(Localization.SelectFolder);
 				}
 
-				using (new Div(writer).WithCustomAttribute("v-if", "showExportWarning").End())
+				using (new Div(writer).WithCustomAttribute("v-if", "export_path_has_files").End())
 				{
 					new P(writer).Close(Localization.WarningThisDirectoryIsNotEmptyAllContentWillBeDeleted);
 				}

--- a/Source/AssetRipper.GUI.Web/Pages/CommandsPage.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/CommandsPage.cs
@@ -45,21 +45,37 @@ public sealed class CommandsPage : VuePage
 						.WithCustomAttribute("@input", "handleExportPathChange").Close();
 				}
 
+				using (new Div(writer).WithClass("form-check mb-2").End())
+				{
+					new Input(writer)
+						.WithType("checkbox")
+						.WithClass("form-check-input")
+						.WithCustomAttribute("v-model", "create_subfolder")
+						.WithId("createSubfolder")
+						.Close();
+					new Label(writer)
+						.WithClass("form-check-label")
+						.WithCustomAttribute("for", "createSubfolder")
+						.Close("Create Subfolder");
+				}
+
 				using (new Form(writer).WithAction("/Export/UnityProject").WithMethod("post").End())
 				{
 					new Input(writer).WithType("hidden").WithName("Path").WithCustomAttribute("v-model", "export_path").Close();
+					new Input(writer).WithType("hidden").WithName("CreateSubfolder").WithCustomAttribute("v-model", "create_subfolder").Close();
 
 					new Button(writer).WithCustomAttribute("v-if", "export_path === '' || export_path !== export_path.trim()").WithClass("btn btn-primary").WithCustomAttribute("disabled").Close(Localization.ExportUnityProject);
-					new Input(writer).WithCustomAttribute("v-else-if", "export_path_has_files").WithType("submit").WithClass("btn btn-danger").WithValue(Localization.ExportUnityProject).Close();
+					new Input(writer).WithCustomAttribute("v-else-if", "export_path_has_files && !create_subfolder").WithType("submit").WithClass("btn btn-danger").WithValue(Localization.ExportUnityProject).Close();
 					new Input(writer).WithCustomAttribute("v-else").WithType("submit").WithClass("btn btn-primary").WithValue(Localization.ExportUnityProject).Close();
 				}
 
 				using (new Form(writer).WithAction("/Export/PrimaryContent").WithMethod("post").End())
 				{
 					new Input(writer).WithType("hidden").WithName("Path").WithCustomAttribute("v-model", "export_path").Close();
+					new Input(writer).WithType("hidden").WithName("CreateSubfolder").WithCustomAttribute("v-model", "create_subfolder").Close();
 
 					new Button(writer).WithCustomAttribute("v-if", "export_path === '' || export_path !== export_path.trim()").WithClass("btn btn-primary").WithCustomAttribute("disabled").Close(Localization.ExportPrimaryContent);
-					new Input(writer).WithCustomAttribute("v-else-if", "export_path_has_files").WithType("submit").WithClass("btn btn-danger").WithValue(Localization.ExportPrimaryContent).Close();
+					new Input(writer).WithCustomAttribute("v-else-if", "export_path_has_files && !create_subfolder").WithType("submit").WithClass("btn btn-danger").WithValue(Localization.ExportPrimaryContent).Close();
 					new Input(writer).WithCustomAttribute("v-else").WithType("submit").WithClass("btn btn-primary").WithValue(Localization.ExportPrimaryContent).Close();
 				}
 
@@ -68,7 +84,7 @@ public sealed class CommandsPage : VuePage
 					new Button(writer).WithCustomAttribute("@click", "handleSelectExportFolder").WithClass("btn btn-success").Close(Localization.SelectFolder);
 				}
 
-				using (new Div(writer).WithCustomAttribute("v-if", "export_path_has_files").End())
+				using (new Div(writer).WithCustomAttribute("v-if", "showExportWarning").End())
 				{
 					new P(writer).Close(Localization.WarningThisDirectoryIsNotEmptyAllContentWillBeDeleted);
 				}

--- a/Source/AssetRipper.GUI.Web/StaticContent/js/commands_page.js
+++ b/Source/AssetRipper.GUI.Web/StaticContent/js/commands_page.js
@@ -6,7 +6,13 @@ const app = createApp({
 			load_path: '',
 			load_path_exists: false,
 			export_path: '',
-			export_path_has_files: false
+			export_path_has_files: false,
+			create_subfolder: false
+		}
+	},
+	computed: {
+		showExportWarning() {
+			return this.export_path_has_files && !this.create_subfolder;
 		}
 	},
 	methods: {

--- a/Source/AssetRipper.GUI.Web/StaticContent/js/commands_page.js
+++ b/Source/AssetRipper.GUI.Web/StaticContent/js/commands_page.js
@@ -10,11 +10,6 @@ const app = createApp({
 			create_subfolder: false
 		}
 	},
-	computed: {
-		showExportWarning() {
-			return this.export_path_has_files && !this.create_subfolder;
-		}
-	},
 	methods: {
 		async handleLoadPathChange() {
 			// Add a debounce mechanism to avoid too many requests in a short time
@@ -38,7 +33,11 @@ const app = createApp({
 
 			this.debouncedInput = setTimeout(async () => {
 				try {
-					this.export_path_has_files = await this.fetchDirectoryExists(this.export_path) && !(await this.fetchDirectoryEmpty(this.export_path));
+					if (this.create_subfolder) {
+						this.export_path_has_files = false;
+					} else {
+						this.export_path_has_files = await this.fetchDirectoryExists(this.export_path) && !(await this.fetchDirectoryEmpty(this.export_path));
+					}
 				} catch (error) {
 					console.error('Error fetching data:', error);
 				}


### PR DESCRIPTION
## Add Option to Create Subfolder During Export

This PR introduces an option for users to automatically create a timestamped subfolder when exporting assets, preventing accidental overwrites of the selected export directory.

## Showcase

https://github.com/user-attachments/assets/ea4b3b7a-53ef-42f8-8c07-667343e83902

