### PR TITLE
Cap length of colliding file names

### DIFF
--- a/Source/AssetRipper.IO.Files/FileSystem.cs
+++ b/Source/AssetRipper.IO.Files/FileSystem.cs
@@ -1,5 +1,4 @@
-﻿using System.Buffers;
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 
 namespace AssetRipper.IO.Files;

--- a/Source/AssetRipper.IO.Files/FileSystem.cs
+++ b/Source/AssetRipper.IO.Files/FileSystem.cs
@@ -48,7 +48,7 @@ public partial class FileSystem
 
 		for (int counter = initial; counter < int.MaxValue; counter++)
 		{
-			int suffixLength =  1 + (int)Math.Ceiling(Math.Log10(counter + 1));
+			int suffixLength =  2 + (counter < 10 ? 0 : (int)Math.Log10(counter));
 			if (nameLength + suffixLength + extLength > maxNameLength)
 			{
 				nameLength = maxNameLength - suffixLength - extLength;


### PR DESCRIPTION
Fixes #1535

I also removed the `!System.IO.Directory.Exists(dirPath)` check because the later check will account for that anyways, and we probably don't want to ignore reserved names when we're the first file in a folder.