### PR TITLE
Handle zero complete image size

### DIFF
--- a/Source/AssetRipper.Export.Modules.Textures/TextureConverter.cs
+++ b/Source/AssetRipper.Export.Modules.Textures/TextureConverter.cs
@@ -168,7 +168,7 @@ namespace AssetRipper.Export.Modules.Textures
 				texture.Width_C28,
 				texture.Height_C28,
 				texture.ImageCount_C28,
-				texture.GetCompleteImageSize(),
+				texture.GetActualImageSize(),
 				texture.Collection.Version,
 				buffer,
 				out bitmap))

--- a/Source/AssetRipper.Export.Modules.Textures/TextureConverter.cs
+++ b/Source/AssetRipper.Export.Modules.Textures/TextureConverter.cs
@@ -168,7 +168,7 @@ namespace AssetRipper.Export.Modules.Textures
 				texture.Width_C28,
 				texture.Height_C28,
 				texture.ImageCount_C28,
-				texture.GetActualImageSize(),
+				texture.ActualImageSize,
 				texture.Collection.Version,
 				buffer,
 				out bitmap))

--- a/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
@@ -17,6 +17,26 @@ namespace AssetRipper.SourceGenerated.Extensions
 			}
 		}
 
+		public static int GetActualImageSize(this ITexture2D texture)
+		{
+			int completeImageSize = texture.GetCompleteImageSize();
+			if (completeImageSize > 0)
+			{
+				return completeImageSize;
+			}
+
+			int dataLength = texture.GetImageDataLength();
+			int count = texture.ImageCount_C28;
+			if (count > 1 && dataLength % count == 0)
+			{
+				return dataLength / count;
+			}
+			else
+			{
+				return dataLength;
+			}
+		}
+
 		public static bool GetMips(this ITexture2D texture)
 		{
 			return texture.MipMap_C28 || texture.MipCount_C28 > 0;
@@ -60,6 +80,22 @@ namespace AssetRipper.SourceGenerated.Extensions
 			}
 
 			return data;
+		}
+
+		public static int GetImageDataLength(this ITexture2D texture)
+		{
+			if (texture.ImageData_C28.Length != 0)
+			{
+				return texture.ImageData_C28.Length;
+			}
+			else if (texture.StreamData_C28 is not null && texture.StreamData_C28.IsSet())
+			{
+				return (int)texture.StreamData_C28.Size;
+			}
+			else
+			{
+				return 0;
+			}
 		}
 
 		public static bool IsSwapBytes(IO.Files.BuildTarget platform, TextureFormat format)

--- a/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
@@ -1,48 +1,65 @@
 ﻿using AssetRipper.SourceGenerated.Classes.ClassID_28;
 using AssetRipper.SourceGenerated.Enums;
 
-namespace AssetRipper.SourceGenerated.Extensions
+namespace AssetRipper.SourceGenerated.Extensions;
+
+public static class Texture2DExtensions
 {
-	public static class Texture2DExtensions
+	extension(ITexture2D texture)
 	{
-		public static int GetCompleteImageSize(this ITexture2D texture)
+		public int CompleteImageSize
 		{
-			if (texture.Has_CompleteImageSize_C28_UInt32())
+			get
 			{
-				return (int)texture.CompleteImageSize_C28_UInt32;//No texture is larger than 2GB
-			}
-			else
-			{
-				return texture.CompleteImageSize_C28_Int32;
+				if (texture.Has_CompleteImageSize_C28_UInt32())
+				{
+					return (int)texture.CompleteImageSize_C28_UInt32;//No texture is larger than 2GB
+				}
+				else
+				{
+					return texture.CompleteImageSize_C28_Int32;
+				}
 			}
 		}
 
-		public static int GetActualImageSize(this ITexture2D texture)
+		/// <summary>
+		/// Get the CompleteImageSize, or a calculated value if necessary
+		/// </summary>
+		/// <remarks>
+		/// <see href="https://github.com/AssetRipper/AssetRipper/issues/1789"/>
+		/// </remarks>
+		public int ActualImageSize
 		{
-			int completeImageSize = texture.GetCompleteImageSize();
-			if (completeImageSize > 0)
+			get
 			{
-				return completeImageSize;
-			}
+				int completeImageSize = texture.CompleteImageSize;
+				if (completeImageSize > 0)
+				{
+					return completeImageSize;
+				}
 
-			int dataLength = texture.GetImageDataLength();
-			int count = texture.ImageCount_C28;
-			if (count > 1 && dataLength % count == 0)
-			{
-				return dataLength / count;
-			}
-			else
-			{
-				return dataLength;
+				// Normally, the complete image size is non-zero, so this only applies in certain situations.
+				// One way this can happen is for server builds of a game.
+				// In server builds, textures are often 1 pixel and have an image size equal to be zero.
+				// However, they still contain a small amount of texture data, so the image size is actual non-zero.
+				// We calculate the actual value below.
+
+				int dataLength = texture.ImageDataLength;
+				int count = texture.ImageCount_C28;
+				if (count > 1 && dataLength % count == 0)
+				{
+					return dataLength / count;
+				}
+				else
+				{
+					return dataLength;
+				}
 			}
 		}
 
-		public static bool GetMips(this ITexture2D texture)
-		{
-			return texture.MipMap_C28 || texture.MipCount_C28 > 0;
-		}
+		public bool Mips => texture.MipMap_C28 || texture.MipCount_C28 > 0;
 
-		public static bool CheckAssetIntegrity(this ITexture2D texture)
+		public bool CheckAssetIntegrity()
 		{
 			if (!texture.ImageData_C28.IsNullOrEmpty())
 			{
@@ -58,20 +75,26 @@ namespace AssetRipper.SourceGenerated.Extensions
 			}
 		}
 
-		public static byte[] GetImageData(this ITexture2D texture)
+		public byte[] GetImageData()
 		{
 			byte[] data = texture.ImageData_C28;
 
+			bool swapBytes = IsSwapBytes(texture.Collection.Platform, texture.Format_C28E);
+
 			if (data.Length != 0)
 			{
-				return texture.ImageData_C28;
+				if (swapBytes)
+				{
+					// Need to copy the data to avoid modifying the original
+					data = data.AsSpan().ToArray();
+				}
 			}
 			else if (texture.StreamData_C28 is not null && texture.StreamData_C28.IsSet())
 			{
 				data = texture.StreamData_C28.GetContent(texture.Collection);
 			}
 
-			if (IsSwapBytes(texture.Collection.Platform, texture.Format_C28E))
+			if (swapBytes)
 			{
 				for (int i = 0; i < data.Length; i += 2)
 				{
@@ -82,39 +105,42 @@ namespace AssetRipper.SourceGenerated.Extensions
 			return data;
 		}
 
-		public static int GetImageDataLength(this ITexture2D texture)
+		public int ImageDataLength
 		{
-			if (texture.ImageData_C28.Length != 0)
+			get
 			{
-				return texture.ImageData_C28.Length;
-			}
-			else if (texture.StreamData_C28 is not null && texture.StreamData_C28.IsSet())
-			{
-				return (int)texture.StreamData_C28.Size;
-			}
-			else
-			{
-				return 0;
-			}
-		}
-
-		public static bool IsSwapBytes(IO.Files.BuildTarget platform, TextureFormat format)
-		{
-			if (platform == IO.Files.BuildTarget.XBox360)
-			{
-				switch (format)
+				if (texture.ImageData_C28.Length != 0)
 				{
-					case TextureFormat.ARGB4444:
-					case TextureFormat.RGB565:
-					case TextureFormat.DXT1:
-					case TextureFormat.DXT1Crunched:
-					case TextureFormat.DXT3:
-					case TextureFormat.DXT5:
-					case TextureFormat.DXT5Crunched:
-						return true;
+					return texture.ImageData_C28.Length;
+				}
+				else if (texture.StreamData_C28 is not null && texture.StreamData_C28.IsSet())
+				{
+					return (int)texture.StreamData_C28.Size;
+				}
+				else
+				{
+					return 0;
 				}
 			}
-			return false;
 		}
+	}
+
+	private static bool IsSwapBytes(IO.Files.BuildTarget platform, TextureFormat format)
+	{
+		if (platform == IO.Files.BuildTarget.XBox360)
+		{
+			switch (format)
+			{
+				case TextureFormat.ARGB4444:
+				case TextureFormat.RGB565:
+				case TextureFormat.DXT1:
+				case TextureFormat.DXT1Crunched:
+				case TextureFormat.DXT3:
+				case TextureFormat.DXT5:
+				case TextureFormat.DXT5Crunched:
+					return true;
+			}
+		}
+		return false;
 	}
 }

--- a/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
+++ b/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
@@ -110,9 +110,9 @@ namespace AssetRipper.Tools.RawTextureExtractor
 							"Type" : "{{texture.ClassName}}",
 							"Format" : "{{texture.Format_C28E}}",
 							"FileSize" : {{data.Length}},
-							"ImageSize" : {{texture.GetCompleteImageSize()}},
+							"ImageSize" : {{texture.CompleteImageSize}},
 							"ImageCount" : {{texture.ImageCount_C28}},
-							"Mips" : {{texture.GetMips().ToJson()}},
+							"Mips" : {{texture.Mips.ToJson()}},
 							"Width" : {{texture.Width_C28}},
 							"Height" : {{texture.Height_C28}}
 						}


### PR DESCRIPTION
This pull request:
* Handles situations where a texture's complete image size is zero
* Switches to extension properties for some related code in the file
* Fixes a minor bug involving XBox 360 textures

Resolves #1789 