### PR TITLE
Add dependencies table to collections view page

### DIFF
--- a/Localizations/en_US.json
+++ b/Localizations/en_US.json
@@ -92,6 +92,7 @@
     "export_unity_project": "Export Unity Project",
     "create_subfolder": "Create Subfolder",
     "failed_files": "Failed Files",
+    "file_id": "File ID",
     "format": "Format",
     "frequency": "Frequency",
     "game_object": "GameObject",

--- a/Source/AssetRipper.GUI.Web/Pages/Collections/ViewPage.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/Collections/ViewPage.cs
@@ -74,7 +74,11 @@ public sealed class ViewPage : DefaultPage
 					for (int i = 1; i < Collection.Dependencies.Count; i++)
 					{
 						AssetCollection? dependency = Collection.Dependencies[i];
-						if (dependency is null) continue;
+						if (dependency is null)
+						{
+							continue;
+						}
+
 						using (new Tr(writer).End())
 						{
 							new Td(writer).Close(i.ToString());

--- a/Source/AssetRipper.GUI.Web/Pages/Collections/ViewPage.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/Collections/ViewPage.cs
@@ -55,5 +55,37 @@ public sealed class ViewPage : DefaultPage
 				}
 			}
 		}
+
+		if (Collection.Dependencies.Count > 1)
+		{
+			new H2(writer).Close(Localization.AssetTabDependencies);
+			using (new Table(writer).WithClass("table").End())
+			{
+				using (new Thead(writer).End())
+				{
+					using (new Tr(writer).End())
+					{
+						new Th(writer).Close(Localization.FileId);
+						new Th(writer).Close(Localization.Name);
+					}
+				}
+				using (new Tbody(writer).End())
+				{
+					for (int i = 1; i < Collection.Dependencies.Count; i++)
+					{
+						AssetCollection? dependency = Collection.Dependencies[i];
+						if (dependency is null) continue;
+						using (new Tr(writer).End())
+						{
+							new Td(writer).Close(i.ToString());
+							using (new Td(writer).End())
+							{
+								PathLinking.WriteLink(writer, dependency);
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This adds a dependencies table to collection pages.

The actual problem is when viewing behaviours, there are sometimes references to other assets in the behaviour's serialized fields, and those don't show up in the asset's dependencies tab. I don't know what the design goal around that tab is, so I just added a new table to solve my immediate issue.