### PR TITLE
Reintegrate try/catch removed in de7233b

### DIFF
--- a/Source/AssetRipper.Export.PrimaryContent/Models/GlbModelExporter.cs
+++ b/Source/AssetRipper.Export.PrimaryContent/Models/GlbModelExporter.cs
@@ -1,5 +1,6 @@
 ﻿using AssetRipper.Assets;
 using AssetRipper.Export.Modules.Models;
+using AssetRipper.Import.Logging;
 using AssetRipper.Processing.Prefabs;
 using SharpGLTF.Scenes;
 using SharpGLTF.Schema2;

--- a/Source/AssetRipper.Export.PrimaryContent/Models/GlbModelExporter.cs
+++ b/Source/AssetRipper.Export.PrimaryContent/Models/GlbModelExporter.cs
@@ -31,13 +31,13 @@ public class GlbModelExporter : IContentExtractor
 
 	public static bool ExportModel(IEnumerable<IUnityObjectBase> assets, string path, bool isScene, FileSystem fileSystem)
 	{
-  		try
+		try
 		{
-  			SceneBuilder sceneBuilder = GlbLevelBuilder.Build(assets, isScene);
+			SceneBuilder sceneBuilder = GlbLevelBuilder.Build(assets, isScene);
 			using Stream fileStream = fileSystem.File.Create(path);
 			sceneBuilder.ToGltf2().WriteGLB(fileStream, new WriteSettings() { MergeBuffers = false });
 			return true;
-  		}
+		}
 		catch (InvalidOperationException ex) when (ex.Message == "Can't merge a buffer larger than 2Gb")
 		{
 			Logger.Error(LogCategory.Export, $"Model was too large to export as GLB.");

--- a/Source/AssetRipper.Export.PrimaryContent/Models/GlbModelExporter.cs
+++ b/Source/AssetRipper.Export.PrimaryContent/Models/GlbModelExporter.cs
@@ -31,9 +31,17 @@ public class GlbModelExporter : IContentExtractor
 
 	public static bool ExportModel(IEnumerable<IUnityObjectBase> assets, string path, bool isScene, FileSystem fileSystem)
 	{
-		SceneBuilder sceneBuilder = GlbLevelBuilder.Build(assets, isScene);
-		using Stream fileStream = fileSystem.File.Create(path);
-		sceneBuilder.ToGltf2().WriteGLB(fileStream, new WriteSettings() { MergeBuffers = false });
-		return true;
+  		try
+		{
+  			SceneBuilder sceneBuilder = GlbLevelBuilder.Build(assets, isScene);
+			using Stream fileStream = fileSystem.File.Create(path);
+			sceneBuilder.ToGltf2().WriteGLB(fileStream, new WriteSettings() { MergeBuffers = false });
+			return true;
+  		}
+		catch (InvalidOperationException ex) when (ex.Message == "Can't merge a buffer larger than 2Gb")
+		{
+			Logger.Error(LogCategory.Export, $"Model was too large to export as GLB.");
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
See #1510.

A try/catch protection on ExportModel for the error `Can't merge buffer larger than 2gb` was added for #1007. However, commit de7233b removed that try/catch.

This patch simply reinsert the try/catch.

PS: Without deep knowledge of the code, I returned `false` in the catch assuming the common pattern that the bool represent a succesful (or not) export.