### PR TITLE
Make errors not stop export

### DIFF
--- a/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
+++ b/Source/AssetRipper.Export.Modules.Shader/IO/SerializedExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using AssetRipper.Assets.Generics;
 using AssetRipper.Export.Modules.Shaders.Extensions;
 using AssetRipper.Export.Modules.Shaders.ShaderBlob;
+using AssetRipper.Import.Logging;
 using AssetRipper.Primitives;
 using AssetRipper.SourceGenerated.Extensions;
 using AssetRipper.SourceGenerated.Extensions.Enums.Shader;
@@ -109,7 +110,14 @@ public static class SerializedExtensions
 			IReadOnlyList<ISerializedPlayerSubProgram> subPrograms = _this.GetPlayerSubPrograms();
 			for (int i = 0; i < subPrograms.Count; i++)
 			{
-				subPrograms[i].Export(_this.GetParameterBlobIndices()[i], writer, type);
+				try
+				{
+					subPrograms[i].Export(_this.GetParameterBlobIndices()[i], writer, type);
+				}
+				catch (Exception ex)
+				{
+					Logger.Error(ex.Message, ex);
+				}
 			}
 		}
 		else
@@ -117,7 +125,14 @@ public static class SerializedExtensions
 			int tierCount = _this.GetTierCount();
 			for (int i = 0; i < _this.SubPrograms.Count; i++)
 			{
-				_this.SubPrograms[i].Export(writer, type, tierCount > 1);
+				try
+				{
+					_this.SubPrograms[i].Export(writer, type, tierCount > 1);
+				}
+				catch (Exception ex)
+				{
+					Logger.Error(ex.Message, ex);
+				}
 			}
 		}
 		writer.WriteIndent(3);

--- a/Source/AssetRipper.Export.UnityProjects/Shaders/USCShaderExporter.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Shaders/USCShaderExporter.cs
@@ -563,7 +563,14 @@ public sealed class USCShaderExporter : ShaderExporterBase
 			IReadOnlyList<ISerializedPlayerSubProgram> subPrograms = _this.GetPlayerSubPrograms();
 			for (int i = 0; i < subPrograms.Count; i++)
 			{
-				subPrograms[i].Export(_this.GetParameterBlobIndices()[i], writer, type);
+				try
+				{
+					subPrograms[i].Export(_this.GetParameterBlobIndices()[i], writer, type);
+				}
+				catch (Exception ex)
+				{
+					Logger.Error(ex.Message, ex);
+				}
 			}
 		}
 		else
@@ -571,7 +578,14 @@ public sealed class USCShaderExporter : ShaderExporterBase
 			int tierCount = _this.GetTierCount();
 			for (int i = 0; i < _this.SubPrograms.Count; i++)
 			{
-				_this.SubPrograms[i].Export(writer, type, tierCount > 1);
+				try
+				{
+					_this.SubPrograms[i].Export(writer, type, tierCount > 1);
+				}
+				catch (Exception ex)
+				{
+					Logger.Error(ex.Message, ex);
+				}
 			}
 		}
 		writer.WriteIndent(3);


### PR DESCRIPTION
In disassembly mode, you could sometimes get the following error:
```
System.Exception: Shader program version 16 doesn't match
   at AssetRipper.Export.Modules.Shaders.ShaderBlob.ShaderSubProgramBlob.GetSubProgram(UInt32 blobIndex, UInt32 paramBlobIndex) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.Modules.Shader\ShaderBlob\ShaderSubProgramBlob.cs:line 107
   at AssetRipper.Export.Modules.Shaders.IO.SerializedExtensions.Export(ISerializedPlayerSubProgram _this, UInt32 paramBlobIndex, ShaderWriter writer, ShaderType type) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.Modules.Shader\IO\SerializedExtensions.cs:line 518
   at AssetRipper.Export.Modules.Shaders.IO.SerializedExtensions.Export(ISerializedProgram _this, ShaderWriter writer, ShaderType type) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.Modules.Shader\IO\SerializedExtensions.cs:line 112
   at AssetRipper.Export.Modules.Shaders.IO.SerializedExtensions.Export(ISerializedPass _this, ShaderWriter writer) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.Modules.Shader\IO\SerializedExtensions.cs:line 57
   at AssetRipper.Export.Modules.Shaders.IO.SerializedExtensions.Export(ISerializedSubShader _this, ShaderWriter writer) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.Modules.Shader\IO\SerializedExtensions.cs:line 546
   at AssetRipper.Export.Modules.Shaders.IO.SerializedExtensions.Export(ISerializedShader _this, ShaderWriter writer) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.Modules.Shader\IO\SerializedExtensions.cs:line 259
   at AssetRipper.Export.UnityProjects.Shaders.ShaderDisassemblyExporter.ExportBinary(IShader shader, Stream stream, Func`2 exporterInstantiator) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.UnityProjects\Shaders\ShaderDisassemblyExporter.cs:line 53
   at AssetRipper.Export.UnityProjects.Shaders.ShaderDisassemblyExporter.Export(IExportContainer container, IUnityObjectBase asset, String path, FileSystem fileSystem) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.UnityProjects\Shaders\ShaderDisassemblyExporter.cs:line 15
   at AssetRipper.Export.UnityProjects.AssetExportCollection`1.Export(IExportContainer container, String projectDirectory, FileSystem fileSystem) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.UnityProjects\AssetExportCollection.cs:line 23
   at AssetRipper.Export.UnityProjects.ProjectExporter.Export(GameBundle fileCollection, CoreConfiguration options, FileSystem fileSystem) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.UnityProjects\ProjectExporter.cs:line 99
   at AssetRipper.Export.UnityProjects.ExportHandler.Export(GameData gameData, String outputPath, FileSystem fileSystem) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.UnityProjects\ExportHandler.cs:line 107
   at AssetRipper.Export.UnityProjects.ExportHandler.Export(GameData gameData, String outputPath) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.Export.UnityProjects\ExportHandler.cs:line 93
   at AssetRipper.GUI.Web.GameFileLoader.ExportUnityProject(String path) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.GUI.Web\GameFileLoader.cs:line 59
   at AssetRipper.GUI.Web.Pages.Commands.ExportUnityProject.AssetRipper.GUI.Web.Pages.ICommand.Execute(HttpRequest request) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.GUI.Web\Pages\Commands.cs:line 110
   at AssetRipper.GUI.Web.Pages.Commands.HandleCommand[T](HttpContext context) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.GUI.Web\Pages\Commands.cs:line 165
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at AssetRipper.GUI.Web.ErrorHandlingMiddleware.InvokeAsync(HttpContext context, RequestDelegate next) in C:\Users\***\Documents\assetrippercode\AssetRipper\Source\AssetRipper.GUI.Web\ErrorHandlingMiddleware.cs:line 12
```
This will cancel the entire export. This pr changes that by adding try/catch statements where the error can occur.
 
THIS DOES NOT FIX THE UNDERLYING ISSUE
It only makes it break less stuff.
With this pr, even if one file fails, the rest will still export. Most of every shader tuned out fine in my testing with the pr.

(I have tried to fix the error, and I can confidently say I understood absolutely nothing.)