### PR TITLE
Implement texture unswizzling for Switch platform

### DIFF
--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -53,11 +53,6 @@ public class SwitchSwizzle
 		height = paddedSize.Height;
 		return Unswizzle(rawData, paddedSize, blockSize, gobsPerBlock);
 	}
-
-	public byte[] PostprocessDeswizzle(byte[] rawData)
-	{
-		return CropFromTopLeft(rawData, paddedSize.Width, paddedSize.Height, originalSize.Width, originalSize.Height);
-	}
 	
 	public static byte[] Unswizzle(byte[] data, Size imageSize, Size blockSize, int blockHeight)
 	{
@@ -167,21 +162,5 @@ public class SwitchSwizzle
 			TextureFormat.RGB24 => TextureFormat.RGBA32,
 			_ => format
 		};
-	}
-	
-	private static byte[] CropFromTopLeft(byte[] data, int width, int height, int cropToWidth, int cropToHeight)
-	{
-		if (cropToWidth > width || cropToHeight > height)
-			throw new ArgumentException("Crop size is bigger than the original image size.");
-
-		int cropToSize = cropToWidth * cropToHeight * 4;
-		byte[] cropped = new byte[cropToSize];
-		for (int i = 0; i < cropToHeight; i++)
-		{
-			int srcIndex = i * width * 4;
-			int dstIndex = i * cropToWidth * 4;
-			Array.Copy(data, srcIndex, cropped, dstIndex, cropToWidth * 4);
-		}
-		return cropped;
 	}
 }

--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -4,8 +4,6 @@ using System.Drawing;
 
 namespace AssetRipper.SourceGenerated.Extensions;
 
-
-// Heavily reused from AssetTools.NET: https://github.com/nesrak1/AssetsTools.NET/blob/main/AssetsTools.NET.Texture/Swizzle/SwitchSwizzle.cs
 public class SwitchSwizzle
 {
 	private const int GOB_X_TEXEL_COUNT = 4;

--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -34,7 +34,6 @@ public static class SwitchSwizzle
 	{
 		TextureFormat realFormat = GetCorrectedSwitchTextureFormat(texture.Format_C28E);
 		
-		
 		// Format is unsupported, we back out
 		if (GetTextureFormatBlockSize(realFormat) is not { } blockSize)
 		{

--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -33,7 +33,7 @@ public class SwitchSwizzle
 
 	public SwitchSwizzle(ITexture2D texture)
 	{
-		originalSize = new Size(texture.Width_C28, texture.Width_C28);
+		originalSize = new Size(texture.Width_C28, texture.Height_C28);
 		realFormat = GetCorrectedSwitchTextureFormat(texture.Format_C28E);
 		gobsPerBlock = GetBlockHeightByPlatformBlob(texture.PlatformBlob_C28);
 

--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -10,7 +10,9 @@ public class SwitchSwizzle
 	private const int GOB_Y_TEXEL_COUNT = 8;
 	private const int TEXEL_BYTE_SIZE = 16;
 	
-	// referring to block here as a compressed texture block, not a gob one
+	/// <summary>
+	/// In this case, "block" refers to a compressed texture block, not a gob one.
+	/// </summary>
 	private const int BLOCKS_IN_GOB = GOB_X_TEXEL_COUNT * GOB_Y_TEXEL_COUNT;
 	
 	private static readonly int[] GOB_X_POSES = new int[]

--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -45,10 +45,10 @@ public static class SwitchSwizzle
 		
 		int blockHeight = GetBlockHeightByPlatformBlob(texture.PlatformBlob_C28);
 		
-		Size paddedSize = GetPaddedTextureSize(texture.Width_C28, texture.Height_C28, blockSize.Width, blockSize.Height, blockHeight);
+		Size paddedSize = GetPaddedTextureSize(texture.Width_C28, texture.Height_C28, blockSize.Value.Width, blockSize.Value.Height, blockHeight);
 
-		int blockCountX = CeilDivide(paddedSize.Width, blockSize.Width);
-		int blockCountY = CeilDivide(paddedSize.Height, blockSize.Height);
+		int blockCountX = CeilDivide(paddedSize.Width, blockSize.Value.Width);
+		int blockCountY = CeilDivide(paddedSize.Height, blockSize.Value.Height);
 
 		int gobCountX = blockCountX / GobXTexelCount;
 		int gobCountY = blockCountY / GobYTexelCount;

--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -1,0 +1,187 @@
+using AssetRipper.SourceGenerated.Classes.ClassID_28;
+using AssetRipper.SourceGenerated.Enums;
+using System.Drawing;
+
+namespace AssetRipper.SourceGenerated.Extensions;
+
+
+// Heavily reused from AssetTools.NET: https://github.com/nesrak1/AssetsTools.NET/blob/main/AssetsTools.NET.Texture/Swizzle/SwitchSwizzle.cs
+public class SwitchSwizzle
+{
+	private const int GOB_X_TEXEL_COUNT = 4;
+	private const int GOB_Y_TEXEL_COUNT = 8;
+	private const int TEXEL_BYTE_SIZE = 16;
+	
+	// referring to block here as a compressed texture block, not a gob one
+	private const int BLOCKS_IN_GOB = GOB_X_TEXEL_COUNT * GOB_Y_TEXEL_COUNT;
+	
+	private static readonly int[] GOB_X_POSES = new int[]
+	{
+		0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3, 2, 2, 3, 3, 2, 2, 3, 3
+	};
+	
+	private static readonly int[] GOB_Y_POSES = new int[]
+	{
+		0, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 0, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7
+	};
+	
+	private readonly Size originalSize;
+	private readonly Size paddedSize;
+	private readonly Size blockSize;
+	private readonly int gobsPerBlock;
+	private readonly TextureFormat realFormat;
+
+	public SwitchSwizzle(ITexture2D texture)
+	{
+		originalSize = new Size(texture.Width_C28, texture.Width_C28);
+		realFormat = GetCorrectedSwitchTextureFormat(texture.Format_C28E);
+		gobsPerBlock = GetBlockHeightByPlatformBlob(texture.PlatformBlob_C28);
+
+		blockSize = GetTextureFormatBlockSize(realFormat);
+		paddedSize = GetPaddedTextureSize(originalSize.Width, originalSize.Height, blockSize.Width, blockSize.Height, gobsPerBlock);
+	}
+	
+	private static int CeilDivide(int a, int b)
+	{
+		return (a + b - 1) / b;
+	}
+	
+	public byte[] PreprocessDeswizzle(byte[] rawData, out TextureFormat format, out int width, out int height)
+	{
+		format = realFormat;
+		width = paddedSize.Width;
+		height = paddedSize.Height;
+		return Unswizzle(rawData, paddedSize, blockSize, gobsPerBlock);
+	}
+
+	public byte[] PostprocessDeswizzle(byte[] rawData)
+	{
+		return CropFromTopLeft(rawData, paddedSize.Width, paddedSize.Height, originalSize.Width, originalSize.Height);
+	}
+	
+	public static byte[] Unswizzle(byte[] data, Size imageSize, Size blockSize, int blockHeight)
+	{
+		byte[] newData = new byte[data.Length];
+
+		int width = imageSize.Width;
+		int height = imageSize.Height;
+
+		int blockCountX = CeilDivide(width, blockSize.Width);
+		int blockCountY = CeilDivide(height, blockSize.Height);
+
+		int gobCountX = blockCountX / GOB_X_TEXEL_COUNT;
+		int gobCountY = blockCountY / GOB_Y_TEXEL_COUNT;
+
+		int srcPos = 0;
+		for (int i = 0; i < gobCountY / blockHeight; i++)
+		{
+			for (int j = 0; j < gobCountX; j++)
+			{
+				for (int k = 0; k < blockHeight; k++)
+				{
+					for (int l = 0; l < BLOCKS_IN_GOB; l++)
+					{
+						int gobX = GOB_X_POSES[l];
+						int gobY = GOB_Y_POSES[l];
+						int gobDstX = j * GOB_X_TEXEL_COUNT + gobX;
+						int gobDstY = (i * blockHeight + k) * GOB_Y_TEXEL_COUNT + gobY;
+						int gobDstLinPos = gobDstY * blockCountX * TEXEL_BYTE_SIZE + gobDstX * TEXEL_BYTE_SIZE;
+
+						Array.Copy(data, srcPos, newData, gobDstLinPos, TEXEL_BYTE_SIZE);
+
+						srcPos += TEXEL_BYTE_SIZE;
+					}
+				}
+			}
+		}
+
+		return newData;
+	}
+
+	private static Size GetTextureFormatBlockSize(TextureFormat textureFormat)
+	{
+		return textureFormat switch
+		{
+			TextureFormat.Alpha8 => new Size(16, 1),
+			TextureFormat.ARGB4444 => new Size(8, 1),
+			TextureFormat.RGBA32 => new Size(4, 1),
+			TextureFormat.ARGB32 => new Size(4, 1),
+			TextureFormat.RGB565 => new Size(8, 1),
+			TextureFormat.R16 => new Size(8, 1),
+			TextureFormat.DXT1 => new Size(8, 4),
+			TextureFormat.DXT5 => new Size(4, 4),
+			TextureFormat.RGBA4444 => new Size(8, 1),
+			TextureFormat.BC6H => new Size(4, 4),
+			TextureFormat.BC7 => new Size(4, 4),
+			TextureFormat.BC4 => new Size(8, 4),
+			TextureFormat.BC5 => new Size(4, 4),
+			TextureFormat.ASTC_RGB_4x4 => new Size(4, 4),
+			TextureFormat.ASTC_RGB_5x5 => new Size(5, 5),
+			TextureFormat.ASTC_RGB_6x6 => new Size(6, 6),
+			TextureFormat.ASTC_RGB_8x8 => new Size(8, 8),
+			TextureFormat.ASTC_RGB_10x10 => new Size(10, 10),
+			TextureFormat.ASTC_RGB_12x12 => new Size(12, 12),
+			TextureFormat.ASTC_RGBA_4x4 => new Size(4, 4),
+			TextureFormat.ASTC_RGBA_5x5 => new Size(5, 5),
+			TextureFormat.ASTC_RGBA_6x6 => new Size(6, 6),
+			TextureFormat.ASTC_RGBA_8x8 => new Size(8, 8),
+			TextureFormat.ASTC_RGBA_10x10 => new Size(10, 10),
+			TextureFormat.ASTC_RGBA_12x12 => new Size(12, 12),
+			TextureFormat.RG16 => new Size(8, 1),
+			TextureFormat.R8 => new Size(16, 1),
+			_ => throw new NotImplementedException(),
+		};
+	}
+	
+	public static Size GetPaddedTextureSize(int width, int height, int blockWidth, int blockHeight, int gobsPerBlock)
+	{
+		width = CeilDivide(width, blockWidth * GOB_X_TEXEL_COUNT) * blockWidth * GOB_X_TEXEL_COUNT;
+		height = CeilDivide(height, blockHeight * GOB_Y_TEXEL_COUNT * gobsPerBlock) * blockHeight * GOB_Y_TEXEL_COUNT * gobsPerBlock;
+		return new Size(width, height);
+	}
+	
+	public static int GetBlockHeightByBlockSize(Size blockSize, int imageHeight)
+	{
+		int blockHeight = CeilDivide(imageHeight, blockSize.Height);
+		int heightAndHalf = blockHeight + blockHeight / 2;
+		
+		return heightAndHalf switch
+		{
+			>= 128 => 16,
+			>= 64 => 8,
+			>= 32 => 4,
+			>= 16 => 2,
+			_ => 1
+		};
+	}
+
+	private static int GetBlockHeightByPlatformBlob(byte[] platformBlob)
+	{
+		return 1 << BitConverter.ToInt32(platformBlob, 8);
+	}
+
+	private static TextureFormat GetCorrectedSwitchTextureFormat(TextureFormat format)
+	{
+		return format switch
+		{
+			TextureFormat.RGB24 => TextureFormat.RGBA32,
+			_ => format
+		};
+	}
+	
+	private static byte[] CropFromTopLeft(byte[] data, int width, int height, int cropToWidth, int cropToHeight)
+	{
+		if (cropToWidth > width || cropToHeight > height)
+			throw new ArgumentException("Crop size is bigger than the original image size.");
+
+		int cropToSize = cropToWidth * cropToHeight * 4;
+		byte[] cropped = new byte[cropToSize];
+		for (int i = 0; i < cropToHeight; i++)
+		{
+			int srcIndex = i * width * 4;
+			int dstIndex = i * cropToWidth * 4;
+			Array.Copy(data, srcIndex, cropped, dstIndex, cropToWidth * 4);
+		}
+		return cropped;
+	}
+}

--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -32,10 +32,17 @@ public static class SwitchSwizzle
 	
 	public static byte[] Unswizzle(ITexture2D texture, byte[] data)
 	{
-		byte[] newData = new byte[data.Length];
-
 		TextureFormat realFormat = GetCorrectedSwitchTextureFormat(texture.Format_C28E);
-		Size blockSize = GetTextureFormatBlockSize(realFormat);
+		Size? blockSize = GetTextureFormatBlockSize(realFormat);
+		
+		// Format is unsupported, we back out
+		if (blockSize == null)
+		{
+			return data;
+		}
+
+		byte[] newData = new byte[data.Length];
+		
 		int blockHeight = GetBlockHeightByPlatformBlob(texture.PlatformBlob_C28);
 		
 		Size paddedSize = GetPaddedTextureSize(texture.Width_C28, texture.Height_C28, blockSize.Width, blockSize.Height, blockHeight);
@@ -72,7 +79,7 @@ public static class SwitchSwizzle
 		return newData;
 	}
 
-	private static Size GetTextureFormatBlockSize(TextureFormat textureFormat)
+	private static Size? GetTextureFormatBlockSize(TextureFormat textureFormat) 
 	{
 		return textureFormat switch
 		{
@@ -103,7 +110,7 @@ public static class SwitchSwizzle
 			TextureFormat.ASTC_RGBA_12x12 => new Size(12, 12),
 			TextureFormat.RG16 => new Size(8, 1),
 			TextureFormat.R8 => new Size(16, 1),
-			_ => throw new NotImplementedException(),
+			_ => null,
 		};
 	}
 	

--- a/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/SwitchSwizzle.cs
@@ -33,10 +33,10 @@ public static class SwitchSwizzle
 	public static byte[] Unswizzle(ITexture2D texture, byte[] data)
 	{
 		TextureFormat realFormat = GetCorrectedSwitchTextureFormat(texture.Format_C28E);
-		Size? blockSize = GetTextureFormatBlockSize(realFormat);
+		
 		
 		// Format is unsupported, we back out
-		if (blockSize == null)
+		if (GetTextureFormatBlockSize(realFormat) is not { } blockSize)
 		{
 			return data;
 		}
@@ -45,10 +45,10 @@ public static class SwitchSwizzle
 		
 		int blockHeight = GetBlockHeightByPlatformBlob(texture.PlatformBlob_C28);
 		
-		Size paddedSize = GetPaddedTextureSize(texture.Width_C28, texture.Height_C28, blockSize.Value.Width, blockSize.Value.Height, blockHeight);
+		Size paddedSize = GetPaddedTextureSize(texture.Width_C28, texture.Height_C28, blockSize.Width, blockSize.Height, blockHeight);
 
-		int blockCountX = CeilDivide(paddedSize.Width, blockSize.Value.Width);
-		int blockCountY = CeilDivide(paddedSize.Height, blockSize.Value.Height);
+		int blockCountX = CeilDivide(paddedSize.Width, blockSize.Width);
+		int blockCountY = CeilDivide(paddedSize.Height, blockSize.Height);
 
 		int gobCountX = blockCountX / GobXTexelCount;
 		int gobCountY = blockCountY / GobYTexelCount;

--- a/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
@@ -81,7 +81,7 @@ public static class Texture2DExtensions
 			byte[] data = texture.ImageData_C28;
 
 			bool swapBytes = IsSwapBytes(texture.Collection.Platform, texture.Format_C28E);
-			bool swizzled = texture is { PlatformBlob_C28: { Length: >= 12 }, Collection.Platform: BuildTarget.Switch };
+			bool switchSwizzled = texture is { PlatformBlob_C28: { Length: >= 12 }, Collection.Platform: BuildTarget.Switch };
 
 			if (data.Length != 0)
 			{
@@ -104,10 +104,9 @@ public static class Texture2DExtensions
 				}
 			}
 
-			if (swizzled)
+			if (switchSwizzled)
 			{
-				SwitchSwizzle unswizzler = new(texture);
-				return unswizzler.PreprocessDeswizzle(data, out _, out _, out _);
+				return SwitchSwizzle.Unswizzle(texture, data);
 			}
 
 			return data;

--- a/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
@@ -1,4 +1,5 @@
-﻿using AssetRipper.SourceGenerated.Classes.ClassID_28;
+﻿using System.Drawing;
+using AssetRipper.SourceGenerated.Classes.ClassID_28;
 using AssetRipper.SourceGenerated.Enums;
 
 namespace AssetRipper.SourceGenerated.Extensions;
@@ -80,6 +81,7 @@ public static class Texture2DExtensions
 			byte[] data = texture.ImageData_C28;
 
 			bool swapBytes = IsSwapBytes(texture.Collection.Platform, texture.Format_C28E);
+			bool swizzled = IsSwitchSwizzled(texture.PlatformBlob_C28);
 
 			if (data.Length != 0)
 			{
@@ -100,6 +102,12 @@ public static class Texture2DExtensions
 				{
 					(data[i], data[i + 1]) = (data[i + 1], data[i]);
 				}
+			}
+
+			if (swizzled)
+			{
+				SwitchSwizzle unswizzler = new(texture);
+				return unswizzler.PreprocessDeswizzle(data, out _, out _, out _);
 			}
 
 			return data;
@@ -142,5 +150,25 @@ public static class Texture2DExtensions
 			}
 		}
 		return false;
+	}
+	
+	private static bool IsSwitchSwizzled(byte[]? platformBlob)
+	{
+		return platformBlob is { Length: >= 12 };
+	}
+	
+	private static void TextureFormatToBlockSize(TextureFormat format)
+	{
+		switch (format)
+		{ 
+			case TextureFormat.ARGB4444:
+			case TextureFormat.RGB565:
+			case TextureFormat.DXT1:
+			case TextureFormat.DXT1Crunched:
+			case TextureFormat.DXT3:
+			case TextureFormat.DXT5:
+			case TextureFormat.DXT5Crunched:
+				break;
+		}
 	}
 }

--- a/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Drawing;
-using AssetRipper.SourceGenerated.Classes.ClassID_28;
+﻿using AssetRipper.SourceGenerated.Classes.ClassID_28;
 using AssetRipper.SourceGenerated.Enums;
 
 namespace AssetRipper.SourceGenerated.Extensions;
@@ -155,20 +154,5 @@ public static class Texture2DExtensions
 	private static bool IsSwitchSwizzled(byte[]? platformBlob)
 	{
 		return platformBlob is { Length: >= 12 };
-	}
-	
-	private static void TextureFormatToBlockSize(TextureFormat format)
-	{
-		switch (format)
-		{ 
-			case TextureFormat.ARGB4444:
-			case TextureFormat.RGB565:
-			case TextureFormat.DXT1:
-			case TextureFormat.DXT1Crunched:
-			case TextureFormat.DXT3:
-			case TextureFormat.DXT5:
-			case TextureFormat.DXT5Crunched:
-				break;
-		}
 	}
 }

--- a/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
@@ -81,7 +81,7 @@ public static class Texture2DExtensions
 			byte[] data = texture.ImageData_C28;
 
 			bool swapBytes = IsSwapBytes(texture.Collection.Platform, texture.Format_C28E);
-			bool swizzled = IsSwitchSwizzled(texture.PlatformBlob_C28) && texture.Collection.Platform == BuildTarget.Switch;
+			bool swizzled = texture is { PlatformBlob_C28: { Length: >= 12 }, Collection.Platform: BuildTarget.Switch };
 
 			if (data.Length != 0)
 			{
@@ -150,10 +150,5 @@ public static class Texture2DExtensions
 			}
 		}
 		return false;
-	}
-	
-	private static bool IsSwitchSwizzled(byte[]? platformBlob)
-	{
-		return platformBlob is { Length: >= 12 };
 	}
 }

--- a/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
+++ b/Source/AssetRipper.SourceGenerated.Extensions/Texture2DExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using AssetRipper.SourceGenerated.Classes.ClassID_28;
 using AssetRipper.SourceGenerated.Enums;
+using BuildTarget = AssetRipper.IO.Files.BuildTarget;
 
 namespace AssetRipper.SourceGenerated.Extensions;
 
@@ -80,7 +81,7 @@ public static class Texture2DExtensions
 			byte[] data = texture.ImageData_C28;
 
 			bool swapBytes = IsSwapBytes(texture.Collection.Platform, texture.Format_C28E);
-			bool swizzled = IsSwitchSwizzled(texture.PlatformBlob_C28);
+			bool swizzled = IsSwitchSwizzled(texture.PlatformBlob_C28) && texture.Collection.Platform == BuildTarget.Switch;
 
 			if (data.Length != 0)
 			{


### PR DESCRIPTION
This pull request implements unswizzling for Nintendo Switch textures. It has been tested on thousands of texture extracted from Fire Emblem Engage successfully

<img width="3824" height="2482" alt="image" src="https://github.com/user-attachments/assets/3b70d422-164d-48ed-a921-7db7fd315c1a" />

<img width="3824" height="2482" alt="image" src="https://github.com/user-attachments/assets/d7289c01-de17-47da-ae96-001ae3061dfb" />

<img width="3824" height="2482" alt="image" src="https://github.com/user-attachments/assets/561c2c12-3577-4620-bc98-a7ae3161478c" />


Resolves #629