### PR TITLE
Add command-line argument --allow-export-overwrite

### DIFF
--- a/Source/AssetRipper.GUI.Web/Arguments.cs
+++ b/Source/AssetRipper.GUI.Web/Arguments.cs
@@ -26,4 +26,8 @@ internal sealed partial class Arguments
 	[CommandLineArgument("local-web-file")]
 	[Description("Files provided with this option will replace online sources.")]
 	public string[]? LocalWebFiles { get; set; }
+
+	[CommandLineArgument(DefaultValue = false)]
+	[Description("If true, existing export directories will be automatically overwritten without confirmation.")]
+	public bool AllowExportOverwrite { get; set; }
 }

--- a/Source/AssetRipper.GUI.Web/GameFileLoader.cs
+++ b/Source/AssetRipper.GUI.Web/GameFileLoader.cs
@@ -18,6 +18,7 @@ public static class GameFileLoader
 	public static GameBundle GameBundle => GameData!.GameBundle;
 	public static IAssemblyManager AssemblyManager => GameData!.AssemblyManager;
 	public static FullConfiguration Settings { get; } = LoadSettings();
+	public static bool AllowExportOverwrite { get; set; }
 
 	public static ExportHandler ExportHandler
 	{
@@ -126,6 +127,11 @@ public static class GameFileLoader
 
 	private static async Task<bool> UserConsentsToDeletion()
 	{
+		if (AllowExportOverwrite)
+		{
+			Logger.Info(LogCategory.Export, "Allowing export directory overwrite due to command line argument.");
+			return true;
+		}
 		ConfirmationDialog.Options options = new()
 		{
 			Message = Localization.ExportDirectoryDeleteUserConfirmation,

--- a/Source/AssetRipper.GUI.Web/WebApplicationLauncher.cs
+++ b/Source/AssetRipper.GUI.Web/WebApplicationLauncher.cs
@@ -34,6 +34,7 @@ public static class WebApplicationLauncher
 		public const bool LaunchBrowser = true;
 		public const bool Log = true;
 		public const string? LogPath = null;
+		public const bool AllowExportOverwrite = false;
 	}
 
 	public static void Launch(string[] args)
@@ -64,11 +65,13 @@ public static class WebApplicationLauncher
 			}
 		}
 
-		Launch(arguments.Port, arguments.LaunchBrowser, arguments.Log, arguments.LogPath);
+		Launch(arguments.Port, arguments.LaunchBrowser, arguments.Log, arguments.LogPath, arguments.AllowExportOverwrite);
 	}
 
-	public static void Launch(int port = Defaults.Port, bool launchBrowser = Defaults.LaunchBrowser, bool log = Defaults.Log, string? logPath = Defaults.LogPath)
+	public static void Launch(int port = Defaults.Port, bool launchBrowser = Defaults.LaunchBrowser, bool log = Defaults.Log, string? logPath = Defaults.LogPath, bool allowExportOverwrite = Defaults.AllowExportOverwrite)
 	{
+		GameFileLoader.AllowExportOverwrite = allowExportOverwrite;
+
 		WelcomeMessage.Print();
 
 		if (log)


### PR DESCRIPTION
**Issue:** Export confirmation dialog blocks batch operations when the export directory already exists with the same name.

<img width="499" height="81" alt="image" src="https://github.com/user-attachments/assets/dd7d519e-28a6-4def-b17c-2c3a9c46e149" />


**Solution:** Added `--allow-export-overwrite` command-line argument. When provided, the export directory is automatically overwritten without confirmation.

**Changes:**
- `Arguments.cs`: Added `AllowExportOverwrite` property
- `GameFileLoader.cs`: Added check in `UserConsentsToDeletion()` method
- `WebApplicationLauncher.cs`: Added parameter to Defaults and Launch method

**Usage:** `dotnet run -- --allow-export-overwrite=true`
