### PR TITLE
Fix SpriteProcessor execution order and filter Texture-Sprite association (Fixes #1994)

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/Textures/TextureExportCollection.cs
+++ b/Source/AssetRipper.Export.UnityProjects/Textures/TextureExportCollection.cs
@@ -27,7 +27,10 @@ public class TextureExportCollection : AssetsExportCollection<ITexture2D>
 			foreach ((ISprite? sprite, ISpriteAtlas? _) in spriteInformationObject.Sprites)
 			{
 				Debug.Assert(sprite.TryGetTexture() == Asset);
-				AddAsset(sprite);
+				if (sprite.TryGetTexture() == Asset)
+				{
+					AddAsset(sprite);
+				}
 			}
 		}
 		AddAsset(spriteInformationObject);
@@ -39,7 +42,7 @@ public class TextureExportCollection : AssetsExportCollection<ITexture2D>
 		if (m_convert)
 		{
 			ITextureImporter importer = ImporterFactory.GenerateTextureImporter(container, texture);
-			AddSprites(container, importer, ((SpriteInformationObject?)Asset.MainAsset)!.Sprites);
+			AddSprites(container, importer, GetFilteredSpriteInfo());
 			return importer;
 		}
 		else
@@ -135,6 +138,24 @@ public class TextureExportCollection : AssetsExportCollection<ITexture2D>
 				AddIDToName(container, importer, textureSpriteInformation);
 			}
 		}
+	}
+
+	private IReadOnlyDictionary<ISprite, ISpriteAtlas?>? GetFilteredSpriteInfo()
+	{
+		SpriteInformationObject? group = (SpriteInformationObject?)Asset.MainAsset;
+		if (group is null)
+		{
+			return null;
+		}
+		var dict = new Dictionary<ISprite, ISpriteAtlas?>();
+		foreach (var kvp in group.Sprites)
+		{
+			if (kvp.Key.TryGetTexture() == Asset)
+			{
+				dict[kvp.Key] = kvp.Value;
+			}
+		}
+		return dict;
 	}
 
 	private static void AddSpriteSheet(ITextureImporter importer, IReadOnlyDictionary<ISprite, ISpriteAtlas?> textureSpriteInformation)

--- a/Source/AssetRipper.Processing/Textures/SpriteProcessor.cs
+++ b/Source/AssetRipper.Processing/Textures/SpriteProcessor.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets;
+using AssetRipper.Assets;
 using AssetRipper.Assets.Cloning;
 using AssetRipper.IO.Files;
 using AssetRipper.SourceGenerated.Classes.ClassID_213;
@@ -32,15 +32,14 @@ public sealed partial class SpriteProcessor : IAssetProcessor
 			}
 			else if (asset is ISprite sprite)
 			{
+				ISpriteAtlas? atlas = sprite.SpriteAtlasP;
+				ProcessSprite(sprite);
 				ITexture2D? spriteTexture = sprite.TryGetTexture();
 				if (spriteTexture is not null)
 				{
 					SpriteInformationObject spriteInformationObject = factory.GetOrCreate(spriteTexture);
-					ISpriteAtlas? atlas = sprite.SpriteAtlasP;
 					spriteInformationObject.AddToDictionary(sprite, atlas);
 				}
-
-				ProcessSprite(sprite);
 			}
 			else if (asset is ISpriteAtlas atlas && atlas.RenderDataMap.Count > 0)
 			{


### PR DESCRIPTION
### Description
This PR addresses issue #1994 regarding `SpriteProcessor` execution order and validates sprite-texture associations during export.

### Changes
1.  **SpriteProcessor.cs**: Adjusted the execution order. `ProcessSprite(sprite)` is now called *before* attempting to retrieve the texture and adding it to the `SpriteInformationObject`. This ensures that the sprite data is correctly initialized before being grouped.
2.  **TextureExportCollection.cs**: 
    * Replaced the strict `Debug.Assert` with a conditional check.
    * Added `GetFilteredSpriteInfo()` to filter the sprites. Now, only sprites that explicitly match the current Texture Asset are added to the export list. This prevents errors when the `SpriteInformationObject` contains sprites that do not belong to the current texture asset.

### Related Issue
Fixes #1994