### PR TITLE
Make random GUIDs more deterministic

### DIFF
--- a/Source/AssetRipper.Assets/Collections/SceneDefinition.cs
+++ b/Source/AssetRipper.Assets/Collections/SceneDefinition.cs
@@ -20,7 +20,7 @@ public sealed class SceneDefinition
 		{
 			Name = name,
 			Path = $"Assets/Scenes/{name}",
-			GUID = guid.IsZero ? UnityGuid.NewGuid() : guid,
+			GUID = guid.IsZero ? new(RandomGuid.Next()) : guid,
 		};
 	}
 
@@ -36,7 +36,7 @@ public sealed class SceneDefinition
 		{
 			Name = System.IO.Path.GetFileName(path),
 			Path = path,
-			GUID = guid.IsZero ? UnityGuid.NewGuid() : guid,
+			GUID = guid.IsZero ? new(RandomGuid.Next()) : guid,
 		};
 	}
 

--- a/Source/AssetRipper.Assets/RandomGuid.cs
+++ b/Source/AssetRipper.Assets/RandomGuid.cs
@@ -1,0 +1,23 @@
+using System.Runtime.InteropServices;
+
+namespace AssetRipper.Assets;
+
+public static class RandomGuid
+{
+	private static readonly Random rng = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SOURCE_DATE_EPOCH"))
+		&& long.TryParse(Environment.GetEnvironmentVariable("SOURCE_DATE_EPOCH"), out long l)
+			? new(Seed: unchecked((int)l))
+			: Random.Shared;
+
+	[ThreadStatic]
+	private static byte[]? buf;
+
+	public static Guid Next()
+	{
+		buf ??= new byte[/*sizeof(Guid)*/16];
+		rng.NextBytes(buf);
+		return MemoryMarshal.Read<Guid>(buf);
+	}
+
+	public static long NextLong() => rng.NextInt64();
+}

--- a/Source/AssetRipper.Export.UnityProjects/AssetExportCollection.cs
+++ b/Source/AssetRipper.Export.UnityProjects/AssetExportCollection.cs
@@ -75,7 +75,7 @@ public class AssetExportCollection<T> : ExportCollection where T : IUnityObjectB
 		return importer;
 	}
 
-	public override UnityGuid GUID { get; } = UnityGuid.NewGuid();
+	public override UnityGuid GUID { get; } = new(RandomGuid.Next());
 	public override IAssetExporter AssetExporter { get; }
 	public override AssetCollection File => Asset.Collection;
 	public override IEnumerable<IUnityObjectBase> Assets

--- a/Source/AssetRipper.Processing/AudioMixers/AudioMixerProcessor.cs
+++ b/Source/AssetRipper.Processing/AudioMixers/AudioMixerProcessor.cs
@@ -1,4 +1,5 @@
-﻿using AssetRipper.Assets.Collections;
+﻿using AssetRipper.Assets;
+using AssetRipper.Assets.Collections;
 using AssetRipper.Assets.Generics;
 using AssetRipper.Checksum;
 using AssetRipper.Import.Logging;
@@ -176,7 +177,7 @@ public sealed class AudioMixerProcessor : IAssetProcessor
 			{
 				IAudioMixerEffectController effect = virtualFile.CreateAudioMixerEffectController();
 				effect.HideFlagsE = HideFlags.HideInHierarchy | HideFlags.HideInInspector;
-				effect.EffectID.CopyValues(UnityGuid.NewGuid());
+				effect.EffectID.CopyValues(new UnityGuid(RandomGuid.Next()));
 				effect.EffectName = "Attenuation";
 				effect.MainAsset = mixer;
 

--- a/Source/AssetRipper.Processing/AudioMixers/GuidIndexTable.cs
+++ b/Source/AssetRipper.Processing/AudioMixers/GuidIndexTable.cs
@@ -1,4 +1,5 @@
-﻿using AssetRipper.Import.Logging;
+﻿using AssetRipper.Assets;
+using AssetRipper.Import.Logging;
 
 namespace AssetRipper.Processing.AudioMixers;
 
@@ -24,7 +25,7 @@ internal readonly struct GuidIndexTable
 		}
 		else
 		{
-			guid = UnityGuid.NewGuid();
+			guid = new(RandomGuid.Next());
 			table.Add(index, guid);
 		}
 		return guid;


### PR DESCRIPTION
~~With this PR I'm hoping to address #1288 and get a reproducible output.~~ I have attained effective reproducibility, but not in the way requested in that issue; launching AssetRipper, loading a game, and exporting the Unity Project will always result in the same output, but it's sensitive to even small patches to the game. Also, the same GUIDs will appear across unrelated games if the same `SOURCE_DATE_EPOCH` value is used, which is why I've left it using `Random.Shared` when the user doesn't set `SOURCE_DATE_EPOCH`.
~~What I have so far is from a simple search for `Random`, `Guid.NewGuid` and `Parallel.ForEach`. I'm not sure there was any improvement so far, but these will probably be necessary in the end, there's just a source of nondeterminism higher up in the chain that I'm not aware of. `GetReleaseAssets` maybe?~~
~~I saw you left some notes in #1098 about using the checksum of an asset's content as its GUID. Is that still relevant and feasible? If [forcing a deterministic order on the inputs](https://reproducible-builds.org/docs/stable-inputs/) and using a global RNG doesn't pan out, checksums are the only alternative I can think of. Maybe [stripping the GUIDs in post](https://reproducible-builds.org/docs/stripping-unreproducible-information/), but they're important to have.~~