### PR TITLE
Fix Build Status badge for Nightly Builds

### DIFF
--- a/docs/articles/Downloads.md
+++ b/docs/articles/Downloads.md
@@ -21,7 +21,7 @@ Pre-releases showcase experimental features and are available in the [releases s
 
 ⚠️ These versions may be unstable and are recommended for testing purposes only.
 
-## Nightly Builds [![Build Status](https://img.shields.io/github/workflow/status/AssetRipper/AssetRipper/Publish/master?label=Build%20Status&style=flat-square)](https://nightly.link/AssetRipper/AssetRipper/workflows/publish/master)
+## Nightly Builds [![Build Status](https://img.shields.io/github/actions/workflow/status/AssetRipper/AssetRipper/publish.yml?branch=master&label=Build%20Status&style=flat-square)](https://nightly.link/AssetRipper/AssetRipper/workflows/publish/master)
 
 For advanced users, every commit triggers an automatic "nightly" build via Github Actions:
 


### PR DESCRIPTION
I noticed that the Build Status badge for Nightly Builds was broken (referencing https://github.com/badges/shields/issues/8671). This migrates to the new url format.