### PR TITLE
Added support for games using Serialize Reference (MonoBehavior)

### DIFF
--- a/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
+++ b/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
@@ -73,6 +73,7 @@ public sealed class SerializedAssetCollection : AssetCollection
 
 	private static void ReadData(SerializedAssetCollection collection, SerializedFile file, AssetFactoryBase factory)
 	{
+		SerializedRefType[] refTypes = file.RefTypes.ToArray();
 		foreach (ObjectInfo objectInfo in file.Objects)
 		{
 			int classID = objectInfo.TypeID < 0 ? 114 : objectInfo.TypeID;

--- a/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
+++ b/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
@@ -61,7 +61,6 @@ public sealed class SerializedAssetCollection : AssetCollection
 			Platform = file.Platform,
 			Flags = file.Flags,
 			EndianType = file.EndianType,
-			RefTypes = file.RefTypes.ToArray(),
 		};
 		ReadOnlySpan<FileIdentifier> fileDependencies = file.Dependencies;
 		if (fileDependencies.Length > 0)

--- a/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
+++ b/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
@@ -77,7 +77,7 @@ public sealed class SerializedAssetCollection : AssetCollection
 		{
 			int classID = objectInfo.TypeID < 0 ? 114 : objectInfo.TypeID;
 			AssetInfo assetInfo = new AssetInfo(collection, objectInfo.FileID, classID);
-			IUnityObjectBase? asset = factory.ReadAsset(assetInfo, objectInfo.ObjectData, objectInfo.Type);
+			IUnityObjectBase? asset = factory.ReadAsset(assetInfo, objectInfo.ObjectData, objectInfo.Type, file.RefTypes);
 			if (asset is not null)
 			{
 				collection.AddAsset(asset);

--- a/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
+++ b/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets.Bundles;
+using AssetRipper.Assets.Bundles;
 using AssetRipper.Assets.IO;
 using AssetRipper.Assets.Metadata;
 using AssetRipper.IO.Files.SerializedFiles;
@@ -12,6 +12,7 @@ namespace AssetRipper.Assets.Collections;
 public sealed class SerializedAssetCollection : AssetCollection
 {
 	private FileIdentifier[]? DependencyIdentifiers { get; set; }
+	public SerializedTypeReference[] RefTypes { get; private set; } = [];
 
 	private SerializedAssetCollection(Bundle bundle) : base(bundle)
 	{
@@ -61,6 +62,7 @@ public sealed class SerializedAssetCollection : AssetCollection
 			Platform = file.Platform,
 			Flags = file.Flags,
 			EndianType = file.EndianType,
+			RefTypes = file.RefTypes.ToArray(),
 		};
 		ReadOnlySpan<FileIdentifier> fileDependencies = file.Dependencies;
 		if (fileDependencies.Length > 0)

--- a/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
+++ b/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
@@ -73,7 +73,7 @@ public sealed class SerializedAssetCollection : AssetCollection
 
 	private static void ReadData(SerializedAssetCollection collection, SerializedFile file, AssetFactoryBase factory)
 	{
-		SerializedRefType[] refTypes = file.RefTypes.ToArray();
+		SerializedTypeReference[] refTypes = file.RefTypes.ToArray();
 		foreach (ObjectInfo objectInfo in file.Objects)
 		{
 			int classID = objectInfo.TypeID < 0 ? 114 : objectInfo.TypeID;

--- a/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
+++ b/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
@@ -12,7 +12,6 @@ namespace AssetRipper.Assets.Collections;
 public sealed class SerializedAssetCollection : AssetCollection
 {
 	private FileIdentifier[]? DependencyIdentifiers { get; set; }
-	public SerializedTypeReference[] RefTypes { get; private set; } = [];
 
 	private SerializedAssetCollection(Bundle bundle) : base(bundle)
 	{

--- a/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
+++ b/Source/AssetRipper.Assets/Collections/SerializedAssetCollection.cs
@@ -78,7 +78,7 @@ public sealed class SerializedAssetCollection : AssetCollection
 		{
 			int classID = objectInfo.TypeID < 0 ? 114 : objectInfo.TypeID;
 			AssetInfo assetInfo = new AssetInfo(collection, objectInfo.FileID, classID);
-			IUnityObjectBase? asset = factory.ReadAsset(assetInfo, objectInfo.ObjectData, objectInfo.Type, file.RefTypes);
+			IUnityObjectBase? asset = factory.ReadAsset(assetInfo, objectInfo.ObjectData, objectInfo.Type, refTypes);
 			if (asset is not null)
 			{
 				collection.AddAsset(asset);

--- a/Source/AssetRipper.Assets/IO/AssetFactoryBase.cs
+++ b/Source/AssetRipper.Assets/IO/AssetFactoryBase.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets.Generics;
+using AssetRipper.Assets.Generics;
 using AssetRipper.Assets.Metadata;
 using AssetRipper.IO.Files.SerializedFiles.Parser;
 
@@ -6,5 +6,5 @@ namespace AssetRipper.Assets.IO;
 
 public abstract class AssetFactoryBase
 {
-	public abstract IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType);
+	public abstract IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedTypeReference> refTypes);
 }

--- a/Source/AssetRipper.Assets/IO/AssetFactoryBase.cs
+++ b/Source/AssetRipper.Assets/IO/AssetFactoryBase.cs
@@ -6,5 +6,5 @@ namespace AssetRipper.Assets.IO;
 
 public abstract class AssetFactoryBase
 {
-	public abstract IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedTypeReference> refTypes);
+	public abstract IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, IReadOnlyList<SerializedTypeReference> refTypes);
 }

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -77,7 +77,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 			if (type is not null && TypeTreeNodeStruct.TryMakeFromTypeTree(type.OldType, out TypeTreeNodeStruct rootNode))
 			{
 				structure = SerializableTreeType.FromRootNode(rootNode, true).CreateSerializableStructure();
-				if (structure.TryRead(ref reader, monoBehaviour, (monoBehaviour.Collection as SerializedAssetCollection)?.RefTypes, null))
+				if (structure.TryRead(ref reader, monoBehaviour, new SerializedRefTypeCollection(refTypes)))
 				{
 					monoBehaviour.Structure = structure;
 				}

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -48,7 +48,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 
 	private IAssemblyManager AssemblyManager { get; }
 
-	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedTypeReference> refTypes)
+	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, IReadOnlyList<SerializedTypeReference> refTypes)
 	{
 		if (assetInfo.Collection.Version.LessThan(3, 5))
 		{

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -1,5 +1,4 @@
 using AssetRipper.Assets;
-using AssetRipper.Assets.Collections;
 using AssetRipper.Assets.Generics;
 using AssetRipper.Assets.IO;
 using AssetRipper.Assets.Metadata;

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -67,7 +67,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 		}
 	}
 
-	private static IMonoBehaviour ReadMonoBehaviour(IMonoBehaviour monoBehaviour, ReadOnlyArraySegment<byte> assetData, IAssemblyManager assemblyManager, SerializedType? type, ReadOnlySpan<SerializedTypeReference> refTypes)
+	private static IMonoBehaviour ReadMonoBehaviour(IMonoBehaviour monoBehaviour, ReadOnlyArraySegment<byte> assetData, IAssemblyManager assemblyManager, SerializedType? type, IReadOnlyList<SerializedTypeReference> refTypes)
 	{
 		EndianSpanReader reader = new EndianSpanReader(assetData, monoBehaviour.Collection.EndianType);
 		try

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -48,7 +48,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 
 	private IAssemblyManager AssemblyManager { get; }
 
-	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedRefType> refTypes)
+	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, IReadOnlyList<SerializedRefType> refTypes)
 	{
 		if (assetInfo.Collection.Version.LessThan(3, 5))
 		{

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -1,4 +1,5 @@
 using AssetRipper.Assets;
+using AssetRipper.Assets.Collections;
 using AssetRipper.Assets.Generics;
 using AssetRipper.Assets.IO;
 using AssetRipper.Assets.Metadata;
@@ -76,13 +77,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 			if (type is not null && TypeTreeNodeStruct.TryMakeFromTypeTree(type.OldType, out TypeTreeNodeStruct rootNode))
 			{
 				structure = SerializableTreeType.FromRootNode(rootNode, true).CreateSerializableStructure();
-				//if (structure.Type.Fields.Count > 0 && structure.Type.Fields[^1] is { Type.Name: "ManagedReferencesRegistry", Name: "references" })
-				//{
-				//	Logger.Error(LogCategory.Import, $"MonoBehaviour has a field with the [SerializeReference] attribute, which is not currently supported.");
-				//	monoBehaviour.Structure = null;
-				//}
-				//else if (structure.TryRead(ref reader, monoBehaviour, assemblyManager))
-				if (structure.TryRead(ref reader, monoBehaviour, assemblyManager))
+				if (structure.TryRead(ref reader, monoBehaviour, (monoBehaviour.Collection as SerializedAssetCollection)?.RefTypes, null))
 				{
 					monoBehaviour.Structure = structure;
 				}

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -48,7 +48,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 
 	private IAssemblyManager AssemblyManager { get; }
 
-	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, IReadOnlyList<SerializedRefType> refTypes)
+	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedTypeReference> refTypes)
 	{
 		if (assetInfo.Collection.Version.LessThan(3, 5))
 		{
@@ -59,7 +59,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 		}
 		else if (assetInfo.ClassID == (int)ClassIDType.MonoBehaviour)
 		{
-			return ReadMonoBehaviour(MonoBehaviour.Create(assetInfo), assetData, AssemblyManager, assetType);
+			return ReadMonoBehaviour(MonoBehaviour.Create(assetInfo), assetData, AssemblyManager, assetType, refTypes);
 		}
 		else
 		{
@@ -67,7 +67,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 		}
 	}
 
-	private static IMonoBehaviour ReadMonoBehaviour(IMonoBehaviour monoBehaviour, ReadOnlyArraySegment<byte> assetData, IAssemblyManager assemblyManager, SerializedType? type)
+	private static IMonoBehaviour ReadMonoBehaviour(IMonoBehaviour monoBehaviour, ReadOnlyArraySegment<byte> assetData, IAssemblyManager assemblyManager, SerializedType? type, ReadOnlySpan<SerializedTypeReference> refTypes)
 	{
 		EndianSpanReader reader = new EndianSpanReader(assetData, monoBehaviour.Collection.EndianType);
 		try
@@ -77,7 +77,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 			if (type is not null && TypeTreeNodeStruct.TryMakeFromTypeTree(type.OldType, out TypeTreeNodeStruct rootNode))
 			{
 				structure = SerializableTreeType.FromRootNode(rootNode, true).CreateSerializableStructure();
-				if (structure.TryRead(ref reader, monoBehaviour, new SerializedRefTypeCollection(refTypes)))
+				if (structure.TryRead(ref reader, monoBehaviour, new TypeTreeSerializedTypeResolver(refTypes)))
 				{
 					monoBehaviour.Structure = structure;
 				}

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -77,7 +77,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 			if (type is not null && TypeTreeNodeStruct.TryMakeFromTypeTree(type.OldType, out TypeTreeNodeStruct rootNode))
 			{
 				structure = SerializableTreeType.FromRootNode(rootNode, true).CreateSerializableStructure();
-				if (structure.TryRead(ref reader, monoBehaviour, new TypeTreeSerializedTypeResolver(refTypes)))
+				if (structure.TryRead(ref reader, monoBehaviour, new TypeTreeResolver(refTypes)))
 				{
 					monoBehaviour.Structure = structure;
 				}

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -48,7 +48,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 
 	private IAssemblyManager AssemblyManager { get; }
 
-	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType)
+	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedRefType> refTypes)
 	{
 		if (assetInfo.Collection.Version.LessThan(3, 5))
 		{

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets;
+using AssetRipper.Assets;
 using AssetRipper.Assets.Generics;
 using AssetRipper.Assets.IO;
 using AssetRipper.Assets.Metadata;
@@ -76,12 +76,13 @@ public sealed class GameAssetFactory : AssetFactoryBase
 			if (type is not null && TypeTreeNodeStruct.TryMakeFromTypeTree(type.OldType, out TypeTreeNodeStruct rootNode))
 			{
 				structure = SerializableTreeType.FromRootNode(rootNode, true).CreateSerializableStructure();
-				if (structure.Type.Fields.Count > 0 && structure.Type.Fields[^1] is { Type.Name: "ManagedReferencesRegistry", Name: "references" })
-				{
-					Logger.Error(LogCategory.Import, $"MonoBehaviour has a field with the [SerializeReference] attribute, which is not currently supported.");
-					monoBehaviour.Structure = null;
-				}
-				else if (structure.TryRead(ref reader, monoBehaviour))
+				//if (structure.Type.Fields.Count > 0 && structure.Type.Fields[^1] is { Type.Name: "ManagedReferencesRegistry", Name: "references" })
+				//{
+				//	Logger.Error(LogCategory.Import, $"MonoBehaviour has a field with the [SerializeReference] attribute, which is not currently supported.");
+				//	monoBehaviour.Structure = null;
+				//}
+				//else if (structure.TryRead(ref reader, monoBehaviour, assemblyManager))
+				if (structure.TryRead(ref reader, monoBehaviour, assemblyManager))
 				{
 					monoBehaviour.Structure = structure;
 				}

--- a/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
+++ b/Source/AssetRipper.Import/AssetCreation/GameAssetFactory.cs
@@ -192,7 +192,7 @@ public sealed class GameAssetFactory : AssetFactoryBase
 		IUnityObjectBase? asset = AssetFactory.CreateSerialized(assetInfo, version);
 		if (asset is null && TypeTreeNodeStruct.TryMakeFromTpk((ClassIDType)assetInfo.ClassID, version, out TypeTreeNodeStruct releaseRoot, out TypeTreeNodeStruct editorRoot))
 		{
-			return TypeTreeObject.Create(assetInfo, releaseRoot, editorRoot);
+			return TypeTreeObject.Create(assetInfo, releaseRoot, editorRoot, ITypeResolver.Null, ITypeResolver.Null);
 		}
 		else
 		{

--- a/Source/AssetRipper.Import/AssetCreation/TypeTreeObject.cs
+++ b/Source/AssetRipper.Import/AssetCreation/TypeTreeObject.cs
@@ -34,7 +34,7 @@ public abstract class TypeTreeObject : NullObject
 
 	public static TypeTreeObject Create(AssetInfo assetInfo, TypeTreeNodeStruct root, ITypeResolver resolver) => new SingleTypeTreeObject(assetInfo, root, resolver);
 
-	public static TypeTreeObject Create(AssetInfo assetInfo, TypeTreeNodeStruct releaseRoot, TypeTreeNodeStruct editorRoot) => new DoubleTypeTreeObject(assetInfo, releaseRoot, editorRoot);
+	public static TypeTreeObject Create(AssetInfo assetInfo, TypeTreeNodeStruct releaseRoot, TypeTreeNodeStruct editorRoot, ITypeResolver releaseResolver, ITypeResolver editorResolver) => new DoubleTypeTreeObject(assetInfo, releaseRoot, editorRoot, releaseResolver, editorResolver);
 
 	private string GetDebuggerDisplay() => ClassName;
 

--- a/Source/AssetRipper.Import/AssetCreation/TypeTreeObject.cs
+++ b/Source/AssetRipper.Import/AssetCreation/TypeTreeObject.cs
@@ -43,20 +43,22 @@ public abstract class TypeTreeObject : NullObject
 		public SerializableStructure Fields { get; }
 		public override SerializableStructure ReleaseFields => Fields;
 		public override SerializableStructure EditorFields => Fields;
+		private readonly ITypeResolver _resolver;
 
-		public SingleTypeTreeObject(AssetInfo assetInfo, TypeTreeNodeStruct root) : base(assetInfo)
+		public SingleTypeTreeObject(AssetInfo assetInfo, TypeTreeNodeStruct root, ITypeResolver resolver) : base(assetInfo)
 		{
+			_resolver = resolver;
 			Fields = SerializableTreeType.FromRootNode(root).CreateSerializableStructure();
 		}
 
 		public override void ReadRelease(ref EndianSpanReader reader)
 		{
-			Fields.Read(ref reader, Collection.Version, Collection.Flags, ITypeResolver.Null);
+			Fields.Read(ref reader, Collection.Version, Collection.Flags, _resolver);
 		}
 
 		public override void ReadEditor(ref EndianSpanReader reader)
 		{
-			Fields.Read(ref reader, Collection.Version, Collection.Flags, ITypeResolver.Null);
+			Fields.Read(ref reader, Collection.Version, Collection.Flags, _resolver);
 		}
 
 		public override void WalkStandard(AssetWalker walker)
@@ -79,22 +81,26 @@ public abstract class TypeTreeObject : NullObject
 	{
 		public override SerializableStructure ReleaseFields { get; }
 		public override SerializableStructure EditorFields { get; }
+		private readonly ITypeResolver _releaseResolver;
+		private readonly ITypeResolver _editorResolver;
 
-		public DoubleTypeTreeObject(AssetInfo assetInfo, TypeTreeNodeStruct releaseRoot, TypeTreeNodeStruct editorRoot) : base(assetInfo)
+		public DoubleTypeTreeObject(AssetInfo assetInfo, TypeTreeNodeStruct releaseRoot, TypeTreeNodeStruct editorRoot, ITypeResolver releaseResolver, ITypeResolver editorResolver) : base(assetInfo)
 		{
+			_releaseResolver = releaseResolver;
+			_editorResolver = editorResolver;
 			ReleaseFields = SerializableTreeType.FromRootNode(releaseRoot).CreateSerializableStructure();
 			EditorFields = SerializableTreeType.FromRootNode(editorRoot).CreateSerializableStructure();
 		}
 
 		public override void ReadRelease(ref EndianSpanReader reader)
 		{
-			ReleaseFields.Read(ref reader, Collection.Version, Collection.Flags, ITypeResolver.Null);
+			ReleaseFields.Read(ref reader, Collection.Version, Collection.Flags, _releaseResolver);
 			ConvertFields(ReleaseFields, EditorFields);
 		}
 
 		public override void ReadEditor(ref EndianSpanReader reader)
 		{
-			EditorFields.Read(ref reader, Collection.Version, Collection.Flags, ITypeResolver.Null);
+			EditorFields.Read(ref reader, Collection.Version, Collection.Flags, _editorResolver);
 			ConvertFields(EditorFields, ReleaseFields);
 		}
 

--- a/Source/AssetRipper.Import/AssetCreation/TypeTreeObject.cs
+++ b/Source/AssetRipper.Import/AssetCreation/TypeTreeObject.cs
@@ -32,7 +32,7 @@ public abstract class TypeTreeObject : NullObject
 
 	public sealed override void WalkEditor(AssetWalker walker) => EditorFields.WalkEditor(walker);
 
-	public static TypeTreeObject Create(AssetInfo assetInfo, TypeTreeNodeStruct root) => new SingleTypeTreeObject(assetInfo, root);
+	public static TypeTreeObject Create(AssetInfo assetInfo, TypeTreeNodeStruct root, ITypeResolver resolver) => new SingleTypeTreeObject(assetInfo, root, resolver);
 
 	public static TypeTreeObject Create(AssetInfo assetInfo, TypeTreeNodeStruct releaseRoot, TypeTreeNodeStruct editorRoot) => new DoubleTypeTreeObject(assetInfo, releaseRoot, editorRoot);
 

--- a/Source/AssetRipper.Import/AssetCreation/TypeTreeObject.cs
+++ b/Source/AssetRipper.Import/AssetCreation/TypeTreeObject.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets;
+using AssetRipper.Assets;
 using AssetRipper.Assets.Cloning;
 using AssetRipper.Assets.IO.Writing;
 using AssetRipper.Assets.Metadata;
@@ -51,12 +51,12 @@ public abstract class TypeTreeObject : NullObject
 
 		public override void ReadRelease(ref EndianSpanReader reader)
 		{
-			Fields.Read(ref reader, Collection.Version, Collection.Flags);
+			Fields.Read(ref reader, Collection.Version, Collection.Flags, ITypeResolver.Null);
 		}
 
 		public override void ReadEditor(ref EndianSpanReader reader)
 		{
-			Fields.Read(ref reader, Collection.Version, Collection.Flags);
+			Fields.Read(ref reader, Collection.Version, Collection.Flags, ITypeResolver.Null);
 		}
 
 		public override void WalkStandard(AssetWalker walker)
@@ -88,13 +88,13 @@ public abstract class TypeTreeObject : NullObject
 
 		public override void ReadRelease(ref EndianSpanReader reader)
 		{
-			ReleaseFields.Read(ref reader, Collection.Version, Collection.Flags);
+			ReleaseFields.Read(ref reader, Collection.Version, Collection.Flags, ITypeResolver.Null);
 			ConvertFields(ReleaseFields, EditorFields);
 		}
 
 		public override void ReadEditor(ref EndianSpanReader reader)
 		{
-			EditorFields.Read(ref reader, Collection.Version, Collection.Flags);
+			EditorFields.Read(ref reader, Collection.Version, Collection.Flags, ITypeResolver.Null);
 			ConvertFields(EditorFields, ReleaseFields);
 		}
 

--- a/Source/AssetRipper.Import/Structure/Assembly/Managers/BaseManager.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Managers/BaseManager.cs
@@ -1,4 +1,4 @@
-﻿using AsmResolver.DotNet;
+using AsmResolver.DotNet;
 using AsmResolver.DotNet.Builder;
 using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.Builder;
@@ -16,7 +16,7 @@ public partial class BaseManager : IAssemblyManager
 	protected readonly Dictionary<string, AssemblyDefinition?> m_assemblies = new();
 	protected readonly Dictionary<AssemblyDefinition, Stream> m_assemblyStreams = new(SignatureComparer.Default);
 	protected readonly Dictionary<string, bool> m_validTypes = new();
-	private readonly Dictionary<FieldSerializer, Dictionary<ITypeDefOrRef, SerializableType>> monoTypeCache = new();
+	private readonly Dictionary<FieldSerializer, Dictionary<ITypeDefOrRef, (SerializableType, bool)>> monoTypeCache = new();
 
 	private event Action<string> m_requestAssemblyCallback;
 	private readonly Dictionary<string, SerializableType> m_serializableTypes = new();
@@ -203,16 +203,16 @@ public partial class BaseManager : IAssemblyManager
 		else
 		{
 			FieldSerializer fieldSerializer = new(version);
-			if (!monoTypeCache.TryGetValue(fieldSerializer, out Dictionary<ITypeDefOrRef, SerializableType>? typeCache))
+			if (!monoTypeCache.TryGetValue(fieldSerializer, out Dictionary<ITypeDefOrRef, (SerializableType, bool)>? typeCache))
 			{
 				typeCache = new(SignatureComparer.Default);
 				monoTypeCache[fieldSerializer] = typeCache;
 			}
 
-			if (typeCache.TryGetValue(type, out SerializableType? monoType)
-				|| fieldSerializer.TryCreateSerializableType(type, typeCache, out monoType, out failureReason))
+			if (typeCache.TryGetValue(type, out (SerializableType, bool) cachedEntry)
+				|| fieldSerializer.TryCreateSerializableType(type, typeCache, out cachedEntry.Item1, out failureReason))
 			{
-				scriptType = monoType;
+				scriptType = cachedEntry.Item1;
 				failureReason = null;
 				return true;
 			}

--- a/Source/AssetRipper.Import/Structure/Assembly/Managers/IAssemblyManager.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Managers/IAssemblyManager.cs
@@ -2,13 +2,7 @@ using AsmResolver.DotNet;
 using AssetRipper.Import.Structure.Platforms;
 using AssetRipper.IO.Files;
 using AssetRipper.SerializationLogic;
-
 using AssetRipper.Import.Structure.Assembly.Serializable;
-using AsmResolver.DotNet;
-using AssetRipper.Import.Structure.Assembly.Serializable;
-using AssetRipper.Import.Structure.Platforms;
-using AssetRipper.IO.Files;
-using AssetRipper.SerializationLogic;
 
 namespace AssetRipper.Import.Structure.Assembly.Managers;
 

--- a/Source/AssetRipper.Import/Structure/Assembly/Managers/IAssemblyManager.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Managers/IAssemblyManager.cs
@@ -4,6 +4,11 @@ using AssetRipper.IO.Files;
 using AssetRipper.SerializationLogic;
 
 using AssetRipper.Import.Structure.Assembly.Serializable;
+using AsmResolver.DotNet;
+using AssetRipper.Import.Structure.Assembly.Serializable;
+using AssetRipper.Import.Structure.Platforms;
+using AssetRipper.IO.Files;
+using AssetRipper.SerializationLogic;
 
 namespace AssetRipper.Import.Structure.Assembly.Managers;
 

--- a/Source/AssetRipper.Import/Structure/Assembly/Managers/IAssemblyManager.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Managers/IAssemblyManager.cs
@@ -3,9 +3,11 @@ using AssetRipper.Import.Structure.Platforms;
 using AssetRipper.IO.Files;
 using AssetRipper.SerializationLogic;
 
+using AssetRipper.Import.Structure.Assembly.Serializable;
+
 namespace AssetRipper.Import.Structure.Assembly.Managers;
 
-public interface IAssemblyManager : IDisposable
+public interface IAssemblyManager : IDisposable, ITypeResolver
 {
 	void Initialize(PlatformGameStructure gameStructure);
 	void Load(string filePath, FileSystem fileSystem);
@@ -16,11 +18,7 @@ public interface IAssemblyManager : IDisposable
 	bool IsAssemblyLoaded(string assembly);
 	bool IsPresent(ScriptIdentifier scriptID);
 	bool IsValid(ScriptIdentifier scriptID);
-	bool TryGetSerializableType(
-		ScriptIdentifier scriptID,
-		UnityVersion version,
-		[NotNullWhen(true)] out SerializableType? scriptType,
-		[NotNullWhen(false)] out string? failureReason);
+
 	TypeDefinition GetTypeDefinition(ScriptIdentifier scriptID);
 	IEnumerable<AssemblyDefinition> GetAssemblies();
 	ScriptIdentifier GetScriptID(string assembly, string @namespace, string name);

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/ITypeResolver.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/ITypeResolver.cs
@@ -1,0 +1,29 @@
+using AssetRipper.SerializationLogic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace AssetRipper.Import.Structure.Assembly.Serializable;
+
+public interface ITypeResolver
+{
+	bool TryGetSerializableType(
+		ScriptIdentifier scriptID,
+		UnityVersion version,
+		[NotNullWhen(true)] out SerializableType? scriptType,
+		[NotNullWhen(false)] out string? failureReason);
+
+	public static ITypeResolver Null { get; } = new NullResolver();
+
+	private sealed class NullResolver : ITypeResolver
+	{
+		public bool TryGetSerializableType(
+			ScriptIdentifier scriptID,
+			UnityVersion version,
+			[NotNullWhen(true)] out SerializableType? scriptType,
+			[NotNullWhen(false)] out string? failureReason)
+		{
+			scriptType = null;
+			failureReason = "No resolver provided";
+			return false;
+		}
+	}
+}

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializablePair.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializablePair.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets.Cloning;
+using AssetRipper.Assets.Cloning;
 using AssetRipper.Assets.IO.Writing;
 using AssetRipper.Assets.Traversal;
 using AssetRipper.IO.Endian;
@@ -27,10 +27,10 @@ public sealed class SerializablePair
 		Depth = depth;
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ITypeResolver serializedTypeResolver)
 	{
-		First.Read(ref reader, version, flags, Depth, FirstField);
-		Second.Read(ref reader, version, flags, Depth, SecondField);
+		First.Read(ref reader, version, flags, Depth, FirstField, serializedTypeResolver);
+		Second.Read(ref reader, version, flags, Depth, SecondField, serializedTypeResolver);
 	}
 
 	public void Write(AssetWriter writer)

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -50,7 +50,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 							string namespaceName = nsVal.AsString;
 							string assemblyName = asmVal.AsString;
 
-							if (!string.IsNullOrEmpty(className) && serializedTypeResolver != null)
+							if (serializedTypeResolver != null)
 							{
 								ScriptIdentifier scriptId = new ScriptIdentifier(assemblyName, namespaceName, className);
 								if (serializedTypeResolver.TryGetSerializableType(scriptId, version, out SerializableType? resolvedType, out _))

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -4,6 +4,7 @@ using AssetRipper.Assets.IO.Writing;
 using AssetRipper.Assets.Metadata;
 using AssetRipper.Assets.Traversal;
 using AssetRipper.Import.Logging;
+using AssetRipper.Import.Structure.Assembly.Managers;
 using AssetRipper.IO.Endian;
 using AssetRipper.IO.Files.SerializedFiles;
 using AssetRipper.SerializationLogic;
@@ -24,7 +25,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		Fields = new SerializableValue[type.Fields.Count];
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, IAssemblyManager? assemblyManager = null)
 	{
 		Version = version;
 		for (int i = 0; i < Fields.Length; i++)
@@ -32,7 +33,46 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 			SerializableType.Field etalon = Type.Fields[i];
 			if (IsAvailable(etalon))
 			{
-				Fields[i].Read(ref reader, version, flags, Depth, etalon);
+				bool skipNormalRead = false;
+
+				if (assemblyManager != null)
+				{
+					if (Type.Name == "ReferencedObject")
+					{
+						if (etalon.Name == "data")
+						{
+							SerializableValue myType = this["type"];
+							string cName = myType["class"].AsString;
+							string nSpace = myType["ns"].AsString;
+							string aName = myType["asm"].AsString;
+
+							if (cName != "" && cName != null)
+							{
+								ScriptIdentifier id = assemblyManager.GetScriptID(aName, nSpace, cName);
+								SerializableType? tempType = null;
+								string? dummy = "";
+								bool success = assemblyManager.TryGetSerializableType(id, version, out tempType, out dummy);
+
+								if (success == true)
+								{
+									SerializableStructure newStruct = new SerializableStructure(tempType!, Depth + 1);
+									newStruct.Read(ref reader, version, flags, assemblyManager);
+
+									SerializableValue tempVal = new SerializableValue();
+									tempVal.AsAsset = newStruct;
+									Fields[i] = tempVal;
+
+									skipNormalRead = true;
+								}
+							}
+						}
+					}
+				}
+
+				if (skipNormalRead == false)
+				{
+					Fields[i].Read(ref reader, version, flags, Depth, etalon, assemblyManager);
+				}
 			}
 		}
 	}
@@ -117,11 +157,11 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		return true;
 	}
 
-	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour)
+	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, IAssemblyManager assemblyManager)
 	{
 		try
 		{
-			Read(ref reader, monoBehaviour.Collection.Version, monoBehaviour.Collection.Flags);
+			Read(ref reader, monoBehaviour.Collection.Version, monoBehaviour.Collection.Flags, assemblyManager);
 		}
 		catch (Exception ex)
 		{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -157,7 +157,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		return true;
 	}
 
-	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, ISerializedTypeResolver? serializedTypeResolver)
+	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, ISerializedTypeResolver serializedTypeResolver)
 	{
 		try
 		{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -36,7 +36,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		Fields = new SerializableValue[type.Fields.Count];
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, IReadOnlyList<SerializedTypeReference>? refTypes = null, IAssemblyManager? assemblyManager = null)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ISerializedTypeResolver serializedTypeResolver)
 	{
 		Read(ref reader, version, flags, new DefaultSerializedTypeResolver(refTypes, assemblyManager));
 	}

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -16,8 +16,11 @@ namespace AssetRipper.Import.Structure.Assembly.Serializable;
 
 public interface ISerializedTypeResolver
 {
-	IReadOnlyList<SerializedTypeReference>? RefTypes { get; }
-	IAssemblyManager? AssemblyManager { get; }
+	bool TryGetSerializableType(
+		ScriptIdentifier scriptID,
+		UnityVersion version,
+		[NotNullWhen(true)] out SerializableType? scriptType,
+		[NotNullWhen(false)] out string? failureReason);
 }
 
 public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -38,7 +38,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 			{
 				bool skipNormalRead = false;
 
-				if (Type.Name == "ReferencedObject" && etalon.Name == "data" && etalon.Type.Fields.Count == 0)
+				if (etalon.Type.Name == "ReferencedObjectData" && etalon.Type.Fields.Count == 0)
 				{
 					if (TryGetField("type", out SerializableValue typeVal) && typeVal.AsAsset is SerializableStructure typeStructure)
 					{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -54,7 +54,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 							if (serializedTypeResolver.TryGetSerializableType(scriptId, version, out SerializableType? resolvedType, out _))
 							{
 								SerializableStructure resolvedStructure = new SerializableStructure(resolvedType, Depth + 1);
-								resolvedStructure.Read(ref reader, version, flags, resolver);
+								resolvedStructure.Read(ref reader, version, flags, serializedTypeResolver);
 
 								SerializableValue resolvedValue = new SerializableValue();
 								resolvedValue.AsAsset = resolvedStructure;
@@ -68,7 +68,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 
 				if (skipNormalRead == false)
 				{
-					Fields[i].Read(ref reader, version, flags, Depth, etalon, resolver);
+					Fields[i].Read(ref reader, version, flags, Depth, etalon, serializedTypeResolver);
 				}
 			}
 		}

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -28,8 +28,9 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		Fields = new SerializableValue[type.Fields.Count];
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ISerializedTypeResolver? serializedTypeResolver = null)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ITypeResolver? serializedTypeResolver = null)
 	{
+		ITypeResolver resolver = serializedTypeResolver ?? ITypeResolver.Null;
 		Version = version;
 		for (int i = 0; i < Fields.Length; i++)
 		{
@@ -50,20 +51,17 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 							string namespaceName = nsVal.AsString;
 							string assemblyName = asmVal.AsString;
 
-							if (serializedTypeResolver != null)
+							ScriptIdentifier scriptId = new ScriptIdentifier(assemblyName, namespaceName, className);
+							if (resolver.TryGetSerializableType(scriptId, version, out SerializableType? resolvedType, out _))
 							{
-								ScriptIdentifier scriptId = new ScriptIdentifier(assemblyName, namespaceName, className);
-								if (serializedTypeResolver.TryGetSerializableType(scriptId, version, out SerializableType? resolvedType, out _))
-								{
-									SerializableStructure resolvedStructure = new SerializableStructure(resolvedType, Depth + 1);
-									resolvedStructure.Read(ref reader, version, flags, serializedTypeResolver);
+								SerializableStructure resolvedStructure = new SerializableStructure(resolvedType, Depth + 1);
+								resolvedStructure.Read(ref reader, version, flags, resolver);
 
-									SerializableValue resolvedValue = new SerializableValue();
-									resolvedValue.AsAsset = resolvedStructure;
-									Fields[i] = resolvedValue;
+								SerializableValue resolvedValue = new SerializableValue();
+								resolvedValue.AsAsset = resolvedStructure;
+								Fields[i] = resolvedValue;
 
-									skipNormalRead = true;
-								}
+								skipNormalRead = true;
 							}
 						}
 					}
@@ -71,7 +69,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 
 				if (skipNormalRead == false)
 				{
-					Fields[i].Read(ref reader, version, flags, Depth, etalon, serializedTypeResolver);
+					Fields[i].Read(ref reader, version, flags, Depth, etalon, resolver);
 				}
 			}
 		}
@@ -157,7 +155,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		return true;
 	}
 
-	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, ISerializedTypeResolver serializedTypeResolver)
+	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, ITypeResolver serializedTypeResolver)
 	{
 		try
 		{
@@ -329,69 +327,4 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 	/// <see href="https://forum.unity.com/threads/4-5-serialization-depth.248321/"/>
 	/// </remarks>
 	private static int GetMaxDepthLevel(UnityVersion version) => version.GreaterThanOrEquals(2020, 2, 0, UnityVersionType.Alpha, 21) ? 10 : 7;
-}
-
-public interface ISerializedTypeResolver
-{
-	bool TryGetSerializableType(
-		ScriptIdentifier scriptID,
-		UnityVersion version,
-		[NotNullWhen(true)] out SerializableType? scriptType,
-		[NotNullWhen(false)] out string? failureReason);
-}
-
-internal sealed class TypeTreeSerializedTypeResolver : ISerializedTypeResolver
-{
-	private readonly SerializedTypeReference[] m_refTypes;
-
-	public TypeTreeSerializedTypeResolver(ReadOnlySpan<SerializedTypeReference> refTypes)
-	{
-		m_refTypes = refTypes.ToArray();
-	}
-
-	public bool TryGetSerializableType(
-		ScriptIdentifier scriptID,
-		UnityVersion version,
-		[NotNullWhen(true)] out SerializableType? scriptType,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		for (int i = 0; i < m_refTypes.Length; i++)
-		{
-			SerializedTypeReference refType = m_refTypes[i];
-			if (refType.ClassName.String == scriptID.Name &&
-				refType.Namespace.String == scriptID.Namespace &&
-				refType.AsmName.String == scriptID.Assembly)
-			{
-				if (TypeTreeNodeStruct.TryMakeFromTypeTree(refType.OldType, out TypeTreeNodeStruct rootNode))
-				{
-					scriptType = SerializableTreeType.FromRootNode(rootNode, true);
-					failureReason = null;
-					return true;
-				}
-			}
-		}
-
-		scriptType = null;
-		failureReason = "type reference not found in type tree";
-		return false;
-	}
-}
-
-internal sealed class AssemblySerializedTypeResolver : ISerializedTypeResolver
-{
-	private readonly IAssemblyManager m_assemblyManager;
-
-	public AssemblySerializedTypeResolver(IAssemblyManager assemblyManager)
-	{
-		m_assemblyManager = assemblyManager;
-	}
-
-	public bool TryGetSerializableType(
-		ScriptIdentifier scriptID,
-		UnityVersion version,
-		[NotNullWhen(true)] out SerializableType? scriptType,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		return m_assemblyManager.TryGetSerializableType(scriptID, version, out scriptType, out failureReason);
-	}
 }

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -5,12 +5,20 @@ using AssetRipper.Assets.Metadata;
 using AssetRipper.Assets.Traversal;
 using AssetRipper.Import.Logging;
 using AssetRipper.Import.Structure.Assembly.Managers;
+using AssetRipper.Import.Structure.Assembly.TypeTrees;
 using AssetRipper.IO.Endian;
 using AssetRipper.IO.Files.SerializedFiles;
+using AssetRipper.IO.Files.SerializedFiles.Parser;
 using AssetRipper.SerializationLogic;
 using AssetRipper.SourceGenerated.Classes.ClassID_114;
 
 namespace AssetRipper.Import.Structure.Assembly.Serializable;
+
+public interface ISerializedTypeResolver
+{
+	IReadOnlyList<SerializedTypeReference>? RefTypes { get; }
+	IAssemblyManager? AssemblyManager { get; }
+}
 
 public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 {
@@ -25,9 +33,19 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		Fields = new SerializableValue[type.Fields.Count];
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, IAssemblyManager? assemblyManager = null)
+	private readonly record struct DefaultSerializedTypeResolver(IReadOnlyList<SerializedTypeReference>? RefTypes, IAssemblyManager? AssemblyManager) : ISerializedTypeResolver;
+
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, IReadOnlyList<SerializedTypeReference>? refTypes = null, IAssemblyManager? assemblyManager = null)
+	{
+		Read(ref reader, version, flags, new DefaultSerializedTypeResolver(refTypes, assemblyManager));
+	}
+
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ISerializedTypeResolver? serializedTypeResolver)
 	{
 		Version = version;
+		IReadOnlyList<SerializedTypeReference>? refTypes = serializedTypeResolver?.RefTypes;
+		IAssemblyManager? assemblyManager = serializedTypeResolver?.AssemblyManager;
+
 		for (int i = 0; i < Fields.Length; i++)
 		{
 			SerializableType.Field etalon = Type.Fields[i];
@@ -35,34 +53,58 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 			{
 				bool skipNormalRead = false;
 
-				if (assemblyManager != null)
+				if (Type.Name == "ReferencedObject" && etalon.Name == "data" && etalon.Type.Fields.Count == 0)
 				{
-					if (Type.Name == "ReferencedObject")
+					if (TryGetField("type", out SerializableValue typeVal) && typeVal.AsAsset is SerializableStructure typeStructure)
 					{
-						if (etalon.Name == "data")
+						if (typeStructure.TryGetField("class", out SerializableValue classVal) &&
+							typeStructure.TryGetField("ns", out SerializableValue nsVal) &&
+							typeStructure.TryGetField("asm", out SerializableValue asmVal))
 						{
-							SerializableValue myType = this["type"];
-							string cName = myType["class"].AsString;
-							string nSpace = myType["ns"].AsString;
-							string aName = myType["asm"].AsString;
+							string className = classVal.AsString;
+							string namespaceName = nsVal.AsString;
+							string assemblyName = asmVal.AsString;
 
-							if (cName != "" && cName != null)
+							if (!string.IsNullOrEmpty(className))
 							{
-								ScriptIdentifier id = assemblyManager.GetScriptID(aName, nSpace, cName);
-								SerializableType? tempType = null;
-								string? dummy = "";
-								bool success = assemblyManager.TryGetSerializableType(id, version, out tempType, out dummy);
-
-								if (success == true)
+								if (refTypes != null)
 								{
-									SerializableStructure newStruct = new SerializableStructure(tempType!, Depth + 1);
-									newStruct.Read(ref reader, version, flags, assemblyManager);
+									foreach (SerializedTypeReference refType in refTypes)
+									{
+										if (refType.ClassName.String == className && refType.Namespace.String == namespaceName && refType.AsmName.String == assemblyName)
+										{
+											if (TypeTreeNodeStruct.TryMakeFromTypeTree(refType.OldType, out TypeTreeNodeStruct rootNode))
+											{
+												SerializableStructure resolvedStructure = SerializableTreeType.FromRootNode(rootNode, true).CreateSerializableStructure();
+												resolvedStructure.Read(ref reader, version, flags, new DefaultSerializedTypeResolver(refTypes, null));
+												
+												SerializableValue resolvedValue = new SerializableValue();
+												resolvedValue.AsAsset = resolvedStructure;
+												Fields[i] = resolvedValue;
+												skipNormalRead = true;
+											}
+											break;
+										}
+									}
+								}
+								else if (assemblyManager != null)
+								{
+									ScriptIdentifier scriptId = assemblyManager.GetScriptID(assemblyName, namespaceName, className);
+									SerializableType? resolvedType = null;
+									string? failureReason = "";
+									bool isTypeResolved = assemblyManager.TryGetSerializableType(scriptId, version, out resolvedType, out failureReason);
 
-									SerializableValue tempVal = new SerializableValue();
-									tempVal.AsAsset = newStruct;
-									Fields[i] = tempVal;
+									if (isTypeResolved == true)
+									{
+										SerializableStructure resolvedStructure = new SerializableStructure(resolvedType!, Depth + 1);
+										resolvedStructure.Read(ref reader, version, flags, new DefaultSerializedTypeResolver(null, assemblyManager));
 
-									skipNormalRead = true;
+										SerializableValue resolvedValue = new SerializableValue();
+										resolvedValue.AsAsset = resolvedStructure;
+										Fields[i] = resolvedValue;
+
+										skipNormalRead = true;
+									}
 								}
 							}
 						}
@@ -71,7 +113,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 
 				if (skipNormalRead == false)
 				{
-					Fields[i].Read(ref reader, version, flags, Depth, etalon, assemblyManager);
+					Fields[i].Read(ref reader, version, flags, Depth, etalon, refTypes, assemblyManager);
 				}
 			}
 		}
@@ -157,11 +199,11 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		return true;
 	}
 
-	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, IAssemblyManager assemblyManager)
+	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, IReadOnlyList<SerializedTypeReference>? refTypes, IAssemblyManager? assemblyManager)
 	{
 		try
 		{
-			Read(ref reader, monoBehaviour.Collection.Version, monoBehaviour.Collection.Flags, assemblyManager);
+			Read(ref reader, monoBehaviour.Collection.Version, monoBehaviour.Collection.Flags, refTypes, assemblyManager);
 		}
 		catch (Exception ex)
 		{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -30,7 +30,6 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 
 	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ITypeResolver serializedTypeResolver)
 	{
-		ITypeResolver resolver = serializedTypeResolver ?? ITypeResolver.Null;
 		Version = version;
 		for (int i = 0; i < Fields.Length; i++)
 		{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -28,7 +28,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		Fields = new SerializableValue[type.Fields.Count];
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ITypeResolver? serializedTypeResolver = null)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ITypeResolver serializedTypeResolver)
 	{
 		ITypeResolver resolver = serializedTypeResolver ?? ITypeResolver.Null;
 		Version = version;

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -376,6 +376,7 @@ internal sealed class TypeTreeSerializedTypeResolver : ISerializedTypeResolver
 		failureReason = "type reference not found in type tree";
 		return false;
 	}
+}
 
 internal sealed class AssemblySerializedTypeResolver : ISerializedTypeResolver
 {

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -36,8 +36,6 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		Fields = new SerializableValue[type.Fields.Count];
 	}
 
-	private readonly record struct DefaultSerializedTypeResolver(IReadOnlyList<SerializedTypeReference>? RefTypes, IAssemblyManager? AssemblyManager) : ISerializedTypeResolver;
-
 	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, IReadOnlyList<SerializedTypeReference>? refTypes = null, IAssemblyManager? assemblyManager = null)
 	{
 		Read(ref reader, version, flags, new DefaultSerializedTypeResolver(refTypes, assemblyManager));

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -31,7 +31,6 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ISerializedTypeResolver? serializedTypeResolver = null)
 	{
 		Version = version;
-
 		for (int i = 0; i < Fields.Length; i++)
 		{
 			SerializableType.Field etalon = Type.Fields[i];

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -51,7 +51,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 							string assemblyName = asmVal.AsString;
 
 							ScriptIdentifier scriptId = new ScriptIdentifier(assemblyName, namespaceName, className);
-							if (resolver.TryGetSerializableType(scriptId, version, out SerializableType? resolvedType, out _))
+							if (serializedTypeResolver.TryGetSerializableType(scriptId, version, out SerializableType? resolvedType, out _))
 							{
 								SerializableStructure resolvedStructure = new SerializableStructure(resolvedType, Depth + 1);
 								resolvedStructure.Read(ref reader, version, flags, resolver);

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableStructure.cs
@@ -1,4 +1,5 @@
 using AssetRipper.Assets;
+using System.Diagnostics.CodeAnalysis;
 using AssetRipper.Assets.Cloning;
 using AssetRipper.Assets.IO.Writing;
 using AssetRipper.Assets.Metadata;
@@ -14,15 +15,6 @@ using AssetRipper.SourceGenerated.Classes.ClassID_114;
 
 namespace AssetRipper.Import.Structure.Assembly.Serializable;
 
-public interface ISerializedTypeResolver
-{
-	bool TryGetSerializableType(
-		ScriptIdentifier scriptID,
-		UnityVersion version,
-		[NotNullWhen(true)] out SerializableType? scriptType,
-		[NotNullWhen(false)] out string? failureReason);
-}
-
 public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 {
 	private UnityVersion Version { get; set; }
@@ -36,16 +28,9 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		Fields = new SerializableValue[type.Fields.Count];
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ISerializedTypeResolver serializedTypeResolver)
-	{
-		Read(ref reader, version, flags, new DefaultSerializedTypeResolver(refTypes, assemblyManager));
-	}
-
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ISerializedTypeResolver? serializedTypeResolver)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, ISerializedTypeResolver? serializedTypeResolver = null)
 	{
 		Version = version;
-		IReadOnlyList<SerializedTypeReference>? refTypes = serializedTypeResolver?.RefTypes;
-		IAssemblyManager? assemblyManager = serializedTypeResolver?.AssemblyManager;
 
 		for (int i = 0; i < Fields.Length; i++)
 		{
@@ -66,46 +51,19 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 							string namespaceName = nsVal.AsString;
 							string assemblyName = asmVal.AsString;
 
-							if (!string.IsNullOrEmpty(className))
+							if (!string.IsNullOrEmpty(className) && serializedTypeResolver != null)
 							{
-								if (refTypes != null)
+								ScriptIdentifier scriptId = new ScriptIdentifier(assemblyName, namespaceName, className);
+								if (serializedTypeResolver.TryGetSerializableType(scriptId, version, out SerializableType? resolvedType, out _))
 								{
-									foreach (SerializedTypeReference refType in refTypes)
-									{
-										if (refType.ClassName.String == className && refType.Namespace.String == namespaceName && refType.AsmName.String == assemblyName)
-										{
-											if (TypeTreeNodeStruct.TryMakeFromTypeTree(refType.OldType, out TypeTreeNodeStruct rootNode))
-											{
-												SerializableStructure resolvedStructure = SerializableTreeType.FromRootNode(rootNode, true).CreateSerializableStructure();
-												resolvedStructure.Read(ref reader, version, flags, new DefaultSerializedTypeResolver(refTypes, null));
-												
-												SerializableValue resolvedValue = new SerializableValue();
-												resolvedValue.AsAsset = resolvedStructure;
-												Fields[i] = resolvedValue;
-												skipNormalRead = true;
-											}
-											break;
-										}
-									}
-								}
-								else if (assemblyManager != null)
-								{
-									ScriptIdentifier scriptId = assemblyManager.GetScriptID(assemblyName, namespaceName, className);
-									SerializableType? resolvedType = null;
-									string? failureReason = "";
-									bool isTypeResolved = assemblyManager.TryGetSerializableType(scriptId, version, out resolvedType, out failureReason);
+									SerializableStructure resolvedStructure = new SerializableStructure(resolvedType, Depth + 1);
+									resolvedStructure.Read(ref reader, version, flags, serializedTypeResolver);
 
-									if (isTypeResolved == true)
-									{
-										SerializableStructure resolvedStructure = new SerializableStructure(resolvedType!, Depth + 1);
-										resolvedStructure.Read(ref reader, version, flags, new DefaultSerializedTypeResolver(null, assemblyManager));
+									SerializableValue resolvedValue = new SerializableValue();
+									resolvedValue.AsAsset = resolvedStructure;
+									Fields[i] = resolvedValue;
 
-										SerializableValue resolvedValue = new SerializableValue();
-										resolvedValue.AsAsset = resolvedStructure;
-										Fields[i] = resolvedValue;
-
-										skipNormalRead = true;
-									}
+									skipNormalRead = true;
 								}
 							}
 						}
@@ -114,7 +72,7 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 
 				if (skipNormalRead == false)
 				{
-					Fields[i].Read(ref reader, version, flags, Depth, etalon, refTypes, assemblyManager);
+					Fields[i].Read(ref reader, version, flags, Depth, etalon, serializedTypeResolver);
 				}
 			}
 		}
@@ -200,11 +158,11 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 		return true;
 	}
 
-	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, IReadOnlyList<SerializedTypeReference>? refTypes, IAssemblyManager? assemblyManager)
+	public bool TryRead(ref EndianSpanReader reader, IMonoBehaviour monoBehaviour, ISerializedTypeResolver? serializedTypeResolver)
 	{
 		try
 		{
-			Read(ref reader, monoBehaviour.Collection.Version, monoBehaviour.Collection.Flags, refTypes, assemblyManager);
+			Read(ref reader, monoBehaviour.Collection.Version, monoBehaviour.Collection.Flags, serializedTypeResolver);
 		}
 		catch (Exception ex)
 		{
@@ -372,4 +330,68 @@ public sealed class SerializableStructure : UnityAssetBase, IDeepCloneable
 	/// <see href="https://forum.unity.com/threads/4-5-serialization-depth.248321/"/>
 	/// </remarks>
 	private static int GetMaxDepthLevel(UnityVersion version) => version.GreaterThanOrEquals(2020, 2, 0, UnityVersionType.Alpha, 21) ? 10 : 7;
+}
+
+public interface ISerializedTypeResolver
+{
+	bool TryGetSerializableType(
+		ScriptIdentifier scriptID,
+		UnityVersion version,
+		[NotNullWhen(true)] out SerializableType? scriptType,
+		[NotNullWhen(false)] out string? failureReason);
+}
+
+internal sealed class TypeTreeSerializedTypeResolver : ISerializedTypeResolver
+{
+	private readonly SerializedTypeReference[] m_refTypes;
+
+	public TypeTreeSerializedTypeResolver(ReadOnlySpan<SerializedTypeReference> refTypes)
+	{
+		m_refTypes = refTypes.ToArray();
+	}
+
+	public bool TryGetSerializableType(
+		ScriptIdentifier scriptID,
+		UnityVersion version,
+		[NotNullWhen(true)] out SerializableType? scriptType,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		for (int i = 0; i < m_refTypes.Length; i++)
+		{
+			SerializedTypeReference refType = m_refTypes[i];
+			if (refType.ClassName.String == scriptID.Name &&
+				refType.Namespace.String == scriptID.Namespace &&
+				refType.AsmName.String == scriptID.Assembly)
+			{
+				if (TypeTreeNodeStruct.TryMakeFromTypeTree(refType.OldType, out TypeTreeNodeStruct rootNode))
+				{
+					scriptType = SerializableTreeType.FromRootNode(rootNode, true);
+					failureReason = null;
+					return true;
+				}
+			}
+		}
+
+		scriptType = null;
+		failureReason = "type reference not found in type tree";
+		return false;
+	}
+
+internal sealed class AssemblySerializedTypeResolver : ISerializedTypeResolver
+{
+	private readonly IAssemblyManager m_assemblyManager;
+
+	public AssemblySerializedTypeResolver(IAssemblyManager assemblyManager)
+	{
+		m_assemblyManager = assemblyManager;
+	}
+
+	public bool TryGetSerializableType(
+		ScriptIdentifier scriptID,
+		UnityVersion version,
+		[NotNullWhen(true)] out SerializableType? scriptType,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		return m_assemblyManager.TryGetSerializableType(scriptID, version, out scriptType, out failureReason);
+	}
 }

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
@@ -7,6 +7,7 @@ using AssetRipper.IO.Endian;
 using AssetRipper.IO.Files.SerializedFiles;
 using AssetRipper.SerializationLogic;
 using AssetRipper.Import.Structure.Assembly.Managers;
+using AssetRipper.IO.Files.SerializedFiles.Parser;
 using System.Collections;
 using System.Diagnostics;
 
@@ -431,7 +432,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 		return result;
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, IAssemblyManager? assemblyManager = null)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, IReadOnlyList<SerializedTypeReference>? refTypes = null, IAssemblyManager? assemblyManager = null)
 	{
 		switch (etalon.ArrayDepth)
 		{
@@ -478,7 +479,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 						AsString = reader.ReadUtf8StringAligned().String;
 						break;
 					case PrimitiveType.Complex:
-						AsAsset = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, assemblyManager);
+						AsAsset = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, refTypes, assemblyManager);
 						break;
 					case PrimitiveType.Pair:
 					case PrimitiveType.MapPair:
@@ -564,7 +565,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 							IUnityAssetBase[] structures = CreateArray<IUnityAssetBase>(count);
 							for (int i = 0; i < count; i++)
 							{
-								structures[i] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, assemblyManager);
+								structures[i] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, refTypes, assemblyManager);
 							}
 							AsAssetArray = structures;
 						}
@@ -629,7 +630,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 								IUnityAssetBase[] structures = CreateArray<IUnityAssetBase>(innerCount);
 								for (int j = 0; j < innerCount; j++)
 								{
-									structures[j] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, assemblyManager);
+									structures[j] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, refTypes, assemblyManager);
 								}
 								result[i] = structures;
 
@@ -655,12 +656,12 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 			reader.Align();
 		}
 
-		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, IAssemblyManager? assemblyManager)
+		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, IReadOnlyList<SerializedTypeReference>? refTypes, IAssemblyManager? assemblyManager)
 		{
 			IUnityAssetBase asset = etalon.Type.CreateInstance(depth + 1, version);
 			if (asset is SerializableStructure structure)
 			{
-				structure.Read(ref reader, version, flags, assemblyManager);
+				structure.Read(ref reader, version, flags, refTypes, assemblyManager);
 			}
 			else
 			{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
@@ -432,7 +432,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 		return result;
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, IReadOnlyList<SerializedTypeReference>? refTypes = null, IAssemblyManager? assemblyManager = null)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, ISerializedTypeResolver? serializedTypeResolver = null)
 	{
 		switch (etalon.ArrayDepth)
 		{
@@ -479,7 +479,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 						AsString = reader.ReadUtf8StringAligned().String;
 						break;
 					case PrimitiveType.Complex:
-						AsAsset = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, refTypes, assemblyManager);
+						AsAsset = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, serializedTypeResolver);
 						break;
 					case PrimitiveType.Pair:
 					case PrimitiveType.MapPair:
@@ -565,7 +565,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 							IUnityAssetBase[] structures = CreateArray<IUnityAssetBase>(count);
 							for (int i = 0; i < count; i++)
 							{
-								structures[i] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, refTypes, assemblyManager);
+								structures[i] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, serializedTypeResolver);
 							}
 							AsAssetArray = structures;
 						}
@@ -630,7 +630,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 								IUnityAssetBase[] structures = CreateArray<IUnityAssetBase>(innerCount);
 								for (int j = 0; j < innerCount; j++)
 								{
-									structures[j] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, refTypes, assemblyManager);
+									structures[j] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, serializedTypeResolver);
 								}
 								result[i] = structures;
 
@@ -656,12 +656,12 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 			reader.Align();
 		}
 
-		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, IReadOnlyList<SerializedTypeReference>? refTypes, IAssemblyManager? assemblyManager)
+		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, ISerializedTypeResolver? serializedTypeResolver)
 		{
 			IUnityAssetBase asset = etalon.Type.CreateInstance(depth + 1, version);
 			if (asset is SerializableStructure structure)
 			{
-				structure.Read(ref reader, version, flags, refTypes, assemblyManager);
+				structure.Read(ref reader, version, flags, serializedTypeResolver);
 			}
 			else
 			{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
@@ -656,7 +656,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 			reader.Align();
 		}
 
-		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, ISerializedTypeResolver? serializedTypeResolver)
+		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, ISerializedTypeResolver serializedTypeResolver)
 		{
 			IUnityAssetBase asset = etalon.Type.CreateInstance(depth + 1, version);
 			if (asset is SerializableStructure structure)

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
@@ -6,8 +6,6 @@ using AssetRipper.Assets.Traversal;
 using AssetRipper.IO.Endian;
 using AssetRipper.IO.Files.SerializedFiles;
 using AssetRipper.SerializationLogic;
-using AssetRipper.Import.Structure.Assembly.Managers;
-using AssetRipper.IO.Files.SerializedFiles.Parser;
 using System.Collections;
 using System.Diagnostics;
 

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
@@ -6,6 +6,7 @@ using AssetRipper.Assets.Traversal;
 using AssetRipper.IO.Endian;
 using AssetRipper.IO.Files.SerializedFiles;
 using AssetRipper.SerializationLogic;
+using AssetRipper.Import.Structure.Assembly.Managers;
 using System.Collections;
 using System.Diagnostics;
 
@@ -430,7 +431,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 		return result;
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, IAssemblyManager? assemblyManager = null)
 	{
 		switch (etalon.ArrayDepth)
 		{
@@ -477,7 +478,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 						AsString = reader.ReadUtf8StringAligned().String;
 						break;
 					case PrimitiveType.Complex:
-						AsAsset = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon);
+						AsAsset = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, assemblyManager);
 						break;
 					case PrimitiveType.Pair:
 					case PrimitiveType.MapPair:
@@ -563,7 +564,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 							IUnityAssetBase[] structures = CreateArray<IUnityAssetBase>(count);
 							for (int i = 0; i < count; i++)
 							{
-								structures[i] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon);
+								structures[i] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, assemblyManager);
 							}
 							AsAssetArray = structures;
 						}
@@ -628,7 +629,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 								IUnityAssetBase[] structures = CreateArray<IUnityAssetBase>(innerCount);
 								for (int j = 0; j < innerCount; j++)
 								{
-									structures[j] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon);
+									structures[j] = CreateAndReadComplexStructure(ref reader, version, flags, depth, etalon, assemblyManager);
 								}
 								result[i] = structures;
 
@@ -654,12 +655,12 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 			reader.Align();
 		}
 
-		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon)
+		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, IAssemblyManager? assemblyManager)
 		{
 			IUnityAssetBase asset = etalon.Type.CreateInstance(depth + 1, version);
 			if (asset is SerializableStructure structure)
 			{
-				structure.Read(ref reader, version, flags);
+				structure.Read(ref reader, version, flags, assemblyManager);
 			}
 			else
 			{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
@@ -432,7 +432,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 		return result;
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, ISerializedTypeResolver? serializedTypeResolver = null)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, ISerializedTypeResolver serializedTypeResolver)
 	{
 		switch (etalon.ArrayDepth)
 		{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/SerializableValue.cs
@@ -432,7 +432,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 		return result;
 	}
 
-	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, ISerializedTypeResolver serializedTypeResolver)
+	public void Read(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, in SerializableType.Field etalon, ITypeResolver serializedTypeResolver)
 	{
 		switch (etalon.ArrayDepth)
 		{
@@ -485,7 +485,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 					case PrimitiveType.MapPair:
 						{
 							SerializablePair pair = new(etalon.Type, depth + 1);
-							pair.Read(ref reader, version, flags);
+							pair.Read(ref reader, version, flags, serializedTypeResolver);
 							AsPair = pair;
 						}
 						break;
@@ -550,7 +550,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 							for (int i = 0; i < count; i++)
 							{
 								SerializablePair pair = new(etalon.Type, depth + 1);
-								pair.Read(ref reader, version, flags);
+								pair.Read(ref reader, version, flags, serializedTypeResolver);
 								pairs[i] = pair;
 							}
 
@@ -656,7 +656,7 @@ public record struct SerializableValue([property: DebuggerBrowsable(DebuggerBrow
 			reader.Align();
 		}
 
-		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, ISerializedTypeResolver serializedTypeResolver)
+		static IUnityAssetBase CreateAndReadComplexStructure(ref EndianSpanReader reader, UnityVersion version, TransferInstructionFlags flags, int depth, SerializableType.Field etalon, ITypeResolver serializedTypeResolver)
 		{
 			IUnityAssetBase asset = etalon.Type.CreateInstance(depth + 1, version);
 			if (asset is SerializableStructure structure)

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
@@ -33,6 +33,12 @@ internal sealed class TypeTreeResolver : ITypeResolver
 					failureReason = null;
 					return true;
 				}
+				else
+				{
+					scriptType = null;
+					failureReason = "failed to create root node from type tree";
+					return false;
+				}
 			}
 		}
 

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
@@ -20,7 +20,7 @@ internal sealed class TypeTreeResolver : ITypeResolver
 		[NotNullWhen(true)] out SerializableType? scriptType,
 		[NotNullWhen(false)] out string? failureReason)
 	{
-		for (int i = 0; i < m_refTypes.Length; i++)
+		for (int i = 0; i < m_refTypes.Count; i++)
 		{
 			SerializedTypeReference refType = m_refTypes[i];
 			if (refType.ClassName.String == scriptID.Name &&

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
@@ -37,7 +37,7 @@ internal sealed class TypeTreeResolver : ITypeResolver
 		}
 
 		scriptType = null;
-		failureReason = "type reference not found in type tree";
+		failureReason = "Serialized type reference was not found in the set of available type trees.";
 		return false;
 	}
 }

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
@@ -36,7 +36,7 @@ internal sealed class TypeTreeResolver : ITypeResolver
 				else
 				{
 					scriptType = null;
-					failureReason = "failed to create root node from type tree";
+					failureReason = "Failed to create nodes from the type tree";
 					return false;
 				}
 			}

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
@@ -11,7 +11,7 @@ internal sealed class TypeTreeResolver : ITypeResolver
 
 	public TypeTreeResolver(IReadOnlyList<SerializedTypeReference> refTypes)
 	{
-		m_refTypes = refTypes is SerializedTypeReference[] array ? array : refTypes.ToArray();
+		m_refTypes = refTypes;
 	}
 
 	public bool TryGetSerializableType(

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
@@ -7,7 +7,7 @@ namespace AssetRipper.Import.Structure.Assembly.Serializable;
 
 internal sealed class TypeTreeResolver : ITypeResolver
 {
-	private readonly SerializedTypeReference[] m_refTypes;
+	private readonly IReadOnlyList<SerializedTypeReference> m_refTypes;
 
 	public TypeTreeResolver(IReadOnlyList<SerializedTypeReference> refTypes)
 	{

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/TypeTreeResolver.cs
@@ -1,0 +1,43 @@
+using AssetRipper.Import.Structure.Assembly.TypeTrees;
+using AssetRipper.IO.Files.SerializedFiles.Parser;
+using AssetRipper.SerializationLogic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace AssetRipper.Import.Structure.Assembly.Serializable;
+
+internal sealed class TypeTreeResolver : ITypeResolver
+{
+	private readonly SerializedTypeReference[] m_refTypes;
+
+	public TypeTreeResolver(IReadOnlyList<SerializedTypeReference> refTypes)
+	{
+		m_refTypes = refTypes is SerializedTypeReference[] array ? array : refTypes.ToArray();
+	}
+
+	public bool TryGetSerializableType(
+		ScriptIdentifier scriptID,
+		UnityVersion version,
+		[NotNullWhen(true)] out SerializableType? scriptType,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		for (int i = 0; i < m_refTypes.Length; i++)
+		{
+			SerializedTypeReference refType = m_refTypes[i];
+			if (refType.ClassName.String == scriptID.Name &&
+				refType.Namespace.String == scriptID.Namespace &&
+				refType.AsmName.String == scriptID.Assembly)
+			{
+				if (TypeTreeNodeStruct.TryMakeFromTypeTree(refType.OldType, out TypeTreeNodeStruct rootNode))
+				{
+					scriptType = SerializableTreeType.FromRootNode(rootNode, true);
+					failureReason = null;
+					return true;
+				}
+			}
+		}
+
+		scriptType = null;
+		failureReason = "type reference not found in type tree";
+		return false;
+	}
+}

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
@@ -71,7 +71,7 @@ public sealed class UnloadedStructure : UnityAssetBase, IDeepCloneable
 		if (structure is not null)
 		{
 			EndianSpanReader reader = new EndianSpanReader(StructureData, MonoBehaviour.Collection.EndianType);
-			if (structure.TryRead(ref reader, MonoBehaviour, new AssemblySerializedTypeResolver(AssemblyManager)))
+			if (structure.TryRead(ref reader, MonoBehaviour, AssemblyManager))
 			{
 				MonoBehaviour.Structure = structure;
 				return structure;

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets;
+using AssetRipper.Assets;
 using AssetRipper.Assets.Cloning;
 using AssetRipper.Assets.Generics;
 using AssetRipper.Assets.IO.Writing;
@@ -71,7 +71,7 @@ public sealed class UnloadedStructure : UnityAssetBase, IDeepCloneable
 		if (structure is not null)
 		{
 			EndianSpanReader reader = new EndianSpanReader(StructureData, MonoBehaviour.Collection.EndianType);
-			if (structure.TryRead(ref reader, MonoBehaviour))
+			if (structure.TryRead(ref reader, MonoBehaviour, AssemblyManager))
 			{
 				MonoBehaviour.Structure = structure;
 				return structure;

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
@@ -71,7 +71,7 @@ public sealed class UnloadedStructure : UnityAssetBase, IDeepCloneable
 		if (structure is not null)
 		{
 			EndianSpanReader reader = new EndianSpanReader(StructureData, MonoBehaviour.Collection.EndianType);
-			if (structure.TryRead(ref reader, MonoBehaviour, AssemblyManager))
+			if (structure.TryRead(ref reader, MonoBehaviour, null, AssemblyManager))
 			{
 				MonoBehaviour.Structure = structure;
 				return structure;

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
@@ -71,7 +71,7 @@ public sealed class UnloadedStructure : UnityAssetBase, IDeepCloneable
 		if (structure is not null)
 		{
 			EndianSpanReader reader = new EndianSpanReader(StructureData, MonoBehaviour.Collection.EndianType);
-			if (structure.TryRead(ref reader, MonoBehaviour, null, AssemblyManager))
+			if (structure.TryRead(ref reader, MonoBehaviour, AssemblyManager))
 			{
 				MonoBehaviour.Structure = structure;
 				return structure;

--- a/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/Serializable/UnloadedStructure.cs
@@ -71,7 +71,7 @@ public sealed class UnloadedStructure : UnityAssetBase, IDeepCloneable
 		if (structure is not null)
 		{
 			EndianSpanReader reader = new EndianSpanReader(StructureData, MonoBehaviour.Collection.EndianType);
-			if (structure.TryRead(ref reader, MonoBehaviour, AssemblyManager))
+			if (structure.TryRead(ref reader, MonoBehaviour, new AssemblySerializedTypeResolver(AssemblyManager)))
 			{
 				MonoBehaviour.Structure = structure;
 				return structure;

--- a/Source/AssetRipper.SerializationLogic.Tests/SerializableTypes.cs
+++ b/Source/AssetRipper.SerializationLogic.Tests/SerializableTypes.cs
@@ -31,10 +31,10 @@ public static class SerializableTypes
 	public static List<SerializableType> CreateMultiple(TypeDefinition type, UnityVersion version)
 	{
 		FieldSerializer serializer = new(version);
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache = [];
+		Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache = [];
 		if (serializer.TryCreateSerializableType(type, typeCache, out _, out string? failureReason))
 		{
-			return typeCache.Values.ToList();
+			return typeCache.Values.Select(v => v.Item1).ToList();
 		}
 		else
 		{

--- a/Source/AssetRipper.SerializationLogic/CustomSerializableType.cs
+++ b/Source/AssetRipper.SerializationLogic/CustomSerializableType.cs
@@ -10,7 +10,7 @@ internal sealed class CustomSerializableType : SerializableType
 		{
 			if (field.Type.IsMaxDepthKnown)
 			{
-				MaxDepth = Math.Max(MaxDepth, field.Type.MaxDepth + 1);
+				MaxDepth = int.Max(MaxDepth, field.Type.MaxDepth + 1);
 			}
 		}
 	}

--- a/Source/AssetRipper.SerializationLogic/CustomSerializableType.cs
+++ b/Source/AssetRipper.SerializationLogic/CustomSerializableType.cs
@@ -1,0 +1,17 @@
+namespace AssetRipper.SerializationLogic;
+
+internal sealed class CustomSerializableType : SerializableType
+{
+	public CustomSerializableType(string? @namespace, PrimitiveType type, string name, IReadOnlyList<SerializableType.Field> fields) : base(@namespace, type, name)
+	{
+		Fields = fields;
+		MaxDepth = 0;
+		foreach (Field field in Fields)
+		{
+			if (field.Type.IsMaxDepthKnown)
+			{
+				MaxDepth = Math.Max(MaxDepth, field.Type.MaxDepth + 1);
+			}
+		}
+	}
+}

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -6,389 +6,389 @@ namespace AssetRipper.SerializationLogic;
 
 public readonly partial struct FieldSerializer
 {
-        public bool TryCreateSerializableType(TypeDefinition typeDefinition,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                return TryCreateSerializableType(typeDefinition, new(SignatureComparer.Default), out result, out failureReason);
-        }
+	public bool TryCreateSerializableType(TypeDefinition typeDefinition,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		return TryCreateSerializableType(typeDefinition, new(SignatureComparer.Default), out result, out failureReason);
+	}
 
-        public bool TryCreateSerializableType(
-                TypeDefinition typeDefinition,
-                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                Stack<MonoType> typeStack = new();
-                bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
-                Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
-                return returnValue;
-        }
+	public bool TryCreateSerializableType(
+		TypeDefinition typeDefinition,
+		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		Stack<MonoType> typeStack = new();
+		bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
+		Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
+		return returnValue;
+	}
 
-        private bool TryCreateSerializableType(
-                TypeSignature typeSignature,
-                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-                Stack<MonoType> typeStack,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
-                {
-                        return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason);
-                }
-                TypeDefinition? typeDefinition = typeSignature.Resolve();
-                if (typeDefinition is null)
-                {
-                        result = null;
-                        failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
-                        return false;
-                }
-                else
-                {
-                        return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
-                }
-        }
+	private bool TryCreateSerializableType(
+		TypeSignature typeSignature,
+		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+		Stack<MonoType> typeStack,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
+		{
+			return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason);
+		}
+		TypeDefinition? typeDefinition = typeSignature.Resolve();
+		if (typeDefinition is null)
+		{
+			result = null;
+			failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
+			return false;
+		}
+		else
+		{
+			return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
+		}
+	}
 
-        private bool TryCreateSerializableType(
-                TypeDefinition typeDefinition,
-                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-                Stack<MonoType> typeStack,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedType))
-                {
-                        result = cachedType;
-                        failureReason = null;
-                        return true;
-                }
-                if (typeDefinition.GenericParameters.Count > 0)
-                {
-                        result = null;
-                        failureReason = "Generic types are not serializable.";
-                        return false;
-                }
-                if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))
-                {
-                        result = SerializablePrimitiveType.GetOrCreate(primitiveType);
-                        typeCache.Add(typeDefinition, result);
-                        failureReason = null;
-                        return true;
-                }
+	private bool TryCreateSerializableType(
+		TypeDefinition typeDefinition,
+		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+		Stack<MonoType> typeStack,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedType))
+		{
+			result = cachedType;
+			failureReason = null;
+			return true;
+		}
+		if (typeDefinition.GenericParameters.Count > 0)
+		{
+			result = null;
+			failureReason = "Generic types are not serializable.";
+			return false;
+		}
+		if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))
+		{
+			result = SerializablePrimitiveType.GetOrCreate(primitiveType);
+			typeCache.Add(typeDefinition, result);
+			failureReason = null;
+			return true;
+		}
 
-                //Ensure we allocate some initial space so that we have less chance of needing to resize the list.
-                List<Field> fields = [];
+		//Ensure we allocate some initial space so that we have less chance of needing to resize the list.
+		List<Field> fields = [];
 
-                //Caching before completion prevents infinite loops.
-                MonoType monoType = new(typeDefinition, fields);
-                typeCache.Add(typeDefinition, monoType);
-                typeStack.Push(monoType);
+		//Caching before completion prevents infinite loops.
+		MonoType monoType = new(typeDefinition, fields);
+		typeCache.Add(typeDefinition, monoType);
+		typeStack.Push(monoType);
 
-                if (typeDefinition.BaseType is not null)
-                {
-                        if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason))
-                        {
-                                typeCache.Remove(typeDefinition);
-                                typeStack.Pop();
-                                result = null;
-                                return false;
-                        }
-                        else
-                        {
-                                fields.EnsureCapacity(baseType.Fields.Count + typeDefinition.Fields.Count);
-                                fields.AddRange(baseType.Fields);
-                        }
-                }
-                else
-                {
-                        fields.EnsureCapacity(typeDefinition.Fields.Count);
-                }
+		if (typeDefinition.BaseType is not null)
+		{
+			if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason))
+			{
+				typeCache.Remove(typeDefinition);
+				typeStack.Pop();
+				result = null;
+				return false;
+			}
+			else
+			{
+				fields.EnsureCapacity(baseType.Fields.Count + typeDefinition.Fields.Count);
+				fields.AddRange(baseType.Fields);
+			}
+		}
+		else
+		{
+			fields.EnsureCapacity(typeDefinition.Fields.Count);
+		}
 
-                if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason))
-                {
-                        monoType.SetDepth();
+		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason))
+		{
+			monoType.SetDepth();
 
-                        if ((typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject())
-                                && monoType.HasSerializeReference)
-                        {
-                                fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
-                        }
+			if ((typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject())
+				&& monoType.HasSerializeReference)
+			{
+				fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
+			}
 
-                        typeStack.Pop();
-                        result = monoType;
-                        return true;
-                }
-                else
-                {
-                        typeCache.Remove(typeDefinition);
-                        typeStack.Pop();
-                        result = null;
-                        return false;
-                }
-        }
+			typeStack.Pop();
+			result = monoType;
+			return true;
+		}
+		else
+		{
+			typeCache.Remove(typeDefinition);
+			typeStack.Pop();
+			result = null;
+			return false;
+		}
+	}
 
-        private bool TryCreateSerializableType(
-                GenericInstanceTypeSignature genericInst,
-                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-                Stack<MonoType> typeStack,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
-                if (typeCache.TryGetValue(typeCacheKey, out SerializableType? cachedType))
-                {
-                        result = cachedType;
-                        failureReason = null;
-                        return true;
-                }
+	private bool TryCreateSerializableType(
+		GenericInstanceTypeSignature genericInst,
+		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+		Stack<MonoType> typeStack,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
+		if (typeCache.TryGetValue(typeCacheKey, out SerializableType? cachedType))
+		{
+			result = cachedType;
+			failureReason = null;
+			return true;
+		}
 
-                List<Field> fields = [];
+		List<Field> fields = [];
 
-                MonoType monoType = new(genericInst.GenericType, fields);
-                typeCache.Add(typeCacheKey, monoType);
-                typeStack.Push(monoType);
+		MonoType monoType = new(genericInst.GenericType, fields);
+		typeCache.Add(typeCacheKey, monoType);
+		typeStack.Push(monoType);
 
-                if (!TryGetBaseType(genericInst, out TypeSignature? baseType))
-                {
-                        typeCache.Remove(typeCacheKey);
-                        typeStack.Pop();
-                        result = null;
-                        failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
-                        return false;
-                }
-                else if (baseType is not null)
-                {
-                        if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason))
-                        {
-                                typeCache.Remove(typeCacheKey);
-                                typeStack.Pop();
-                                result = null;
-                                return false;
-                        }
-                        else
-                        {
-                                fields.EnsureCapacity(baseMonoType.Fields.Count + genericInst.GenericType.Resolve()!.Fields.Count);
-                                fields.AddRange(baseMonoType.Fields);
-                        }
-                }
-                else
-                {
-                        fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
-                }
+		if (!TryGetBaseType(genericInst, out TypeSignature? baseType))
+		{
+			typeCache.Remove(typeCacheKey);
+			typeStack.Pop();
+			result = null;
+			failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
+			return false;
+		}
+		else if (baseType is not null)
+		{
+			if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason))
+			{
+				typeCache.Remove(typeCacheKey);
+				typeStack.Pop();
+				result = null;
+				return false;
+			}
+			else
+			{
+				fields.EnsureCapacity(baseMonoType.Fields.Count + genericInst.GenericType.Resolve()!.Fields.Count);
+				fields.AddRange(baseMonoType.Fields);
+			}
+		}
+		else
+		{
+			fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
+		}
 
-                if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason))
-                {
-                        monoType.SetDepth();
-                        typeStack.Pop();
-                        result = monoType;
-                        return true;
-                }
-                else
-                {
-                        typeCache.Remove(typeCacheKey);
-                        typeStack.Pop();
-                        result = null;
-                        return false;
-                }
-        }
+		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason))
+		{
+			monoType.SetDepth();
+			typeStack.Pop();
+			result = monoType;
+			return true;
+		}
+		else
+		{
+			typeCache.Remove(typeCacheKey);
+			typeStack.Pop();
+			result = null;
+			return false;
+		}
+	}
 
-        private bool TryCreateSerializableFields(
-                Stack<MonoType> typeStack,
-                MonoType monoType,
-                List<Field> fields,
-                IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
-                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                foreach ((FieldDefinition, TypeSignature) pair in enumerable)
-                {
-                        (FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;
-                        if (WillUnitySerialize(fieldDefinition, fieldType))
-                        {
-                                if (fieldDefinition.HasSerializeReferenceAttribute())
-                                {
-                                        fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
-                                        continue;
-                                }
+	private bool TryCreateSerializableFields(
+		Stack<MonoType> typeStack,
+		MonoType monoType,
+		List<Field> fields,
+		IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
+		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		foreach ((FieldDefinition, TypeSignature) pair in enumerable)
+		{
+			(FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;
+			if (WillUnitySerialize(fieldDefinition, fieldType))
+			{
+				if (fieldDefinition.HasSerializeReferenceAttribute())
+				{
+					fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
+					continue;
+				}
 
-                                int arrayDepth = 0;
-                                if (fieldDefinition.HasFixedBufferAttribute())
-                                {
-                                        fieldType = fieldDefinition.GetFixedBufferElementType();
-                                        arrayDepth = 1;
-                                }
+				int arrayDepth = 0;
+				if (fieldDefinition.HasFixedBufferAttribute())
+				{
+					fieldType = fieldDefinition.GetFixedBufferElementType();
+					arrayDepth = 1;
+				}
 
-                                if (fieldType is CustomModifierTypeSignature customModifierType)
-                                {
-                                        fieldType = customModifierType.BaseType;
-                                }
+				if (fieldType is CustomModifierTypeSignature customModifierType)
+				{
+					fieldType = customModifierType.BaseType;
+				}
 
-                                if (TryCreateSerializableField(typeStack, fieldDefinition.Name ?? "", fieldType, arrayDepth, typeCache, out Field field, out failureReason))
-                                {
-                                        if (monoType.IsCyclicReference(field.Type))
-                                        {
-                                                // Infinite recursion disqualifies a field from serialization.
-                                        }
-                                        else if (!field.Type.IsMaxDepthKnown)
-                                        {
-                                                // New cycle reference detected.
-                                                List<MonoType> cycleList = new(typeStack.Count);
-                                                foreach (MonoType monoTypeInStack in typeStack)
-                                                {
-                                                        cycleList.Add(monoTypeInStack);
-                                                        if (monoTypeInStack == field.Type)
-                                                        {
-                                                                break;
-                                                        }
-                                                }
+				if (TryCreateSerializableField(typeStack, fieldDefinition.Name ?? "", fieldType, arrayDepth, typeCache, out Field field, out failureReason))
+				{
+					if (monoType.IsCyclicReference(field.Type))
+					{
+						// Infinite recursion disqualifies a field from serialization.
+					}
+					else if (!field.Type.IsMaxDepthKnown)
+					{
+						// New cycle reference detected.
+						List<MonoType> cycleList = new(typeStack.Count);
+						foreach (MonoType monoTypeInStack in typeStack)
+						{
+							cycleList.Add(monoTypeInStack);
+							if (monoTypeInStack == field.Type)
+							{
+								break;
+							}
+						}
 
-                                                for (int i = 0; i < cycleList.Count; i++)
-                                                {
-                                                        for (int j = 0; j <= i; j++)
-                                                        {
-                                                                SerializableType type1 = cycleList[i];
-                                                                SerializableType type2 = cycleList[j];
-                                                                type1.AddCyclicReference(type2);
-                                                                type2.AddCyclicReference(type1);
-                                                        }
-                                                }
-                                        }
-                                        else
-                                        {
-                                                fields.Add(field);
-                                        }
-                                }
-                                else
-                                {
-                                        return false;
-                                }
-                        }
-                }
-                failureReason = null;
-                return true;
-        }
+						for (int i = 0; i < cycleList.Count; i++)
+						{
+							for (int j = 0; j <= i; j++)
+							{
+								SerializableType type1 = cycleList[i];
+								SerializableType type2 = cycleList[j];
+								type1.AddCyclicReference(type2);
+								type2.AddCyclicReference(type1);
+							}
+						}
+					}
+					else
+					{
+						fields.Add(field);
+					}
+				}
+				else
+				{
+					return false;
+				}
+			}
+		}
+		failureReason = null;
+		return true;
+	}
 
-        private bool TryCreateSerializableField(
-                Stack<MonoType> typeStack,
-                string name,
-                TypeSignature typeSignature,
-                int arrayDepth,
-                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-                out Field result,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                switch (typeSignature)
-                {
-                        case TypeDefOrRefSignature typeDefOrRefSignature:
-                                TypeDefinition typeDefinition = typeDefOrRefSignature.Type.CheckedResolve();
-                                SerializableType fieldType;
-                                if (typeDefinition.IsEnum)
-                                {
-                                        CorLibTypeSignature enumValueType = (CorLibTypeSignature?)typeDefinition.GetEnumUnderlyingType() ?? throw new("Failed to resolve enum underlying type.");
-                                        PrimitiveType primitiveType = enumValueType.ToPrimitiveType();
-                                        fieldType = SerializablePrimitiveType.GetOrCreate(primitiveType);
-                                }
-                                else if (typeDefinition.InheritsFromObject())
-                                {
-                                        fieldType = SerializablePointerType.Shared;
-                                }
-                                else if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedMonoType))
-                                {
-                                        //This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
-                                        fieldType = cachedMonoType;
-                                }
-                                else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason))
-                                {
-                                        fieldType = monoType;
-                                }
-                                else
-                                {
-                                        result = default;
-                                        return false;
-                                }
+	private bool TryCreateSerializableField(
+		Stack<MonoType> typeStack,
+		string name,
+		TypeSignature typeSignature,
+		int arrayDepth,
+		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+		out Field result,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		switch (typeSignature)
+		{
+			case TypeDefOrRefSignature typeDefOrRefSignature:
+				TypeDefinition typeDefinition = typeDefOrRefSignature.Type.CheckedResolve();
+				SerializableType fieldType;
+				if (typeDefinition.IsEnum)
+				{
+					CorLibTypeSignature enumValueType = (CorLibTypeSignature?)typeDefinition.GetEnumUnderlyingType() ?? throw new("Failed to resolve enum underlying type.");
+					PrimitiveType primitiveType = enumValueType.ToPrimitiveType();
+					fieldType = SerializablePrimitiveType.GetOrCreate(primitiveType);
+				}
+				else if (typeDefinition.InheritsFromObject())
+				{
+					fieldType = SerializablePointerType.Shared;
+				}
+				else if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedMonoType))
+				{
+					//This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
+					fieldType = cachedMonoType;
+				}
+				else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason))
+				{
+					fieldType = monoType;
+				}
+				else
+				{
+					result = default;
+					return false;
+				}
 
-                                result = new Field(fieldType, arrayDepth, name, true);
-                                failureReason = null;
-                                return true;
+				result = new Field(fieldType, arrayDepth, name, true);
+				failureReason = null;
+				return true;
 
-                        case CorLibTypeSignature corLibTypeSignature:
-                                result = new Field(SerializablePrimitiveType.GetOrCreate(corLibTypeSignature.ToPrimitiveType()), arrayDepth, name, true);
-                                failureReason = null;
-                                return true;
+			case CorLibTypeSignature corLibTypeSignature:
+				result = new Field(SerializablePrimitiveType.GetOrCreate(corLibTypeSignature.ToPrimitiveType()), arrayDepth, name, true);
+				failureReason = null;
+				return true;
 
-                        case SzArrayTypeSignature szArrayTypeSignature:
-                                return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason);
+			case SzArrayTypeSignature szArrayTypeSignature:
+				return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason);
 
-                        case GenericInstanceTypeSignature genericInstanceTypeSignature:
-                                if (genericInstanceTypeSignature.InheritsFromObject())
-                                {
-                                        result = new Field(SerializablePointerType.Shared, arrayDepth, name, true);
-                                        failureReason = null;
-                                        return true;
-                                }
-                                else if (typeCache.TryGetValue(genericInstanceTypeSignature.ToTypeDefOrRef(), out SerializableType? cachedGenericMonoType))
-                                {
-                                        result = new Field(cachedGenericMonoType, arrayDepth, name, true);
-                                        failureReason = null;
-                                        return true;
-                                }
-                                else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
-                                {
-                                        return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason);
-                                }
-                                else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason))
-                                {
-                                        result = new(monoType, arrayDepth, name, true);
-                                        return true;
-                                }
-                                else
-                                {
-                                        result = default;
-                                        return false;
-                                }
+			case GenericInstanceTypeSignature genericInstanceTypeSignature:
+				if (genericInstanceTypeSignature.InheritsFromObject())
+				{
+					result = new Field(SerializablePointerType.Shared, arrayDepth, name, true);
+					failureReason = null;
+					return true;
+				}
+				else if (typeCache.TryGetValue(genericInstanceTypeSignature.ToTypeDefOrRef(), out SerializableType? cachedGenericMonoType))
+				{
+					result = new Field(cachedGenericMonoType, arrayDepth, name, true);
+					failureReason = null;
+					return true;
+				}
+				else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
+				{
+					return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason);
+				}
+				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason))
+				{
+					result = new(monoType, arrayDepth, name, true);
+					return true;
+				}
+				else
+				{
+					result = default;
+					return false;
+				}
 
-                        default:
-                                result = default;
-                                failureReason = $"{typeSignature.FullName} not supported.";
-                                return false;
-                }
-        }
+			default:
+				result = default;
+				failureReason = $"{typeSignature.FullName} not supported.";
+				return false;
+		}
+	}
 
-        private static bool TryGetBaseType(GenericInstanceTypeSignature genericInstanceType, out TypeSignature? baseType)
-        {
-                TypeDefinition? typeDefinition = genericInstanceType.GenericType.Resolve();
-                if (typeDefinition is null)
-                {
-                        baseType = null;
-                        return false;
-                }
+	private static bool TryGetBaseType(GenericInstanceTypeSignature genericInstanceType, out TypeSignature? baseType)
+	{
+		TypeDefinition? typeDefinition = genericInstanceType.GenericType.Resolve();
+		if (typeDefinition is null)
+		{
+			baseType = null;
+			return false;
+		}
 
-                baseType = typeDefinition.BaseType?.ToTypeSignature().InstantiateGenericTypes(new GenericContext(genericInstanceType, null));
-                return true;
-        }
+		baseType = typeDefinition.BaseType?.ToTypeSignature().InstantiateGenericTypes(new GenericContext(genericInstanceType, null));
+		return true;
+	}
 
-        private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(TypeDefinition typeDefinition)
-        {
-                return typeDefinition.Fields.Select(field =>
-                {
-                        TypeSignature fieldType = field.Signature!.FieldType;
-                        return (field, fieldType);
-                });
-        }
+	private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(TypeDefinition typeDefinition)
+	{
+		return typeDefinition.Fields.Select(field =>
+		{
+			TypeSignature fieldType = field.Signature!.FieldType;
+			return (field, fieldType);
+		});
+	}
 
-        private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(GenericInstanceTypeSignature genericInst)
-        {
-                TypeDefinition? typeDefinition = genericInst.Resolve();
-                if (typeDefinition is null)
-                {
-                        return [];
-                }
-                return typeDefinition.Fields.Select(field =>
-                {
-                        TypeSignature fieldType = field.Signature!.FieldType;
-                        GenericContext genericContext = new GenericContext(genericInst, null);
-                        TypeSignature instanceTypeSignature = fieldType.InstantiateGenericTypes(genericContext);
-                        return (field, instanceTypeSignature);
-                });
-        }
+	private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(GenericInstanceTypeSignature genericInst)
+	{
+		TypeDefinition? typeDefinition = genericInst.Resolve();
+		if (typeDefinition is null)
+		{
+			return [];
+		}
+		return typeDefinition.Fields.Select(field =>
+		{
+			TypeSignature fieldType = field.Signature!.FieldType;
+			GenericContext genericContext = new GenericContext(genericInst, null);
+			TypeSignature instanceTypeSignature = fieldType.InstantiateGenericTypes(genericContext);
+			return (field, instanceTypeSignature);
+		});
+	}
 }

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -351,7 +351,7 @@ public readonly partial struct FieldSerializer
 				{
 					return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
 				}
-				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason, out _))
+				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
 				{
 					result = new(monoType, arrayDepth, name, true);
 					return true;

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -104,12 +104,13 @@ public readonly partial struct FieldSerializer
 			fields.EnsureCapacity(typeDefinition.Fields.Count);
 		}
 
-		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason))
+		
+		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference))
 		{
 			monoType.SetDepth();
 
 			if ((typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject())
-				&& monoType.HasSerializeReference)
+				&& containsSerializeReference)
 			{
 				fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
 			}
@@ -176,7 +177,8 @@ public readonly partial struct FieldSerializer
 			fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
 		}
 
-		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason))
+		
+		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out _))
 		{
 			monoType.SetDepth();
 			typeStack.Pop();

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -112,6 +112,7 @@ public readonly partial struct FieldSerializer
 
 		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference))
 		{
+			containsSerializeReference |= containsSerializeReference2;
 			monoType.SetDepth();
 
 			if (containsSerializeReference && (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject()))

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -6,424 +6,389 @@ namespace AssetRipper.SerializationLogic;
 
 public readonly partial struct FieldSerializer
 {
-	private static bool HasSerializeReferenceRecursive(SerializableType type, HashSet<SerializableType> visited)
-	{
-		if (!visited.Add(type))
-		{
-			return false;
-		}
+        public bool TryCreateSerializableType(TypeDefinition typeDefinition,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                return TryCreateSerializableType(typeDefinition, new(SignatureComparer.Default), out result, out failureReason);
+        }
 
-		if (type.Type == PrimitiveType.Complex)
-		{
-			if (type.Name == "managedReference" || type.Name == "ReferencedObjectData")
-			{
-				return true;
-			}
-			foreach (SerializableType.Field field in type.Fields)
-			{
-				if (HasSerializeReferenceRecursive(field.Type, visited))
-				{
-					return true;
-				}
-			}
-		}
-		return false;
-	}
+        public bool TryCreateSerializableType(
+                TypeDefinition typeDefinition,
+                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                Stack<MonoType> typeStack = new();
+                bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
+                Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
+                return returnValue;
+        }
 
-	public bool TryCreateSerializableType(TypeDefinition typeDefinition,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		return TryCreateSerializableType(typeDefinition, new(SignatureComparer.Default), out result, out failureReason);
-	}
+        private bool TryCreateSerializableType(
+                TypeSignature typeSignature,
+                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+                Stack<MonoType> typeStack,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
+                {
+                        return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason);
+                }
+                TypeDefinition? typeDefinition = typeSignature.Resolve();
+                if (typeDefinition is null)
+                {
+                        result = null;
+                        failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
+                        return false;
+                }
+                else
+                {
+                        return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
+                }
+        }
 
-	public bool TryCreateSerializableType(
-		TypeDefinition typeDefinition,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		Stack<MonoType> typeStack = new();
-		bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
-		Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
-		return returnValue;
-	}
+        private bool TryCreateSerializableType(
+                TypeDefinition typeDefinition,
+                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+                Stack<MonoType> typeStack,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedType))
+                {
+                        result = cachedType;
+                        failureReason = null;
+                        return true;
+                }
+                if (typeDefinition.GenericParameters.Count > 0)
+                {
+                        result = null;
+                        failureReason = "Generic types are not serializable.";
+                        return false;
+                }
+                if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))
+                {
+                        result = SerializablePrimitiveType.GetOrCreate(primitiveType);
+                        typeCache.Add(typeDefinition, result);
+                        failureReason = null;
+                        return true;
+                }
 
-	private bool TryCreateSerializableType(
-		TypeSignature typeSignature,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		Stack<MonoType> typeStack,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
-		{
-			return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason);
-		}
-		TypeDefinition? typeDefinition = typeSignature.Resolve();
-		if (typeDefinition is null)
-		{
-			result = null;
-			failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
-			return false;
-		}
-		else
-		{
-			return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
-		}
-	}
+                //Ensure we allocate some initial space so that we have less chance of needing to resize the list.
+                List<Field> fields = [];
 
-	private bool TryCreateSerializableType(
-		TypeDefinition typeDefinition,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		Stack<MonoType> typeStack,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedType))
-		{
-			result = cachedType;
-			failureReason = null;
-			return true;
-		}
-		if (typeDefinition.GenericParameters.Count > 0)
-		{
-			result = null;
-			failureReason = "Generic types are not serializable.";
-			return false;
-		}
-		if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))
-		{
-			result = SerializablePrimitiveType.GetOrCreate(primitiveType);
-			typeCache.Add(typeDefinition, result);
-			failureReason = null;
-			return true;
-		}
+                //Caching before completion prevents infinite loops.
+                MonoType monoType = new(typeDefinition, fields);
+                typeCache.Add(typeDefinition, monoType);
+                typeStack.Push(monoType);
 
-		//Ensure we allocate some initial space so that we have less chance of needing to resize the list.
-		List<Field> fields = [];
+                if (typeDefinition.BaseType is not null)
+                {
+                        if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason))
+                        {
+                                typeCache.Remove(typeDefinition);
+                                typeStack.Pop();
+                                result = null;
+                                return false;
+                        }
+                        else
+                        {
+                                fields.EnsureCapacity(baseType.Fields.Count + typeDefinition.Fields.Count);
+                                fields.AddRange(baseType.Fields);
+                        }
+                }
+                else
+                {
+                        fields.EnsureCapacity(typeDefinition.Fields.Count);
+                }
 
-		//Caching before completion prevents infinite loops.
-		MonoType monoType = new(typeDefinition, fields);
-		typeCache.Add(typeDefinition, monoType);
-		typeStack.Push(monoType);
+                if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason))
+                {
+                        monoType.SetDepth();
 
-		if (typeDefinition.BaseType is not null)
-		{
-			if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason))
-			{
-				typeCache.Remove(typeDefinition);
-				typeStack.Pop();
-				result = null;
-				return false;
-			}
-			else
-			{
-				fields.EnsureCapacity(baseType.Fields.Count + typeDefinition.Fields.Count);
-				fields.AddRange(baseType.Fields);
-			}
-		}
-		else
-		{
-			fields.EnsureCapacity(typeDefinition.Fields.Count);
-		}
+                        if ((typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject())
+                                && monoType.HasSerializeReference)
+                        {
+                                fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
+                        }
 
-		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason))
-		{
-			if (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject())
-			{
-				bool hasSerializeReference = false;
-				HashSet<SerializableType> visited = new();
-				foreach (Field field in fields)
-				{
-					if (HasSerializeReferenceRecursive(field.Type, visited))
-					{
-						hasSerializeReference = true;
-						break;
-					}
-				}
+                        typeStack.Pop();
+                        result = monoType;
+                        return true;
+                }
+                else
+                {
+                        typeCache.Remove(typeDefinition);
+                        typeStack.Pop();
+                        result = null;
+                        return false;
+                }
+        }
 
-				if (hasSerializeReference)
-				{
-					fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
-				}
-			}
-			monoType.SetDepth();
-			typeStack.Pop();
-			result = monoType;
-			return true;
-		}
-		else
-		{
-			typeCache.Remove(typeDefinition);
-			typeStack.Pop();
-			result = null;
-			return false;
-		}
-	}
+        private bool TryCreateSerializableType(
+                GenericInstanceTypeSignature genericInst,
+                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+                Stack<MonoType> typeStack,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
+                if (typeCache.TryGetValue(typeCacheKey, out SerializableType? cachedType))
+                {
+                        result = cachedType;
+                        failureReason = null;
+                        return true;
+                }
 
-	private bool TryCreateSerializableType(
-		GenericInstanceTypeSignature genericInst,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		Stack<MonoType> typeStack,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
-		if (typeCache.TryGetValue(typeCacheKey, out SerializableType? cachedType))
-		{
-			result = cachedType;
-			failureReason = null;
-			return true;
-		}
+                List<Field> fields = [];
 
-		List<Field> fields = [];
+                MonoType monoType = new(genericInst.GenericType, fields);
+                typeCache.Add(typeCacheKey, monoType);
+                typeStack.Push(monoType);
 
-		MonoType monoType = new(genericInst.GenericType, fields);
-		typeCache.Add(typeCacheKey, monoType);
-		typeStack.Push(monoType);
+                if (!TryGetBaseType(genericInst, out TypeSignature? baseType))
+                {
+                        typeCache.Remove(typeCacheKey);
+                        typeStack.Pop();
+                        result = null;
+                        failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
+                        return false;
+                }
+                else if (baseType is not null)
+                {
+                        if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason))
+                        {
+                                typeCache.Remove(typeCacheKey);
+                                typeStack.Pop();
+                                result = null;
+                                return false;
+                        }
+                        else
+                        {
+                                fields.EnsureCapacity(baseMonoType.Fields.Count + genericInst.GenericType.Resolve()!.Fields.Count);
+                                fields.AddRange(baseMonoType.Fields);
+                        }
+                }
+                else
+                {
+                        fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
+                }
 
-		if (!TryGetBaseType(genericInst, out TypeSignature? baseType))
-		{
-			typeCache.Remove(typeCacheKey);
-			typeStack.Pop();
-			result = null;
-			failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
-			return false;
-		}
-		else if (baseType is not null)
-		{
-			if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason))
-			{
-				typeCache.Remove(typeCacheKey);
-				typeStack.Pop();
-				result = null;
-				return false;
-			}
-			else
-			{
-				fields.EnsureCapacity(baseMonoType.Fields.Count + genericInst.GenericType.Resolve()!.Fields.Count);
-				fields.AddRange(baseMonoType.Fields);
-			}
-		}
-		else
-		{
-			fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
-		}
+                if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason))
+                {
+                        monoType.SetDepth();
+                        typeStack.Pop();
+                        result = monoType;
+                        return true;
+                }
+                else
+                {
+                        typeCache.Remove(typeCacheKey);
+                        typeStack.Pop();
+                        result = null;
+                        return false;
+                }
+        }
 
-		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason))
-		{
-			monoType.SetDepth();
-			typeStack.Pop();
-			result = monoType;
-			return true;
-		}
-		else
-		{
-			typeCache.Remove(typeCacheKey);
-			typeStack.Pop();
-			result = null;
-			return false;
-		}
-	}
+        private bool TryCreateSerializableFields(
+                Stack<MonoType> typeStack,
+                MonoType monoType,
+                List<Field> fields,
+                IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
+                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                foreach ((FieldDefinition, TypeSignature) pair in enumerable)
+                {
+                        (FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;
+                        if (WillUnitySerialize(fieldDefinition, fieldType))
+                        {
+                                if (fieldDefinition.HasSerializeReferenceAttribute())
+                                {
+                                        fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
+                                        continue;
+                                }
 
-	private bool TryCreateSerializableFields(
-		Stack<MonoType> typeStack,
-		MonoType monoType,
-		List<Field> fields,
-		IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		foreach ((FieldDefinition, TypeSignature) pair in enumerable)
-		{
-			(FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;
-			if (WillUnitySerialize(fieldDefinition, fieldType))
-			{
-				if (fieldDefinition.HasSerializeReferenceAttribute())
-				{
-					fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
-					continue;
-				}
+                                int arrayDepth = 0;
+                                if (fieldDefinition.HasFixedBufferAttribute())
+                                {
+                                        fieldType = fieldDefinition.GetFixedBufferElementType();
+                                        arrayDepth = 1;
+                                }
 
-				int arrayDepth = 0;
-				if (fieldDefinition.HasFixedBufferAttribute())
-				{
-					fieldType = fieldDefinition.GetFixedBufferElementType();
-					arrayDepth = 1;
-				}
+                                if (fieldType is CustomModifierTypeSignature customModifierType)
+                                {
+                                        fieldType = customModifierType.BaseType;
+                                }
 
-				if (fieldType is CustomModifierTypeSignature customModifierType)
-				{
-					fieldType = customModifierType.BaseType;
-				}
+                                if (TryCreateSerializableField(typeStack, fieldDefinition.Name ?? "", fieldType, arrayDepth, typeCache, out Field field, out failureReason))
+                                {
+                                        if (monoType.IsCyclicReference(field.Type))
+                                        {
+                                                // Infinite recursion disqualifies a field from serialization.
+                                        }
+                                        else if (!field.Type.IsMaxDepthKnown)
+                                        {
+                                                // New cycle reference detected.
+                                                List<MonoType> cycleList = new(typeStack.Count);
+                                                foreach (MonoType monoTypeInStack in typeStack)
+                                                {
+                                                        cycleList.Add(monoTypeInStack);
+                                                        if (monoTypeInStack == field.Type)
+                                                        {
+                                                                break;
+                                                        }
+                                                }
 
-				if (TryCreateSerializableField(typeStack, fieldDefinition.Name ?? "", fieldType, arrayDepth, typeCache, out Field field, out failureReason))
-				{
-					if (monoType.IsCyclicReference(field.Type))
-					{
-						// Infinite recursion disqualifies a field from serialization.
-					}
-					else if (!field.Type.IsMaxDepthKnown)
-					{
-						// New cycle reference detected.
-						List<MonoType> cycleList = new(typeStack.Count);
-						foreach (MonoType monoTypeInStack in typeStack)
-						{
-							cycleList.Add(monoTypeInStack);
-							if (monoTypeInStack == field.Type)
-							{
-								break;
-							}
-						}
+                                                for (int i = 0; i < cycleList.Count; i++)
+                                                {
+                                                        for (int j = 0; j <= i; j++)
+                                                        {
+                                                                SerializableType type1 = cycleList[i];
+                                                                SerializableType type2 = cycleList[j];
+                                                                type1.AddCyclicReference(type2);
+                                                                type2.AddCyclicReference(type1);
+                                                        }
+                                                }
+                                        }
+                                        else
+                                        {
+                                                fields.Add(field);
+                                        }
+                                }
+                                else
+                                {
+                                        return false;
+                                }
+                        }
+                }
+                failureReason = null;
+                return true;
+        }
 
-						for (int i = 0; i < cycleList.Count; i++)
-						{
-							for (int j = 0; j <= i; j++)
-							{
-								SerializableType type1 = cycleList[i];
-								SerializableType type2 = cycleList[j];
-								type1.AddCyclicReference(type2);
-								type2.AddCyclicReference(type1);
-							}
-						}
-					}
-					else
-					{
-						fields.Add(field);
-					}
-				}
-				else
-				{
-					return false;
-				}
-			}
-		}
-		failureReason = null;
-		return true;
-	}
+        private bool TryCreateSerializableField(
+                Stack<MonoType> typeStack,
+                string name,
+                TypeSignature typeSignature,
+                int arrayDepth,
+                Dictionary<ITypeDefOrRef, SerializableType> typeCache,
+                out Field result,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                switch (typeSignature)
+                {
+                        case TypeDefOrRefSignature typeDefOrRefSignature:
+                                TypeDefinition typeDefinition = typeDefOrRefSignature.Type.CheckedResolve();
+                                SerializableType fieldType;
+                                if (typeDefinition.IsEnum)
+                                {
+                                        CorLibTypeSignature enumValueType = (CorLibTypeSignature?)typeDefinition.GetEnumUnderlyingType() ?? throw new("Failed to resolve enum underlying type.");
+                                        PrimitiveType primitiveType = enumValueType.ToPrimitiveType();
+                                        fieldType = SerializablePrimitiveType.GetOrCreate(primitiveType);
+                                }
+                                else if (typeDefinition.InheritsFromObject())
+                                {
+                                        fieldType = SerializablePointerType.Shared;
+                                }
+                                else if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedMonoType))
+                                {
+                                        //This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
+                                        fieldType = cachedMonoType;
+                                }
+                                else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason))
+                                {
+                                        fieldType = monoType;
+                                }
+                                else
+                                {
+                                        result = default;
+                                        return false;
+                                }
 
-	private bool TryCreateSerializableField(
-		Stack<MonoType> typeStack,
-		string name,
-		TypeSignature typeSignature,
-		int arrayDepth,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		out Field result,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		switch (typeSignature)
-		{
-			case TypeDefOrRefSignature typeDefOrRefSignature:
-				TypeDefinition typeDefinition = typeDefOrRefSignature.Type.CheckedResolve();
-				SerializableType fieldType;
-				if (typeDefinition.IsEnum)
-				{
-					CorLibTypeSignature enumValueType = (CorLibTypeSignature?)typeDefinition.GetEnumUnderlyingType() ?? throw new("Failed to resolve enum underlying type.");
-					PrimitiveType primitiveType = enumValueType.ToPrimitiveType();
-					fieldType = SerializablePrimitiveType.GetOrCreate(primitiveType);
-				}
-				else if (typeDefinition.InheritsFromObject())
-				{
-					fieldType = SerializablePointerType.Shared;
-				}
-				else if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedMonoType))
-				{
-					//This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
-					fieldType = cachedMonoType;
-				}
-				else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason))
-				{
-					fieldType = monoType;
-				}
-				else
-				{
-					result = default;
-					return false;
-				}
+                                result = new Field(fieldType, arrayDepth, name, true);
+                                failureReason = null;
+                                return true;
 
-				result = new Field(fieldType, arrayDepth, name, true);
-				failureReason = null;
-				return true;
+                        case CorLibTypeSignature corLibTypeSignature:
+                                result = new Field(SerializablePrimitiveType.GetOrCreate(corLibTypeSignature.ToPrimitiveType()), arrayDepth, name, true);
+                                failureReason = null;
+                                return true;
 
-			case CorLibTypeSignature corLibTypeSignature:
-				result = new Field(SerializablePrimitiveType.GetOrCreate(corLibTypeSignature.ToPrimitiveType()), arrayDepth, name, true);
-				failureReason = null;
-				return true;
+                        case SzArrayTypeSignature szArrayTypeSignature:
+                                return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason);
 
-			case SzArrayTypeSignature szArrayTypeSignature:
-				return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason);
+                        case GenericInstanceTypeSignature genericInstanceTypeSignature:
+                                if (genericInstanceTypeSignature.InheritsFromObject())
+                                {
+                                        result = new Field(SerializablePointerType.Shared, arrayDepth, name, true);
+                                        failureReason = null;
+                                        return true;
+                                }
+                                else if (typeCache.TryGetValue(genericInstanceTypeSignature.ToTypeDefOrRef(), out SerializableType? cachedGenericMonoType))
+                                {
+                                        result = new Field(cachedGenericMonoType, arrayDepth, name, true);
+                                        failureReason = null;
+                                        return true;
+                                }
+                                else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
+                                {
+                                        return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason);
+                                }
+                                else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason))
+                                {
+                                        result = new(monoType, arrayDepth, name, true);
+                                        return true;
+                                }
+                                else
+                                {
+                                        result = default;
+                                        return false;
+                                }
 
-			case GenericInstanceTypeSignature genericInstanceTypeSignature:
-				if (genericInstanceTypeSignature.InheritsFromObject())
-				{
-					result = new Field(SerializablePointerType.Shared, arrayDepth, name, true);
-					failureReason = null;
-					return true;
-				}
-				else if (typeCache.TryGetValue(genericInstanceTypeSignature.ToTypeDefOrRef(), out SerializableType? cachedGenericMonoType))
-				{
-					result = new Field(cachedGenericMonoType, arrayDepth, name, true);
-					failureReason = null;
-					return true;
-				}
-				else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
-				{
-					return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason);
-				}
-				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason))
-				{
-					result = new(monoType, arrayDepth, name, true);
-					return true;
-				}
-				else
-				{
-					result = default;
-					return false;
-				}
+                        default:
+                                result = default;
+                                failureReason = $"{typeSignature.FullName} not supported.";
+                                return false;
+                }
+        }
 
-			default:
-				result = default;
-				failureReason = $"{typeSignature.FullName} not supported.";
-				return false;
-		}
-	}
+        private static bool TryGetBaseType(GenericInstanceTypeSignature genericInstanceType, out TypeSignature? baseType)
+        {
+                TypeDefinition? typeDefinition = genericInstanceType.GenericType.Resolve();
+                if (typeDefinition is null)
+                {
+                        baseType = null;
+                        return false;
+                }
 
-	private static bool TryGetBaseType(GenericInstanceTypeSignature genericInstanceType, out TypeSignature? baseType)
-	{
-		TypeDefinition? typeDefinition = genericInstanceType.GenericType.Resolve();
-		if (typeDefinition is null)
-		{
-			baseType = null;
-			return false;
-		}
+                baseType = typeDefinition.BaseType?.ToTypeSignature().InstantiateGenericTypes(new GenericContext(genericInstanceType, null));
+                return true;
+        }
 
-		baseType = typeDefinition.BaseType?.ToTypeSignature().InstantiateGenericTypes(new GenericContext(genericInstanceType, null));
-		return true;
-	}
+        private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(TypeDefinition typeDefinition)
+        {
+                return typeDefinition.Fields.Select(field =>
+                {
+                        TypeSignature fieldType = field.Signature!.FieldType;
+                        return (field, fieldType);
+                });
+        }
 
-	private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(TypeDefinition typeDefinition)
-	{
-		return typeDefinition.Fields.Select(field =>
-		{
-			TypeSignature fieldType = field.Signature!.FieldType;
-			return (field, fieldType);
-		});
-	}
-
-	private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(GenericInstanceTypeSignature genericInst)
-	{
-		TypeDefinition? typeDefinition = genericInst.Resolve();
-		if (typeDefinition is null)
-		{
-			return [];
-		}
-		return typeDefinition.Fields.Select(field =>
-		{
-			TypeSignature fieldType = field.Signature!.FieldType;
-			GenericContext genericContext = new GenericContext(genericInst, null);
-			TypeSignature instanceTypeSignature = fieldType.InstantiateGenericTypes(genericContext);
-			return (field, instanceTypeSignature);
-		});
-	}
+        private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(GenericInstanceTypeSignature genericInst)
+        {
+                TypeDefinition? typeDefinition = genericInst.Resolve();
+                if (typeDefinition is null)
+                {
+                        return [];
+                }
+                return typeDefinition.Fields.Select(field =>
+                {
+                        TypeSignature fieldType = field.Signature!.FieldType;
+                        GenericContext genericContext = new GenericContext(genericInst, null);
+                        TypeSignature instanceTypeSignature = fieldType.InstantiateGenericTypes(genericContext);
+                        return (field, instanceTypeSignature);
+                });
+        }
 }

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -63,6 +63,7 @@ public readonly partial struct FieldSerializer
 		{
 			result = cachedType;
 			failureReason = null;
+			containsSerializeReference = default;
 			return true;
 		}
 		if (typeDefinition.GenericParameters.Count > 0)

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -132,7 +132,8 @@ public readonly partial struct FieldSerializer
 		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
 		Stack<MonoType> typeStack,
 		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
 	{
 		ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
 		if (typeCache.TryGetValue(typeCacheKey, out SerializableType? cachedType))

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -78,6 +78,7 @@ public readonly partial struct FieldSerializer
 			result = SerializablePrimitiveType.GetOrCreate(primitiveType);
 			typeCache.Add(typeDefinition, result);
 			failureReason = null;
+			containsSerializeReference = false;
 			return true;
 		}
 
@@ -146,6 +147,7 @@ public readonly partial struct FieldSerializer
 		{
 			result = cachedType;
 			failureReason = null;
+			containsSerializeReference = default;
 			return true;
 		}
 
@@ -185,7 +187,7 @@ public readonly partial struct FieldSerializer
 			containsSerializeReference = false;
 		}
 
-		
+
 		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out bool containsSerializeReference2))
 		{
 			containsSerializeReference |= containsSerializeReference2;
@@ -311,7 +313,7 @@ public readonly partial struct FieldSerializer
 					//This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
 					fieldType = cachedMonoType;
 				}
-				else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason))
+				else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason, out _))
 				{
 					fieldType = monoType;
 				}
@@ -350,7 +352,7 @@ public readonly partial struct FieldSerializer
 				{
 					return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason);
 				}
-				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason))
+				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason, out _))
 				{
 					result = new(monoType, arrayDepth, name, true);
 					return true;

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -198,7 +198,8 @@ public readonly partial struct FieldSerializer
 		List<Field> fields,
 		IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
 		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		[NotNullWhen(false)] out string? failureReason)
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
 	{
 		containsSerializeReference = false;
 		foreach ((FieldDefinition, TypeSignature) pair in enumerable)

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -332,7 +332,7 @@ public readonly partial struct FieldSerializer
 				return true;
 
 			case SzArrayTypeSignature szArrayTypeSignature:
-				return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason);
+				return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
 
 			case GenericInstanceTypeSignature genericInstanceTypeSignature:
 				if (genericInstanceTypeSignature.InheritsFromObject())

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -15,7 +15,7 @@ public readonly partial struct FieldSerializer
 
 		if (type.Type == PrimitiveType.Complex)
 		{
-			if (type.Name == "managedReference")
+			if (type.Name == "managedReference" || type.Name == "ReferencedObjectData")
 			{
 				return true;
 			}

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -41,6 +41,7 @@ public readonly partial struct FieldSerializer
 		{
 			result = null;
 			failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
+			containsSerializeReference = default;
 			return false;
 		}
 		else

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -290,7 +290,8 @@ public readonly partial struct FieldSerializer
 		int arrayDepth,
 		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
 		out Field result,
-		[NotNullWhen(false)] out string? failureReason)
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
 	{
 		switch (typeSignature)
 		{

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -154,6 +154,7 @@ public readonly partial struct FieldSerializer
 			typeStack.Pop();
 			result = null;
 			failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
+			containsSerializeReference = default;
 			return false;
 		}
 		else if (baseType is not null)

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -177,7 +177,7 @@ public readonly partial struct FieldSerializer
 		}
 
 		
-		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out _))
+		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out bool containsSerializeReference2))
 		{
 			containsSerializeReference |= containsSerializeReference2;
 			monoType.SetDepth();

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -68,6 +68,7 @@ public readonly partial struct FieldSerializer
 		{
 			result = null;
 			failureReason = "Generic types are not serializable.";
+			containsSerializeReference = default;
 			return false;
 		}
 		if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -113,8 +113,7 @@ public readonly partial struct FieldSerializer
 		{
 			monoType.SetDepth();
 
-			if ((typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject())
-				&& containsSerializeReference)
+			if (containsSerializeReference && (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject()))
 			{
 				fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
 			}

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -130,20 +130,23 @@ public readonly partial struct FieldSerializer
 
 		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason))
 		{
-			bool hasSerializeReference = false;
-			HashSet<SerializableType> visited = new();
-			foreach (Field field in fields)
+			if (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject())
 			{
-				if (HasSerializeReferenceRecursive(field.Type, visited))
+				bool hasSerializeReference = false;
+				HashSet<SerializableType> visited = new();
+				foreach (Field field in fields)
 				{
-					hasSerializeReference = true;
-					break;
+					if (HasSerializeReferenceRecursive(field.Type, visited))
+					{
+						hasSerializeReference = true;
+						break;
+					}
 				}
-			}
 
-			if (hasSerializeReference && (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject()))
-			{
-				fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
+				if (hasSerializeReference)
+				{
+					fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
+				}
 			}
 			monoType.SetDepth();
 			typeStack.Pop();

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -104,7 +104,6 @@ public readonly partial struct FieldSerializer
 			fields.EnsureCapacity(typeDefinition.Fields.Count);
 		}
 
-		
 		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference))
 		{
 			monoType.SetDepth();

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -46,7 +46,7 @@ public readonly partial struct FieldSerializer
 		}
 		else
 		{
-			return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
+			return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
 		}
 	}
 

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -20,7 +20,7 @@ public readonly partial struct FieldSerializer
 		[NotNullWhen(false)] out string? failureReason)
 	{
 		Stack<MonoType> typeStack = new();
-		bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason);
+		bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out _);
 		Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
 		return returnValue;
 	}

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -6,415 +6,415 @@ namespace AssetRipper.SerializationLogic;
 
 public readonly partial struct FieldSerializer
 {
-        public bool TryCreateSerializableType(TypeDefinition typeDefinition,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                return TryCreateSerializableType(typeDefinition, new(SignatureComparer.Default), out result, out failureReason);
-        }
+	public bool TryCreateSerializableType(TypeDefinition typeDefinition,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		return TryCreateSerializableType(typeDefinition, new(SignatureComparer.Default), out result, out failureReason);
+	}
 
-        public bool TryCreateSerializableType(
-                TypeDefinition typeDefinition,
-                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason)
-        {
-                Stack<MonoType> typeStack = new();
-                bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out _);
-                Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
-                return returnValue;
-        }
+	public bool TryCreateSerializableType(
+		TypeDefinition typeDefinition,
+		Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason)
+	{
+		Stack<MonoType> typeStack = new();
+		bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out _);
+		Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
+		return returnValue;
+	}
 
-        private bool TryCreateSerializableType(
-                TypeSignature typeSignature,
-                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
-                Stack<MonoType> typeStack,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason,
-                out bool containsSerializeReference)
-        {
-                if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
-                {
-                        return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
-                }
-                TypeDefinition? typeDefinition = typeSignature.Resolve();
-                if (typeDefinition is null)
-                {
-                        result = null;
-                        failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
-                        containsSerializeReference = default;
-                        return false;
-                }
-                else
-                {
-                        return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
-                }
-        }
+	private bool TryCreateSerializableType(
+		TypeSignature typeSignature,
+		Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+		Stack<MonoType> typeStack,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
+	{
+		if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
+		{
+			return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
+		}
+		TypeDefinition? typeDefinition = typeSignature.Resolve();
+		if (typeDefinition is null)
+		{
+			result = null;
+			failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
+			containsSerializeReference = default;
+			return false;
+		}
+		else
+		{
+			return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
+		}
+	}
 
-        private bool TryCreateSerializableType(
-                TypeDefinition typeDefinition,
-                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
-                Stack<MonoType> typeStack,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason,
-                out bool containsSerializeReference)
-        {
-                if (typeCache.TryGetValue(typeDefinition, out (SerializableType, bool) cachedEntry))
-                {
-                        result = cachedEntry.Item1;
-                        failureReason = null;
-                        containsSerializeReference = cachedEntry.Item2;
-                        return true;
-                }
-                if (typeDefinition.GenericParameters.Count > 0)
-                {
-                        result = null;
-                        failureReason = "Generic types are not serializable.";
-                        containsSerializeReference = default;
-                        return false;
-                }
-                if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))
-                {
-                        result = SerializablePrimitiveType.GetOrCreate(primitiveType);
-                        typeCache.Add(typeDefinition, (result, false));
-                        failureReason = null;
-                        containsSerializeReference = false;
-                        return true;
-                }
+	private bool TryCreateSerializableType(
+		TypeDefinition typeDefinition,
+		Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+		Stack<MonoType> typeStack,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
+	{
+		if (typeCache.TryGetValue(typeDefinition, out (SerializableType, bool) cachedEntry))
+		{
+			result = cachedEntry.Item1;
+			failureReason = null;
+			containsSerializeReference = cachedEntry.Item2;
+			return true;
+		}
+		if (typeDefinition.GenericParameters.Count > 0)
+		{
+			result = null;
+			failureReason = "Generic types are not serializable.";
+			containsSerializeReference = default;
+			return false;
+		}
+		if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))
+		{
+			result = SerializablePrimitiveType.GetOrCreate(primitiveType);
+			typeCache.Add(typeDefinition, (result, false));
+			failureReason = null;
+			containsSerializeReference = false;
+			return true;
+		}
 
-                //Ensure we allocate some initial space so that we have less chance of needing to resize the list.
-                List<Field> fields = [];
+		//Ensure we allocate some initial space so that we have less chance of needing to resize the list.
+		List<Field> fields = [];
 
-                //Caching before completion prevents infinite loops.
-                MonoType monoType = new(typeDefinition, fields);
-                typeCache.Add(typeDefinition, (monoType, false));
-                typeStack.Push(monoType);
+		//Caching before completion prevents infinite loops.
+		MonoType monoType = new(typeDefinition, fields);
+		typeCache.Add(typeDefinition, (monoType, false));
+		typeStack.Push(monoType);
 
-                if (typeDefinition.BaseType is not null)
-                {
-                        if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason, out containsSerializeReference))
-                        {
-                                typeCache.Remove(typeDefinition);
-                                typeStack.Pop();
-                                result = null;
-                                return false;
-                        }
-                        else
-                        {
-                                fields.EnsureCapacity(baseType.Fields.Count + typeDefinition.Fields.Count);
-                                fields.AddRange(baseType.Fields);
-                        }
-                }
-                else
-                {
-                        fields.EnsureCapacity(typeDefinition.Fields.Count);
-                        containsSerializeReference = false;
-                }
+		if (typeDefinition.BaseType is not null)
+		{
+			if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason, out containsSerializeReference))
+			{
+				typeCache.Remove(typeDefinition);
+				typeStack.Pop();
+				result = null;
+				return false;
+			}
+			else
+			{
+				fields.EnsureCapacity(baseType.Fields.Count + typeDefinition.Fields.Count);
+				fields.AddRange(baseType.Fields);
+			}
+		}
+		else
+		{
+			fields.EnsureCapacity(typeDefinition.Fields.Count);
+			containsSerializeReference = false;
+		}
 
-                if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference2))
-                {
-                        containsSerializeReference |= containsSerializeReference2;
-                        monoType.SetDepth();
+		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference2))
+		{
+			containsSerializeReference |= containsSerializeReference2;
+			monoType.SetDepth();
 
-                        if (containsSerializeReference && (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject()))
-                        {
-                                fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
-                        }
+			if (containsSerializeReference && (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject()))
+			{
+				fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
+			}
 
-                        typeCache[typeDefinition] = (monoType, containsSerializeReference);
-                        typeStack.Pop();
-                        result = monoType;
-                        return true;
-                }
-                else
-                {
-                        typeCache.Remove(typeDefinition);
-                        typeStack.Pop();
-                        result = null;
-                        return false;
-                }
-        }
+			typeCache[typeDefinition] = (monoType, containsSerializeReference);
+			typeStack.Pop();
+			result = monoType;
+			return true;
+		}
+		else
+		{
+			typeCache.Remove(typeDefinition);
+			typeStack.Pop();
+			result = null;
+			return false;
+		}
+	}
 
-        private bool TryCreateSerializableType(
-                GenericInstanceTypeSignature genericInst,
-                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
-                Stack<MonoType> typeStack,
-                [NotNullWhen(true)] out SerializableType? result,
-                [NotNullWhen(false)] out string? failureReason,
-                out bool containsSerializeReference)
-        {
-                ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
-                if (typeCache.TryGetValue(typeCacheKey, out (SerializableType, bool) cachedEntry))
-                {
-                        result = cachedEntry.Item1;
-                        failureReason = null;
-                        containsSerializeReference = cachedEntry.Item2;
-                        return true;
-                }
+	private bool TryCreateSerializableType(
+		GenericInstanceTypeSignature genericInst,
+		Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+		Stack<MonoType> typeStack,
+		[NotNullWhen(true)] out SerializableType? result,
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
+	{
+		ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
+		if (typeCache.TryGetValue(typeCacheKey, out (SerializableType, bool) cachedEntry))
+		{
+			result = cachedEntry.Item1;
+			failureReason = null;
+			containsSerializeReference = cachedEntry.Item2;
+			return true;
+		}
 
-                List<Field> fields = [];
+		List<Field> fields = [];
 
-                MonoType monoType = new(genericInst.GenericType, fields);
-                typeCache.Add(typeCacheKey, (monoType, false));
-                typeStack.Push(monoType);
+		MonoType monoType = new(genericInst.GenericType, fields);
+		typeCache.Add(typeCacheKey, (monoType, false));
+		typeStack.Push(monoType);
 
-                if (!TryGetBaseType(genericInst, out TypeSignature? baseType))
-                {
-                        typeCache.Remove(typeCacheKey);
-                        typeStack.Pop();
-                        result = null;
-                        failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
-                        containsSerializeReference = default;
-                        return false;
-                }
-                else if (baseType is not null)
-                {
-                        if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason, out containsSerializeReference))
-                        {
-                                typeCache.Remove(typeCacheKey);
-                                typeStack.Pop();
-                                result = null;
-                                return false;
-                        }
-                        else
-                        {
-                                fields.EnsureCapacity(baseMonoType.Fields.Count + genericInst.GenericType.Resolve()!.Fields.Count);
-                                fields.AddRange(baseMonoType.Fields);
-                        }
-                }
-                else
-                {
-                        fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
-                        containsSerializeReference = false;
-                }
+		if (!TryGetBaseType(genericInst, out TypeSignature? baseType))
+		{
+			typeCache.Remove(typeCacheKey);
+			typeStack.Pop();
+			result = null;
+			failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
+			containsSerializeReference = default;
+			return false;
+		}
+		else if (baseType is not null)
+		{
+			if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason, out containsSerializeReference))
+			{
+				typeCache.Remove(typeCacheKey);
+				typeStack.Pop();
+				result = null;
+				return false;
+			}
+			else
+			{
+				fields.EnsureCapacity(baseMonoType.Fields.Count + genericInst.GenericType.Resolve()!.Fields.Count);
+				fields.AddRange(baseMonoType.Fields);
+			}
+		}
+		else
+		{
+			fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
+			containsSerializeReference = false;
+		}
 
-                if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out bool containsSerializeReference2))
-                {
-                        containsSerializeReference |= containsSerializeReference2;
-                        monoType.SetDepth();
-                        typeCache[typeCacheKey] = (monoType, containsSerializeReference);
-                        typeStack.Pop();
-                        result = monoType;
-                        return true;
-                }
-                else
-                {
-                        typeCache.Remove(typeCacheKey);
-                        typeStack.Pop();
-                        result = null;
-                        return false;
-                }
-        }
+		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out bool containsSerializeReference2))
+		{
+			containsSerializeReference |= containsSerializeReference2;
+			monoType.SetDepth();
+			typeCache[typeCacheKey] = (monoType, containsSerializeReference);
+			typeStack.Pop();
+			result = monoType;
+			return true;
+		}
+		else
+		{
+			typeCache.Remove(typeCacheKey);
+			typeStack.Pop();
+			result = null;
+			return false;
+		}
+	}
 
-        private bool TryCreateSerializableFields(
-                Stack<MonoType> typeStack,
-                MonoType monoType,
-                List<Field> fields,
-                IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
-                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
-                [NotNullWhen(false)] out string? failureReason,
-                out bool containsSerializeReference)
-        {
-                containsSerializeReference = false;
-                foreach ((FieldDefinition, TypeSignature) pair in enumerable)
-                {
-                        (FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;
-                        if (WillUnitySerialize(fieldDefinition, fieldType))
-                        {
-                                if (fieldDefinition.HasSerializeReferenceAttribute())
-                                {
-                                        fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
-                                        containsSerializeReference = true;
-                                        continue;
-                                }
+	private bool TryCreateSerializableFields(
+		Stack<MonoType> typeStack,
+		MonoType monoType,
+		List<Field> fields,
+		IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
+		Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
+	{
+		containsSerializeReference = false;
+		foreach ((FieldDefinition, TypeSignature) pair in enumerable)
+		{
+			(FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;
+			if (WillUnitySerialize(fieldDefinition, fieldType))
+			{
+				if (fieldDefinition.HasSerializeReferenceAttribute())
+				{
+					fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
+					containsSerializeReference = true;
+					continue;
+				}
 
-                                int arrayDepth = 0;
-                                if (fieldDefinition.HasFixedBufferAttribute())
-                                {
-                                        fieldType = fieldDefinition.GetFixedBufferElementType();
-                                        arrayDepth = 1;
-                                }
+				int arrayDepth = 0;
+				if (fieldDefinition.HasFixedBufferAttribute())
+				{
+					fieldType = fieldDefinition.GetFixedBufferElementType();
+					arrayDepth = 1;
+				}
 
-                                if (fieldType is CustomModifierTypeSignature customModifierType)
-                                {
-                                        fieldType = customModifierType.BaseType;
-                                }
+				if (fieldType is CustomModifierTypeSignature customModifierType)
+				{
+					fieldType = customModifierType.BaseType;
+				}
 
-                                if (TryCreateSerializableField(typeStack, fieldDefinition.Name ?? "", fieldType, arrayDepth, typeCache, out Field field, out failureReason, out bool fieldContainsSerializeReference))
-                                {
-                                        containsSerializeReference |= fieldContainsSerializeReference;
-                                        if (monoType.IsCyclicReference(field.Type))
-                                        {
-                                                // Infinite recursion disqualifies a field from serialization.
-                                        }
-                                        else if (!field.Type.IsMaxDepthKnown)
-                                        {
-                                                // New cycle reference detected.
-                                                List<MonoType> cycleList = new(typeStack.Count);
-                                                foreach (MonoType monoTypeInStack in typeStack)
-                                                {
-                                                        cycleList.Add(monoTypeInStack);
-                                                        if (monoTypeInStack == field.Type)
-                                                        {
-                                                                break;
-                                                        }
-                                                }
+				if (TryCreateSerializableField(typeStack, fieldDefinition.Name ?? "", fieldType, arrayDepth, typeCache, out Field field, out failureReason, out bool fieldContainsSerializeReference))
+				{
+					containsSerializeReference |= fieldContainsSerializeReference;
+					if (monoType.IsCyclicReference(field.Type))
+					{
+						// Infinite recursion disqualifies a field from serialization.
+					}
+					else if (!field.Type.IsMaxDepthKnown)
+					{
+						// New cycle reference detected.
+						List<MonoType> cycleList = new(typeStack.Count);
+						foreach (MonoType monoTypeInStack in typeStack)
+						{
+							cycleList.Add(monoTypeInStack);
+							if (monoTypeInStack == field.Type)
+							{
+								break;
+							}
+						}
 
-                                                for (int i = 0; i < cycleList.Count; i++)
-                                                {
-                                                        for (int j = 0; j <= i; j++)
-                                                        {
-                                                                SerializableType type1 = cycleList[i];
-                                                                SerializableType type2 = cycleList[j];
-                                                                type1.AddCyclicReference(type2);
-                                                                type2.AddCyclicReference(type1);
-                                                        }
-                                                }
-                                        }
-                                        else
-                                        {
-                                                fields.Add(field);
-                                        }
-                                }
-                                else
-                                {
-                                        return false;
-                                }
-                        }
-                }
-                failureReason = null;
-                return true;
-        }
+						for (int i = 0; i < cycleList.Count; i++)
+						{
+							for (int j = 0; j <= i; j++)
+							{
+								SerializableType type1 = cycleList[i];
+								SerializableType type2 = cycleList[j];
+								type1.AddCyclicReference(type2);
+								type2.AddCyclicReference(type1);
+							}
+						}
+					}
+					else
+					{
+						fields.Add(field);
+					}
+				}
+				else
+				{
+					return false;
+				}
+			}
+		}
+		failureReason = null;
+		return true;
+	}
 
-        private bool TryCreateSerializableField(
-                Stack<MonoType> typeStack,
-                string name,
-                TypeSignature typeSignature,
-                int arrayDepth,
-                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
-                out Field result,
-                [NotNullWhen(false)] out string? failureReason,
-                out bool containsSerializeReference)
-        {
-                switch (typeSignature)
-                {
-                        case TypeDefOrRefSignature typeDefOrRefSignature:
-                                TypeDefinition typeDefinition = typeDefOrRefSignature.Type.CheckedResolve();
-                                SerializableType fieldType;
-                                if (typeDefinition.IsEnum)
-                                {
-                                        CorLibTypeSignature enumValueType = (CorLibTypeSignature?)typeDefinition.GetEnumUnderlyingType() ?? throw new("Failed to resolve enum underlying type.");
-                                        PrimitiveType primitiveType = enumValueType.ToPrimitiveType();
-                                        fieldType = SerializablePrimitiveType.GetOrCreate(primitiveType);
-                                        containsSerializeReference = false;
-                                }
-                                else if (typeDefinition.InheritsFromObject())
-                                {
-                                        fieldType = SerializablePointerType.Shared;
-                                        containsSerializeReference = false;
-                                }
-                                else if (typeCache.TryGetValue(typeDefinition, out (SerializableType, bool) cachedEntry))
-                                {
-                                        //This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
-                                        fieldType = cachedEntry.Item1;
-                                        containsSerializeReference = cachedEntry.Item2;
-                                }
-                                else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
-                                {
-                                        fieldType = monoType;
-                                }
-                                else
-                                {
-                                        result = default;
-                                        return false;
-                                }
+	private bool TryCreateSerializableField(
+		Stack<MonoType> typeStack,
+		string name,
+		TypeSignature typeSignature,
+		int arrayDepth,
+		Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+		out Field result,
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
+	{
+		switch (typeSignature)
+		{
+			case TypeDefOrRefSignature typeDefOrRefSignature:
+				TypeDefinition typeDefinition = typeDefOrRefSignature.Type.CheckedResolve();
+				SerializableType fieldType;
+				if (typeDefinition.IsEnum)
+				{
+					CorLibTypeSignature enumValueType = (CorLibTypeSignature?)typeDefinition.GetEnumUnderlyingType() ?? throw new("Failed to resolve enum underlying type.");
+					PrimitiveType primitiveType = enumValueType.ToPrimitiveType();
+					fieldType = SerializablePrimitiveType.GetOrCreate(primitiveType);
+					containsSerializeReference = false;
+				}
+				else if (typeDefinition.InheritsFromObject())
+				{
+					fieldType = SerializablePointerType.Shared;
+					containsSerializeReference = false;
+				}
+				else if (typeCache.TryGetValue(typeDefinition, out (SerializableType, bool) cachedEntry))
+				{
+					//This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
+					fieldType = cachedEntry.Item1;
+					containsSerializeReference = cachedEntry.Item2;
+				}
+				else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
+				{
+					fieldType = monoType;
+				}
+				else
+				{
+					result = default;
+					return false;
+				}
 
-                                result = new Field(fieldType, arrayDepth, name, true);
-                                failureReason = null;
-                                return true;
+				result = new Field(fieldType, arrayDepth, name, true);
+				failureReason = null;
+				return true;
 
-                        case CorLibTypeSignature corLibTypeSignature:
-                                result = new Field(SerializablePrimitiveType.GetOrCreate(corLibTypeSignature.ToPrimitiveType()), arrayDepth, name, true);
-                                failureReason = null;
-                                containsSerializeReference = false;
-                                return true;
+			case CorLibTypeSignature corLibTypeSignature:
+				result = new Field(SerializablePrimitiveType.GetOrCreate(corLibTypeSignature.ToPrimitiveType()), arrayDepth, name, true);
+				failureReason = null;
+				containsSerializeReference = false;
+				return true;
 
-                        case SzArrayTypeSignature szArrayTypeSignature:
-                                return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
+			case SzArrayTypeSignature szArrayTypeSignature:
+				return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
 
-                        case GenericInstanceTypeSignature genericInstanceTypeSignature:
-                                if (genericInstanceTypeSignature.InheritsFromObject())
-                                {
-                                        result = new Field(SerializablePointerType.Shared, arrayDepth, name, true);
-                                        failureReason = null;
-                                        containsSerializeReference = false;
-                                        return true;
-                                }
-                                else if (typeCache.TryGetValue(genericInstanceTypeSignature.ToTypeDefOrRef(), out (SerializableType, bool) cachedGenericEntry))
-                                {
-                                        result = new Field(cachedGenericEntry.Item1, arrayDepth, name, true);
-                                        failureReason = null;
-                                        containsSerializeReference = cachedGenericEntry.Item2;
-                                        return true;
-                                }
-                                else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
-                                {
-                                        return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
-                                }
-                                else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
-                                {
-                                        result = new(monoType, arrayDepth, name, true);
-                                        return true;
-                                }
-                                else
-                                {
-                                        result = default;
-                                        return false;
-                                }
+			case GenericInstanceTypeSignature genericInstanceTypeSignature:
+				if (genericInstanceTypeSignature.InheritsFromObject())
+				{
+					result = new Field(SerializablePointerType.Shared, arrayDepth, name, true);
+					failureReason = null;
+					containsSerializeReference = false;
+					return true;
+				}
+				else if (typeCache.TryGetValue(genericInstanceTypeSignature.ToTypeDefOrRef(), out (SerializableType, bool) cachedGenericEntry))
+				{
+					result = new Field(cachedGenericEntry.Item1, arrayDepth, name, true);
+					failureReason = null;
+					containsSerializeReference = cachedGenericEntry.Item2;
+					return true;
+				}
+				else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
+				{
+					return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
+				}
+				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
+				{
+					result = new(monoType, arrayDepth, name, true);
+					return true;
+				}
+				else
+				{
+					result = default;
+					return false;
+				}
 
-                        default:
-                                result = default;
-                                failureReason = $"{typeSignature.FullName} not supported.";
-                                containsSerializeReference = default;
-                                return false;
-                }
-        }
+			default:
+				result = default;
+				failureReason = $"{typeSignature.FullName} not supported.";
+				containsSerializeReference = default;
+				return false;
+		}
+	}
 
-        private static bool TryGetBaseType(GenericInstanceTypeSignature genericInstanceType, out TypeSignature? baseType)
-        {
-                TypeDefinition? typeDefinition = genericInstanceType.GenericType.Resolve();
-                if (typeDefinition is null)
-                {
-                        baseType = null;
-                        return false;
-                }
+	private static bool TryGetBaseType(GenericInstanceTypeSignature genericInstanceType, out TypeSignature? baseType)
+	{
+		TypeDefinition? typeDefinition = genericInstanceType.GenericType.Resolve();
+		if (typeDefinition is null)
+		{
+			baseType = null;
+			return false;
+		}
 
-                baseType = typeDefinition.BaseType?.ToTypeSignature().InstantiateGenericTypes(new GenericContext(genericInstanceType, null));
-                return true;
-        }
+		baseType = typeDefinition.BaseType?.ToTypeSignature().InstantiateGenericTypes(new GenericContext(genericInstanceType, null));
+		return true;
+	}
 
-        private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(TypeDefinition typeDefinition)
-        {
-                return typeDefinition.Fields.Select(field =>
-                {
-                        TypeSignature fieldType = field.Signature!.FieldType;
-                        return (field, fieldType);
-                });
-        }
+	private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(TypeDefinition typeDefinition)
+	{
+		return typeDefinition.Fields.Select(field =>
+		{
+			TypeSignature fieldType = field.Signature!.FieldType;
+			return (field, fieldType);
+		});
+	}
 
-        private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(GenericInstanceTypeSignature genericInst)
-        {
-                TypeDefinition? typeDefinition = genericInst.Resolve();
-                if (typeDefinition is null)
-                {
-                        return [];
-                }
-                return typeDefinition.Fields.Select(field =>
-                {
-                        TypeSignature fieldType = field.Signature!.FieldType;
-                        GenericContext genericContext = new GenericContext(genericInst, null);
-                        TypeSignature instanceTypeSignature = fieldType.InstantiateGenericTypes(genericContext);
-                        return (field, instanceTypeSignature);
-                });
-        }
+	private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(GenericInstanceTypeSignature genericInst)
+	{
+		TypeDefinition? typeDefinition = genericInst.Resolve();
+		if (typeDefinition is null)
+		{
+			return [];
+		}
+		return typeDefinition.Fields.Select(field =>
+		{
+			TypeSignature fieldType = field.Signature!.FieldType;
+			GenericContext genericContext = new GenericContext(genericInst, null);
+			TypeSignature instanceTypeSignature = fieldType.InstantiateGenericTypes(genericContext);
+			return (field, instanceTypeSignature);
+		});
+	}
 }

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -187,7 +187,6 @@ public readonly partial struct FieldSerializer
 			containsSerializeReference = false;
 		}
 
-
 		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out bool containsSerializeReference2))
 		{
 			containsSerializeReference |= containsSerializeReference2;

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -179,6 +179,7 @@ public readonly partial struct FieldSerializer
 		
 		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out _))
 		{
+			containsSerializeReference |= containsSerializeReference2;
 			monoType.SetDepth();
 			typeStack.Pop();
 			result = monoType;

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -91,7 +91,7 @@ public readonly partial struct FieldSerializer
 
 		if (typeDefinition.BaseType is not null)
 		{
-			if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason))
+			if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason, out containsSerializeReference))
 			{
 				typeCache.Remove(typeDefinition);
 				typeStack.Pop();

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -158,7 +158,7 @@ public readonly partial struct FieldSerializer
 		}
 		else if (baseType is not null)
 		{
-			if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason))
+			if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason, out containsSerializeReference))
 			{
 				typeCache.Remove(typeCacheKey);
 				typeStack.Pop();

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -107,6 +107,7 @@ public readonly partial struct FieldSerializer
 		else
 		{
 			fields.EnsureCapacity(typeDefinition.Fields.Count);
+			containsSerializeReference = false;
 		}
 
 		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference))

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.SerializationLogic.Extensions;
+using AssetRipper.SerializationLogic.Extensions;
 using System.Diagnostics;
 using static AssetRipper.SerializationLogic.SerializableType;
 
@@ -6,6 +6,30 @@ namespace AssetRipper.SerializationLogic;
 
 public readonly partial struct FieldSerializer
 {
+	private static bool HasSerializeReferenceRecursive(SerializableType type, HashSet<SerializableType> visited)
+	{
+		if (!visited.Add(type))
+		{
+			return false;
+		}
+
+		if (type.Type == PrimitiveType.Complex)
+		{
+			if (type.Name == "managedReference")
+			{
+				return true;
+			}
+			foreach (SerializableType.Field field in type.Fields)
+			{
+				if (HasSerializeReferenceRecursive(field.Type, visited))
+				{
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
 	public bool TryCreateSerializableType(TypeDefinition typeDefinition,
 		[NotNullWhen(true)] out SerializableType? result,
 		[NotNullWhen(false)] out string? failureReason)
@@ -106,6 +130,21 @@ public readonly partial struct FieldSerializer
 
 		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason))
 		{
+			bool hasSerializeReference = false;
+			HashSet<SerializableType> visited = new();
+			foreach (Field field in fields)
+			{
+				if (HasSerializeReferenceRecursive(field.Type, visited))
+				{
+					hasSerializeReference = true;
+					break;
+				}
+			}
+
+			if (hasSerializeReference && (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject()))
+			{
+				fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
+			}
 			monoType.SetDepth();
 			typeStack.Pop();
 			result = monoType;
@@ -200,8 +239,8 @@ public readonly partial struct FieldSerializer
 			{
 				if (fieldDefinition.HasSerializeReferenceAttribute())
 				{
-					failureReason = $"{fieldDefinition.DeclaringType?.FullName}.{fieldDefinition.Name} uses the [SerializeReference] attribute, which is currently not supported.";
-					return false;
+					fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
+					continue;
 				}
 
 				int arrayDepth = 0;

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -313,7 +313,7 @@ public readonly partial struct FieldSerializer
 					//This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
 					fieldType = cachedMonoType;
 				}
-				else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason, out _))
+				else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
 				{
 					fieldType = monoType;
 				}

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -35,7 +35,7 @@ public readonly partial struct FieldSerializer
 	{
 		if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
 		{
-			return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason);
+			return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
 		}
 		TypeDefinition? typeDefinition = typeSignature.Resolve();
 		if (typeDefinition is null)

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -349,7 +349,7 @@ public readonly partial struct FieldSerializer
 				}
 				else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
 				{
-					return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason);
+					return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
 				}
 				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason, out _))
 				{

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -56,7 +56,8 @@ public readonly partial struct FieldSerializer
 		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
 		Stack<MonoType> typeStack,
 		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
 	{
 		if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedType))
 		{

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -30,7 +30,8 @@ public readonly partial struct FieldSerializer
 		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
 		Stack<MonoType> typeStack,
 		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
+		[NotNullWhen(false)] out string? failureReason,
+		out bool containsSerializeReference)
 	{
 		if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
 		{

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -6,405 +6,415 @@ namespace AssetRipper.SerializationLogic;
 
 public readonly partial struct FieldSerializer
 {
-	public bool TryCreateSerializableType(TypeDefinition typeDefinition,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		return TryCreateSerializableType(typeDefinition, new(SignatureComparer.Default), out result, out failureReason);
-	}
+        public bool TryCreateSerializableType(TypeDefinition typeDefinition,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                return TryCreateSerializableType(typeDefinition, new(SignatureComparer.Default), out result, out failureReason);
+        }
 
-	public bool TryCreateSerializableType(
-		TypeDefinition typeDefinition,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason)
-	{
-		Stack<MonoType> typeStack = new();
-		bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out _);
-		Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
-		return returnValue;
-	}
+        public bool TryCreateSerializableType(
+                TypeDefinition typeDefinition,
+                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason)
+        {
+                Stack<MonoType> typeStack = new();
+                bool returnValue = TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out _);
+                Debug.Assert(typeStack.Count == 0, "The type stack should be empty after processing.");
+                return returnValue;
+        }
 
-	private bool TryCreateSerializableType(
-		TypeSignature typeSignature,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		Stack<MonoType> typeStack,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason,
-		out bool containsSerializeReference)
-	{
-		if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
-		{
-			return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
-		}
-		TypeDefinition? typeDefinition = typeSignature.Resolve();
-		if (typeDefinition is null)
-		{
-			result = null;
-			failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
-			containsSerializeReference = default;
-			return false;
-		}
-		else
-		{
-			return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
-		}
-	}
+        private bool TryCreateSerializableType(
+                TypeSignature typeSignature,
+                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+                Stack<MonoType> typeStack,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason,
+                out bool containsSerializeReference)
+        {
+                if (typeSignature is GenericInstanceTypeSignature genericInstanceType)
+                {
+                        return TryCreateSerializableType(genericInstanceType, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
+                }
+                TypeDefinition? typeDefinition = typeSignature.Resolve();
+                if (typeDefinition is null)
+                {
+                        result = null;
+                        failureReason = $"Failed to resolve type signature {typeSignature.FullName}.";
+                        containsSerializeReference = default;
+                        return false;
+                }
+                else
+                {
+                        return TryCreateSerializableType(typeDefinition, typeCache, typeStack, out result, out failureReason, out containsSerializeReference);
+                }
+        }
 
-	private bool TryCreateSerializableType(
-		TypeDefinition typeDefinition,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		Stack<MonoType> typeStack,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason,
-		out bool containsSerializeReference)
-	{
-		if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedType))
-		{
-			result = cachedType;
-			failureReason = null;
-			containsSerializeReference = default;
-			return true;
-		}
-		if (typeDefinition.GenericParameters.Count > 0)
-		{
-			result = null;
-			failureReason = "Generic types are not serializable.";
-			containsSerializeReference = default;
-			return false;
-		}
-		if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))
-		{
-			result = SerializablePrimitiveType.GetOrCreate(primitiveType);
-			typeCache.Add(typeDefinition, result);
-			failureReason = null;
-			containsSerializeReference = false;
-			return true;
-		}
+        private bool TryCreateSerializableType(
+                TypeDefinition typeDefinition,
+                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+                Stack<MonoType> typeStack,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason,
+                out bool containsSerializeReference)
+        {
+                if (typeCache.TryGetValue(typeDefinition, out (SerializableType, bool) cachedEntry))
+                {
+                        result = cachedEntry.Item1;
+                        failureReason = null;
+                        containsSerializeReference = cachedEntry.Item2;
+                        return true;
+                }
+                if (typeDefinition.GenericParameters.Count > 0)
+                {
+                        result = null;
+                        failureReason = "Generic types are not serializable.";
+                        containsSerializeReference = default;
+                        return false;
+                }
+                if (typeDefinition.TryGetPrimitiveType(out PrimitiveType primitiveType))
+                {
+                        result = SerializablePrimitiveType.GetOrCreate(primitiveType);
+                        typeCache.Add(typeDefinition, (result, false));
+                        failureReason = null;
+                        containsSerializeReference = false;
+                        return true;
+                }
 
-		//Ensure we allocate some initial space so that we have less chance of needing to resize the list.
-		List<Field> fields = [];
+                //Ensure we allocate some initial space so that we have less chance of needing to resize the list.
+                List<Field> fields = [];
 
-		//Caching before completion prevents infinite loops.
-		MonoType monoType = new(typeDefinition, fields);
-		typeCache.Add(typeDefinition, monoType);
-		typeStack.Push(monoType);
+                //Caching before completion prevents infinite loops.
+                MonoType monoType = new(typeDefinition, fields);
+                typeCache.Add(typeDefinition, (monoType, false));
+                typeStack.Push(monoType);
 
-		if (typeDefinition.BaseType is not null)
-		{
-			if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason, out containsSerializeReference))
-			{
-				typeCache.Remove(typeDefinition);
-				typeStack.Pop();
-				result = null;
-				return false;
-			}
-			else
-			{
-				fields.EnsureCapacity(baseType.Fields.Count + typeDefinition.Fields.Count);
-				fields.AddRange(baseType.Fields);
-			}
-		}
-		else
-		{
-			fields.EnsureCapacity(typeDefinition.Fields.Count);
-			containsSerializeReference = false;
-		}
+                if (typeDefinition.BaseType is not null)
+                {
+                        if (!TryCreateSerializableType(typeDefinition.BaseType.ToTypeSignature(), typeCache, typeStack, out SerializableType? baseType, out failureReason, out containsSerializeReference))
+                        {
+                                typeCache.Remove(typeDefinition);
+                                typeStack.Pop();
+                                result = null;
+                                return false;
+                        }
+                        else
+                        {
+                                fields.EnsureCapacity(baseType.Fields.Count + typeDefinition.Fields.Count);
+                                fields.AddRange(baseType.Fields);
+                        }
+                }
+                else
+                {
+                        fields.EnsureCapacity(typeDefinition.Fields.Count);
+                        containsSerializeReference = false;
+                }
 
-		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference2))
-		{
-			containsSerializeReference |= containsSerializeReference2;
-			monoType.SetDepth();
+                if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference2))
+                {
+                        containsSerializeReference |= containsSerializeReference2;
+                        monoType.SetDepth();
 
-			if (containsSerializeReference && (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject()))
-			{
-				fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
-			}
+                        if (containsSerializeReference && (typeDefinition.InheritsFromMonoBehaviour() || typeDefinition.InheritsFromScriptableObject()))
+                        {
+                                fields.Add(new SerializableType.Field(ManagedReferenceTypes.GetManagedReferencesRegistryType(), 0, "references", true));
+                        }
 
-			typeStack.Pop();
-			result = monoType;
-			return true;
-		}
-		else
-		{
-			typeCache.Remove(typeDefinition);
-			typeStack.Pop();
-			result = null;
-			return false;
-		}
-	}
+                        typeCache[typeDefinition] = (monoType, containsSerializeReference);
+                        typeStack.Pop();
+                        result = monoType;
+                        return true;
+                }
+                else
+                {
+                        typeCache.Remove(typeDefinition);
+                        typeStack.Pop();
+                        result = null;
+                        return false;
+                }
+        }
 
-	private bool TryCreateSerializableType(
-		GenericInstanceTypeSignature genericInst,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		Stack<MonoType> typeStack,
-		[NotNullWhen(true)] out SerializableType? result,
-		[NotNullWhen(false)] out string? failureReason,
-		out bool containsSerializeReference)
-	{
-		ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
-		if (typeCache.TryGetValue(typeCacheKey, out SerializableType? cachedType))
-		{
-			result = cachedType;
-			failureReason = null;
-			containsSerializeReference = default;
-			return true;
-		}
+        private bool TryCreateSerializableType(
+                GenericInstanceTypeSignature genericInst,
+                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+                Stack<MonoType> typeStack,
+                [NotNullWhen(true)] out SerializableType? result,
+                [NotNullWhen(false)] out string? failureReason,
+                out bool containsSerializeReference)
+        {
+                ITypeDefOrRef typeCacheKey = genericInst.ToTypeDefOrRef();
+                if (typeCache.TryGetValue(typeCacheKey, out (SerializableType, bool) cachedEntry))
+                {
+                        result = cachedEntry.Item1;
+                        failureReason = null;
+                        containsSerializeReference = cachedEntry.Item2;
+                        return true;
+                }
 
-		List<Field> fields = [];
+                List<Field> fields = [];
 
-		MonoType monoType = new(genericInst.GenericType, fields);
-		typeCache.Add(typeCacheKey, monoType);
-		typeStack.Push(monoType);
+                MonoType monoType = new(genericInst.GenericType, fields);
+                typeCache.Add(typeCacheKey, (monoType, false));
+                typeStack.Push(monoType);
 
-		if (!TryGetBaseType(genericInst, out TypeSignature? baseType))
-		{
-			typeCache.Remove(typeCacheKey);
-			typeStack.Pop();
-			result = null;
-			failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
-			containsSerializeReference = default;
-			return false;
-		}
-		else if (baseType is not null)
-		{
-			if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason, out containsSerializeReference))
-			{
-				typeCache.Remove(typeCacheKey);
-				typeStack.Pop();
-				result = null;
-				return false;
-			}
-			else
-			{
-				fields.EnsureCapacity(baseMonoType.Fields.Count + genericInst.GenericType.Resolve()!.Fields.Count);
-				fields.AddRange(baseMonoType.Fields);
-			}
-		}
-		else
-		{
-			fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
-			containsSerializeReference = false;
-		}
+                if (!TryGetBaseType(genericInst, out TypeSignature? baseType))
+                {
+                        typeCache.Remove(typeCacheKey);
+                        typeStack.Pop();
+                        result = null;
+                        failureReason = $"Failed to resolve base type of {genericInst.FullName}.";
+                        containsSerializeReference = default;
+                        return false;
+                }
+                else if (baseType is not null)
+                {
+                        if (!TryCreateSerializableType(baseType, typeCache, typeStack, out SerializableType? baseMonoType, out failureReason, out containsSerializeReference))
+                        {
+                                typeCache.Remove(typeCacheKey);
+                                typeStack.Pop();
+                                result = null;
+                                return false;
+                        }
+                        else
+                        {
+                                fields.EnsureCapacity(baseMonoType.Fields.Count + genericInst.GenericType.Resolve()!.Fields.Count);
+                                fields.AddRange(baseMonoType.Fields);
+                        }
+                }
+                else
+                {
+                        fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
+                        containsSerializeReference = false;
+                }
 
-		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out bool containsSerializeReference2))
-		{
-			containsSerializeReference |= containsSerializeReference2;
-			monoType.SetDepth();
-			typeStack.Pop();
-			result = monoType;
-			return true;
-		}
-		else
-		{
-			typeCache.Remove(typeCacheKey);
-			typeStack.Pop();
-			result = null;
-			return false;
-		}
-	}
+                if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(genericInst), typeCache, out failureReason, out bool containsSerializeReference2))
+                {
+                        containsSerializeReference |= containsSerializeReference2;
+                        monoType.SetDepth();
+                        typeCache[typeCacheKey] = (monoType, containsSerializeReference);
+                        typeStack.Pop();
+                        result = monoType;
+                        return true;
+                }
+                else
+                {
+                        typeCache.Remove(typeCacheKey);
+                        typeStack.Pop();
+                        result = null;
+                        return false;
+                }
+        }
 
-	private bool TryCreateSerializableFields(
-		Stack<MonoType> typeStack,
-		MonoType monoType,
-		List<Field> fields,
-		IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		[NotNullWhen(false)] out string? failureReason,
-		out bool containsSerializeReference)
-	{
-		containsSerializeReference = false;
-		foreach ((FieldDefinition, TypeSignature) pair in enumerable)
-		{
-			(FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;
-			if (WillUnitySerialize(fieldDefinition, fieldType))
-			{
-				if (fieldDefinition.HasSerializeReferenceAttribute())
-				{
-					fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
-					containsSerializeReference = true;
-					continue;
-				}
+        private bool TryCreateSerializableFields(
+                Stack<MonoType> typeStack,
+                MonoType monoType,
+                List<Field> fields,
+                IEnumerable<(FieldDefinition, TypeSignature)> enumerable,
+                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+                [NotNullWhen(false)] out string? failureReason,
+                out bool containsSerializeReference)
+        {
+                containsSerializeReference = false;
+                foreach ((FieldDefinition, TypeSignature) pair in enumerable)
+                {
+                        (FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;
+                        if (WillUnitySerialize(fieldDefinition, fieldType))
+                        {
+                                if (fieldDefinition.HasSerializeReferenceAttribute())
+                                {
+                                        fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
+                                        containsSerializeReference = true;
+                                        continue;
+                                }
 
-				int arrayDepth = 0;
-				if (fieldDefinition.HasFixedBufferAttribute())
-				{
-					fieldType = fieldDefinition.GetFixedBufferElementType();
-					arrayDepth = 1;
-				}
+                                int arrayDepth = 0;
+                                if (fieldDefinition.HasFixedBufferAttribute())
+                                {
+                                        fieldType = fieldDefinition.GetFixedBufferElementType();
+                                        arrayDepth = 1;
+                                }
 
-				if (fieldType is CustomModifierTypeSignature customModifierType)
-				{
-					fieldType = customModifierType.BaseType;
-				}
+                                if (fieldType is CustomModifierTypeSignature customModifierType)
+                                {
+                                        fieldType = customModifierType.BaseType;
+                                }
 
-				if (TryCreateSerializableField(typeStack, fieldDefinition.Name ?? "", fieldType, arrayDepth, typeCache, out Field field, out failureReason))
-				{
-					if (monoType.IsCyclicReference(field.Type))
-					{
-						// Infinite recursion disqualifies a field from serialization.
-					}
-					else if (!field.Type.IsMaxDepthKnown)
-					{
-						// New cycle reference detected.
-						List<MonoType> cycleList = new(typeStack.Count);
-						foreach (MonoType monoTypeInStack in typeStack)
-						{
-							cycleList.Add(monoTypeInStack);
-							if (monoTypeInStack == field.Type)
-							{
-								break;
-							}
-						}
+                                if (TryCreateSerializableField(typeStack, fieldDefinition.Name ?? "", fieldType, arrayDepth, typeCache, out Field field, out failureReason, out bool fieldContainsSerializeReference))
+                                {
+                                        containsSerializeReference |= fieldContainsSerializeReference;
+                                        if (monoType.IsCyclicReference(field.Type))
+                                        {
+                                                // Infinite recursion disqualifies a field from serialization.
+                                        }
+                                        else if (!field.Type.IsMaxDepthKnown)
+                                        {
+                                                // New cycle reference detected.
+                                                List<MonoType> cycleList = new(typeStack.Count);
+                                                foreach (MonoType monoTypeInStack in typeStack)
+                                                {
+                                                        cycleList.Add(monoTypeInStack);
+                                                        if (monoTypeInStack == field.Type)
+                                                        {
+                                                                break;
+                                                        }
+                                                }
 
-						for (int i = 0; i < cycleList.Count; i++)
-						{
-							for (int j = 0; j <= i; j++)
-							{
-								SerializableType type1 = cycleList[i];
-								SerializableType type2 = cycleList[j];
-								type1.AddCyclicReference(type2);
-								type2.AddCyclicReference(type1);
-							}
-						}
-					}
-					else
-					{
-						fields.Add(field);
-					}
-				}
-				else
-				{
-					return false;
-				}
-			}
-		}
-		failureReason = null;
-		return true;
-	}
+                                                for (int i = 0; i < cycleList.Count; i++)
+                                                {
+                                                        for (int j = 0; j <= i; j++)
+                                                        {
+                                                                SerializableType type1 = cycleList[i];
+                                                                SerializableType type2 = cycleList[j];
+                                                                type1.AddCyclicReference(type2);
+                                                                type2.AddCyclicReference(type1);
+                                                        }
+                                                }
+                                        }
+                                        else
+                                        {
+                                                fields.Add(field);
+                                        }
+                                }
+                                else
+                                {
+                                        return false;
+                                }
+                        }
+                }
+                failureReason = null;
+                return true;
+        }
 
-	private bool TryCreateSerializableField(
-		Stack<MonoType> typeStack,
-		string name,
-		TypeSignature typeSignature,
-		int arrayDepth,
-		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
-		out Field result,
-		[NotNullWhen(false)] out string? failureReason,
-		out bool containsSerializeReference)
-	{
-		switch (typeSignature)
-		{
-			case TypeDefOrRefSignature typeDefOrRefSignature:
-				TypeDefinition typeDefinition = typeDefOrRefSignature.Type.CheckedResolve();
-				SerializableType fieldType;
-				if (typeDefinition.IsEnum)
-				{
-					CorLibTypeSignature enumValueType = (CorLibTypeSignature?)typeDefinition.GetEnumUnderlyingType() ?? throw new("Failed to resolve enum underlying type.");
-					PrimitiveType primitiveType = enumValueType.ToPrimitiveType();
-					fieldType = SerializablePrimitiveType.GetOrCreate(primitiveType);
-				}
-				else if (typeDefinition.InheritsFromObject())
-				{
-					fieldType = SerializablePointerType.Shared;
-				}
-				else if (typeCache.TryGetValue(typeDefinition, out SerializableType? cachedMonoType))
-				{
-					//This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
-					fieldType = cachedMonoType;
-				}
-				else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
-				{
-					fieldType = monoType;
-				}
-				else
-				{
-					result = default;
-					return false;
-				}
+        private bool TryCreateSerializableField(
+                Stack<MonoType> typeStack,
+                string name,
+                TypeSignature typeSignature,
+                int arrayDepth,
+                Dictionary<ITypeDefOrRef, (SerializableType, bool)> typeCache,
+                out Field result,
+                [NotNullWhen(false)] out string? failureReason,
+                out bool containsSerializeReference)
+        {
+                switch (typeSignature)
+                {
+                        case TypeDefOrRefSignature typeDefOrRefSignature:
+                                TypeDefinition typeDefinition = typeDefOrRefSignature.Type.CheckedResolve();
+                                SerializableType fieldType;
+                                if (typeDefinition.IsEnum)
+                                {
+                                        CorLibTypeSignature enumValueType = (CorLibTypeSignature?)typeDefinition.GetEnumUnderlyingType() ?? throw new("Failed to resolve enum underlying type.");
+                                        PrimitiveType primitiveType = enumValueType.ToPrimitiveType();
+                                        fieldType = SerializablePrimitiveType.GetOrCreate(primitiveType);
+                                        containsSerializeReference = false;
+                                }
+                                else if (typeDefinition.InheritsFromObject())
+                                {
+                                        fieldType = SerializablePointerType.Shared;
+                                        containsSerializeReference = false;
+                                }
+                                else if (typeCache.TryGetValue(typeDefinition, out (SerializableType, bool) cachedEntry))
+                                {
+                                        //This needs to come after the InheritsFromObject check so that those fields get properly converted into PPtr assets.
+                                        fieldType = cachedEntry.Item1;
+                                        containsSerializeReference = cachedEntry.Item2;
+                                }
+                                else if (TryCreateSerializableType(typeDefinition, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
+                                {
+                                        fieldType = monoType;
+                                }
+                                else
+                                {
+                                        result = default;
+                                        return false;
+                                }
 
-				result = new Field(fieldType, arrayDepth, name, true);
-				failureReason = null;
-				return true;
+                                result = new Field(fieldType, arrayDepth, name, true);
+                                failureReason = null;
+                                return true;
 
-			case CorLibTypeSignature corLibTypeSignature:
-				result = new Field(SerializablePrimitiveType.GetOrCreate(corLibTypeSignature.ToPrimitiveType()), arrayDepth, name, true);
-				failureReason = null;
-				return true;
+                        case CorLibTypeSignature corLibTypeSignature:
+                                result = new Field(SerializablePrimitiveType.GetOrCreate(corLibTypeSignature.ToPrimitiveType()), arrayDepth, name, true);
+                                failureReason = null;
+                                containsSerializeReference = false;
+                                return true;
 
-			case SzArrayTypeSignature szArrayTypeSignature:
-				return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
+                        case SzArrayTypeSignature szArrayTypeSignature:
+                                return TryCreateSerializableField(typeStack, name, szArrayTypeSignature.BaseType, arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
 
-			case GenericInstanceTypeSignature genericInstanceTypeSignature:
-				if (genericInstanceTypeSignature.InheritsFromObject())
-				{
-					result = new Field(SerializablePointerType.Shared, arrayDepth, name, true);
-					failureReason = null;
-					return true;
-				}
-				else if (typeCache.TryGetValue(genericInstanceTypeSignature.ToTypeDefOrRef(), out SerializableType? cachedGenericMonoType))
-				{
-					result = new Field(cachedGenericMonoType, arrayDepth, name, true);
-					failureReason = null;
-					return true;
-				}
-				else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
-				{
-					return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
-				}
-				else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
-				{
-					result = new(monoType, arrayDepth, name, true);
-					return true;
-				}
-				else
-				{
-					result = default;
-					return false;
-				}
+                        case GenericInstanceTypeSignature genericInstanceTypeSignature:
+                                if (genericInstanceTypeSignature.InheritsFromObject())
+                                {
+                                        result = new Field(SerializablePointerType.Shared, arrayDepth, name, true);
+                                        failureReason = null;
+                                        containsSerializeReference = false;
+                                        return true;
+                                }
+                                else if (typeCache.TryGetValue(genericInstanceTypeSignature.ToTypeDefOrRef(), out (SerializableType, bool) cachedGenericEntry))
+                                {
+                                        result = new Field(cachedGenericEntry.Item1, arrayDepth, name, true);
+                                        failureReason = null;
+                                        containsSerializeReference = cachedGenericEntry.Item2;
+                                        return true;
+                                }
+                                else if (genericInstanceTypeSignature.GenericType is { Namespace.Value: "System.Collections.Generic", Name.Value: "List`1" })
+                                {
+                                        return TryCreateSerializableField(typeStack, name, genericInstanceTypeSignature.TypeArguments[0], arrayDepth + 1, typeCache, out result, out failureReason, out containsSerializeReference);
+                                }
+                                else if (TryCreateSerializableType(genericInstanceTypeSignature, typeCache, typeStack, out SerializableType? monoType, out failureReason, out containsSerializeReference))
+                                {
+                                        result = new(monoType, arrayDepth, name, true);
+                                        return true;
+                                }
+                                else
+                                {
+                                        result = default;
+                                        return false;
+                                }
 
-			default:
-				result = default;
-				failureReason = $"{typeSignature.FullName} not supported.";
-				return false;
-		}
-	}
+                        default:
+                                result = default;
+                                failureReason = $"{typeSignature.FullName} not supported.";
+                                containsSerializeReference = default;
+                                return false;
+                }
+        }
 
-	private static bool TryGetBaseType(GenericInstanceTypeSignature genericInstanceType, out TypeSignature? baseType)
-	{
-		TypeDefinition? typeDefinition = genericInstanceType.GenericType.Resolve();
-		if (typeDefinition is null)
-		{
-			baseType = null;
-			return false;
-		}
+        private static bool TryGetBaseType(GenericInstanceTypeSignature genericInstanceType, out TypeSignature? baseType)
+        {
+                TypeDefinition? typeDefinition = genericInstanceType.GenericType.Resolve();
+                if (typeDefinition is null)
+                {
+                        baseType = null;
+                        return false;
+                }
 
-		baseType = typeDefinition.BaseType?.ToTypeSignature().InstantiateGenericTypes(new GenericContext(genericInstanceType, null));
-		return true;
-	}
+                baseType = typeDefinition.BaseType?.ToTypeSignature().InstantiateGenericTypes(new GenericContext(genericInstanceType, null));
+                return true;
+        }
 
-	private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(TypeDefinition typeDefinition)
-	{
-		return typeDefinition.Fields.Select(field =>
-		{
-			TypeSignature fieldType = field.Signature!.FieldType;
-			return (field, fieldType);
-		});
-	}
+        private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(TypeDefinition typeDefinition)
+        {
+                return typeDefinition.Fields.Select(field =>
+                {
+                        TypeSignature fieldType = field.Signature!.FieldType;
+                        return (field, fieldType);
+                });
+        }
 
-	private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(GenericInstanceTypeSignature genericInst)
-	{
-		TypeDefinition? typeDefinition = genericInst.Resolve();
-		if (typeDefinition is null)
-		{
-			return [];
-		}
-		return typeDefinition.Fields.Select(field =>
-		{
-			TypeSignature fieldType = field.Signature!.FieldType;
-			GenericContext genericContext = new GenericContext(genericInst, null);
-			TypeSignature instanceTypeSignature = fieldType.InstantiateGenericTypes(genericContext);
-			return (field, instanceTypeSignature);
-		});
-	}
+        private static IEnumerable<(FieldDefinition, TypeSignature)> GetFieldsInType(GenericInstanceTypeSignature genericInst)
+        {
+                TypeDefinition? typeDefinition = genericInst.Resolve();
+                if (typeDefinition is null)
+                {
+                        return [];
+                }
+                return typeDefinition.Fields.Select(field =>
+                {
+                        TypeSignature fieldType = field.Signature!.FieldType;
+                        GenericContext genericContext = new GenericContext(genericInst, null);
+                        TypeSignature instanceTypeSignature = fieldType.InstantiateGenericTypes(genericContext);
+                        return (field, instanceTypeSignature);
+                });
+        }
 }

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -110,7 +110,7 @@ public readonly partial struct FieldSerializer
 			containsSerializeReference = false;
 		}
 
-		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference))
+		if (TryCreateSerializableFields(typeStack, monoType, fields, GetFieldsInType(typeDefinition), typeCache, out failureReason, out bool containsSerializeReference2))
 		{
 			containsSerializeReference |= containsSerializeReference2;
 			monoType.SetDepth();

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -209,6 +209,7 @@ public readonly partial struct FieldSerializer
 				if (fieldDefinition.HasSerializeReferenceAttribute())
 				{
 					fields.Add(new Field(ManagedReferenceTypes.GetManagedReferenceType(), 0, fieldDefinition.Name ?? "", true));
+					containsSerializeReference = true;
 					continue;
 				}
 

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -200,6 +200,7 @@ public readonly partial struct FieldSerializer
 		Dictionary<ITypeDefOrRef, SerializableType> typeCache,
 		[NotNullWhen(false)] out string? failureReason)
 	{
+		containsSerializeReference = false;
 		foreach ((FieldDefinition, TypeSignature) pair in enumerable)
 		{
 			(FieldDefinition fieldDefinition, TypeSignature fieldType) = pair;

--- a/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
+++ b/Source/AssetRipper.SerializationLogic/FieldSerializer.cs
@@ -174,6 +174,7 @@ public readonly partial struct FieldSerializer
 		else
 		{
 			fields.EnsureCapacity(genericInst.GenericType.Resolve()!.Fields.Count);
+			containsSerializeReference = false;
 		}
 
 		

--- a/Source/AssetRipper.SerializationLogic/ManagedReferenceTypes.cs
+++ b/Source/AssetRipper.SerializationLogic/ManagedReferenceTypes.cs
@@ -1,0 +1,46 @@
+namespace AssetRipper.SerializationLogic;
+
+internal static class ManagedReferenceTypes
+{
+	private static SerializableType? s_managedReferenceType;
+	public static SerializableType GetManagedReferenceType()
+	{
+		if (s_managedReferenceType == null)
+		{
+			SerializableType longType = SerializablePrimitiveType.GetOrCreate(PrimitiveType.Long);
+			s_managedReferenceType = new CustomSerializableType(null, PrimitiveType.Complex, "managedReference", [new SerializableType.Field(longType, 0, "rid", true)]);
+		}
+		return s_managedReferenceType;
+	}
+
+	private static SerializableType? s_managedReferencesRegistryType;
+	public static SerializableType GetManagedReferencesRegistryType()
+	{
+		if (s_managedReferencesRegistryType == null)
+		{
+			SerializableType stringType = SerializablePrimitiveType.GetOrCreate(PrimitiveType.String);
+			SerializableType intType = SerializablePrimitiveType.GetOrCreate(PrimitiveType.Int);
+			SerializableType longType = SerializablePrimitiveType.GetOrCreate(PrimitiveType.Long);
+
+			SerializableType typeType = new CustomSerializableType(null, PrimitiveType.Complex, "ReferencedManagedType", [
+				new SerializableType.Field(stringType, 0, "class", true),
+				new SerializableType.Field(stringType, 0, "ns", true),
+				new SerializableType.Field(stringType, 0, "asm", true)
+			]);
+
+			SerializableType dataType = new CustomSerializableType(null, PrimitiveType.Complex, "ReferencedObjectData", []);
+
+			SerializableType referencedObjectType = new CustomSerializableType(null, PrimitiveType.Complex, "ReferencedObject", [
+				new SerializableType.Field(longType, 0, "rid", true),
+				new SerializableType.Field(typeType, 0, "type", true),
+				new SerializableType.Field(dataType, 0, "data", true)
+			]);
+
+			s_managedReferencesRegistryType = new CustomSerializableType(null, PrimitiveType.Complex, "ManagedReferencesRegistry", [
+				new SerializableType.Field(intType, 0, "version", true),
+				new SerializableType.Field(referencedObjectType, 1, "RefIds", true)
+			]);
+		}
+		return s_managedReferencesRegistryType;
+	}
+}

--- a/Source/AssetRipper.SerializationLogic/MonoType.cs
+++ b/Source/AssetRipper.SerializationLogic/MonoType.cs
@@ -4,36 +4,36 @@ namespace AssetRipper.SerializationLogic;
 
 internal sealed class MonoType : SerializableType
 {
-        private MonoType(ITypeDefOrRef type) : base(type.Namespace ?? "", PrimitiveType.Complex, type.Name ?? "")
-        {
-        }
+	private MonoType(ITypeDefOrRef type) : base(type.Namespace ?? "", PrimitiveType.Complex, type.Name ?? "")
+	{
+	}
 
-        internal MonoType(ITypeDefOrRef type, IReadOnlyList<Field> fields) : this(type)
-        {
-                Fields = fields;
-        }
+	internal MonoType(ITypeDefOrRef type, IReadOnlyList<Field> fields) : this(type)
+	{
+		Fields = fields;
+	}
 
-        internal void SetDepth()
-        {
-                Debug.Assert(IsMaxDepthKnown == false, "The depth of this type is already known.");
-                int maxDepth = 0;
-                foreach (Field field in Fields)
-                {
-                        if (field.Type.HasSerializeReference)
-                        {
-                                HasSerializeReference = true;
-                        }
+	internal void SetDepth()
+	{
+		Debug.Assert(IsMaxDepthKnown == false, "The depth of this type is already known.");
+		int maxDepth = 0;
+		foreach (Field field in Fields)
+		{
+			if (field.Type.HasSerializeReference)
+			{
+				HasSerializeReference = true;
+			}
 
-                        if (field.Type.IsMaxDepthKnown)
-                        {
-                                maxDepth = Math.Max(maxDepth, field.Type.MaxDepth + 1);
-                        }
-                        else
-                        {
-                                maxDepth = -1;
-                                break;
-                        }
-                }
-                MaxDepth = maxDepth;
-        }
+			if (field.Type.IsMaxDepthKnown)
+			{
+				maxDepth = Math.Max(maxDepth, field.Type.MaxDepth + 1);
+			}
+			else
+			{
+				maxDepth = -1;
+				break;
+			}
+		}
+		MaxDepth = maxDepth;
+	}
 }

--- a/Source/AssetRipper.SerializationLogic/MonoType.cs
+++ b/Source/AssetRipper.SerializationLogic/MonoType.cs
@@ -4,31 +4,36 @@ namespace AssetRipper.SerializationLogic;
 
 internal sealed class MonoType : SerializableType
 {
-	private MonoType(ITypeDefOrRef type) : base(type.Namespace ?? "", PrimitiveType.Complex, type.Name ?? "")
-	{
-	}
+        private MonoType(ITypeDefOrRef type) : base(type.Namespace ?? "", PrimitiveType.Complex, type.Name ?? "")
+        {
+        }
 
-	internal MonoType(ITypeDefOrRef type, IReadOnlyList<Field> fields) : this(type)
-	{
-		Fields = fields;
-	}
+        internal MonoType(ITypeDefOrRef type, IReadOnlyList<Field> fields) : this(type)
+        {
+                Fields = fields;
+        }
 
-	internal void SetDepth()
-	{
-		Debug.Assert(IsMaxDepthKnown == false, "The depth of this type is already known.");
-		int maxDepth = 0;
-		foreach (Field field in Fields)
-		{
-			if (field.Type.IsMaxDepthKnown)
-			{
-				maxDepth = Math.Max(maxDepth, field.Type.MaxDepth + 1);
-			}
-			else
-			{
-				maxDepth = -1;
-				break;
-			}
-		}
-		MaxDepth = maxDepth;
-	}
+        internal void SetDepth()
+        {
+                Debug.Assert(IsMaxDepthKnown == false, "The depth of this type is already known.");
+                int maxDepth = 0;
+                foreach (Field field in Fields)
+                {
+                        if (field.Type.HasSerializeReference)
+                        {
+                                HasSerializeReference = true;
+                        }
+
+                        if (field.Type.IsMaxDepthKnown)
+                        {
+                                maxDepth = Math.Max(maxDepth, field.Type.MaxDepth + 1);
+                        }
+                        else
+                        {
+                                maxDepth = -1;
+                                break;
+                        }
+                }
+                MaxDepth = maxDepth;
+        }
 }

--- a/Source/AssetRipper.SerializationLogic/MonoType.cs
+++ b/Source/AssetRipper.SerializationLogic/MonoType.cs
@@ -19,11 +19,6 @@ internal sealed class MonoType : SerializableType
 		int maxDepth = 0;
 		foreach (Field field in Fields)
 		{
-			if (field.Type.HasSerializeReference)
-			{
-				HasSerializeReference = true;
-			}
-
 			if (field.Type.IsMaxDepthKnown)
 			{
 				maxDepth = Math.Max(maxDepth, field.Type.MaxDepth + 1);

--- a/Source/AssetRipper.SerializationLogic/MonoType.cs
+++ b/Source/AssetRipper.SerializationLogic/MonoType.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace AssetRipper.SerializationLogic;
 

--- a/Source/AssetRipper.SerializationLogic/SerializableType.cs
+++ b/Source/AssetRipper.SerializationLogic/SerializableType.cs
@@ -2,76 +2,79 @@ namespace AssetRipper.SerializationLogic;
 
 public abstract class SerializableType
 {
-	public readonly record struct Field(SerializableType Type, int ArrayDepth, string Name, bool Align)
-	{
-		public override string? ToString()
-		{
-			if (Type == null)
-			{
-				return base.ToString();
-			}
+        public readonly record struct Field(SerializableType Type, int ArrayDepth, string Name, bool Align)
+        {
+                public override string? ToString()
+                {
+                        if (Type == null)
+                        {
+                                return base.ToString();
+                        }
 
-			return $"{Type}{string.Concat(Enumerable.Repeat("[]", ArrayDepth))} {Name}";
-		}
+                        return $"{Type}{string.Concat(Enumerable.Repeat("[]", ArrayDepth))} {Name}";
+                }
 
-		public bool IsArray => ArrayDepth == 1;
-	}
+                public bool IsArray => ArrayDepth == 1;
+        }
 
-	protected SerializableType(string? @namespace, PrimitiveType type, string name)
-	{
-		ArgumentNullException.ThrowIfNull(name);
-		Namespace = @namespace;
-		Type = type;
-		Name = name;
-	}
+        protected SerializableType(string? @namespace, PrimitiveType type, string name)
+        {
+                ArgumentNullException.ThrowIfNull(name);
+                Namespace = @namespace;
+                Type = type;
+                Name = name;
+                HasSerializeReference = type == PrimitiveType.Complex &&
+                        (name == "managedReference" || name == "ReferencedObjectData");
+        }
 
-	public bool IsPrimitive()
-	{
-		return Type.IsCSharpPrimitive();
-	}
+        public bool IsPrimitive()
+        {
+                return Type.IsCSharpPrimitive();
+        }
 
-	public bool IsEngineStruct()
-	{
-		return MonoUtils.IsEngineStruct(Namespace, Name);
-	}
+        public bool IsEngineStruct()
+        {
+                return MonoUtils.IsEngineStruct(Namespace, Name);
+        }
 
-	public bool IsEnginePointer()
-	{
-		return MonoUtils.IsObject(Namespace, Name) || MonoUtils.IsMonoPrime(Namespace, Name);
-	}
+        public bool IsEnginePointer()
+        {
+                return MonoUtils.IsObject(Namespace, Name) || MonoUtils.IsMonoPrime(Namespace, Name);
+        }
 
-	public override string ToString() => FullName;
+        public override string ToString() => FullName;
 
-	public string FullName => string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";
+        public string FullName => string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";
 
-	public string? Namespace { get; }
-	public PrimitiveType Type { get; }
-	public string Name { get; }
-	public IReadOnlyList<Field> Fields { get; protected set; } = [];
-	public virtual int Version => 1;
-	public virtual bool FlowMappedInYaml => false;
-	/// <summary>
-	/// The maximum depth of the structure.
-	/// </summary>
-	/// <remarks>
-	/// A type with no fields has a depth of 0, such as a primitive type, including strings.<br/>
-	/// A type with a single field has a depth of 1 + the depth of that field.<br/>
-	/// Arrays do not increase depth. For example, a type with a string[] field has a depth of 1, not 2.<br/>
-	/// Despite technically having two numeric fields, PPtrs are treated as primitive types with a depth of 0.<br/>
-	/// A negative value means that the depth is not yet known.
-	/// </remarks>
-	public int MaxDepth { get; protected set; } = -1;
-	public bool IsMaxDepthKnown => MaxDepth >= 0;
-	private HashSet<SerializableType>? _cyclicReferences;
+        public string? Namespace { get; }
+        public PrimitiveType Type { get; }
+        public string Name { get; }
+        public IReadOnlyList<Field> Fields { get; protected set; } = [];
+        public virtual int Version => 1;
+        public virtual bool FlowMappedInYaml => false;
+        /// <summary>
+        /// The maximum depth of the structure.
+        /// </summary>
+        /// <remarks>
+        /// A type with no fields has a depth of 0, such as a primitive type, including strings.<br/>
+        /// A type with a single field has a depth of 1 + the depth of that field.<br/>
+        /// Arrays do not increase depth. For example, a type with a string[] field has a depth of 1, not 2.<br/>
+        /// Despite technically having two numeric fields, PPtrs are treated as primitive types with a depth of 0.<br/>
+        /// A negative value means that the depth is not yet known.
+        /// </remarks>
+        public int MaxDepth { get; protected set; } = -1;
+        public bool IsMaxDepthKnown => MaxDepth >= 0;
+        public bool HasSerializeReference { get; protected set; }
+        private HashSet<SerializableType>? _cyclicReferences;
 
-	internal protected void AddCyclicReference(SerializableType other)
-	{
-		_cyclicReferences ??= [];
-		_cyclicReferences.Add(other);
-	}
+        internal protected void AddCyclicReference(SerializableType other)
+        {
+                _cyclicReferences ??= [];
+                _cyclicReferences.Add(other);
+        }
 
-	internal protected bool IsCyclicReference(SerializableType other)
-	{
-		return _cyclicReferences is not null && _cyclicReferences.Contains(other);
-	}
+        internal protected bool IsCyclicReference(SerializableType other)
+        {
+                return _cyclicReferences is not null && _cyclicReferences.Contains(other);
+        }
 }

--- a/Source/AssetRipper.SerializationLogic/SerializableType.cs
+++ b/Source/AssetRipper.SerializationLogic/SerializableType.cs
@@ -62,7 +62,6 @@ public abstract class SerializableType
 	/// </remarks>
 	public int MaxDepth { get; protected set; } = -1;
 	public bool IsMaxDepthKnown => MaxDepth >= 0;
-	public bool HasSerializeReference { get; protected set; }
 	private HashSet<SerializableType>? _cyclicReferences;
 
 	internal protected void AddCyclicReference(SerializableType other)

--- a/Source/AssetRipper.SerializationLogic/SerializableType.cs
+++ b/Source/AssetRipper.SerializationLogic/SerializableType.cs
@@ -23,8 +23,6 @@ public abstract class SerializableType
 		Namespace = @namespace;
 		Type = type;
 		Name = name;
-		HasSerializeReference = type == PrimitiveType.Complex &&
-			(name == "managedReference" || name == "ReferencedObjectData");
 	}
 
 	public bool IsPrimitive()

--- a/Source/AssetRipper.SerializationLogic/SerializableType.cs
+++ b/Source/AssetRipper.SerializationLogic/SerializableType.cs
@@ -2,79 +2,79 @@ namespace AssetRipper.SerializationLogic;
 
 public abstract class SerializableType
 {
-        public readonly record struct Field(SerializableType Type, int ArrayDepth, string Name, bool Align)
-        {
-                public override string? ToString()
-                {
-                        if (Type == null)
-                        {
-                                return base.ToString();
-                        }
+	public readonly record struct Field(SerializableType Type, int ArrayDepth, string Name, bool Align)
+	{
+		public override string? ToString()
+		{
+			if (Type == null)
+			{
+				return base.ToString();
+			}
 
-                        return $"{Type}{string.Concat(Enumerable.Repeat("[]", ArrayDepth))} {Name}";
-                }
+			return $"{Type}{string.Concat(Enumerable.Repeat("[]", ArrayDepth))} {Name}";
+		}
 
-                public bool IsArray => ArrayDepth == 1;
-        }
+		public bool IsArray => ArrayDepth == 1;
+	}
 
-        protected SerializableType(string? @namespace, PrimitiveType type, string name)
-        {
-                ArgumentNullException.ThrowIfNull(name);
-                Namespace = @namespace;
-                Type = type;
-                Name = name;
-                HasSerializeReference = type == PrimitiveType.Complex &&
-                        (name == "managedReference" || name == "ReferencedObjectData");
-        }
+	protected SerializableType(string? @namespace, PrimitiveType type, string name)
+	{
+		ArgumentNullException.ThrowIfNull(name);
+		Namespace = @namespace;
+		Type = type;
+		Name = name;
+		HasSerializeReference = type == PrimitiveType.Complex &&
+			(name == "managedReference" || name == "ReferencedObjectData");
+	}
 
-        public bool IsPrimitive()
-        {
-                return Type.IsCSharpPrimitive();
-        }
+	public bool IsPrimitive()
+	{
+		return Type.IsCSharpPrimitive();
+	}
 
-        public bool IsEngineStruct()
-        {
-                return MonoUtils.IsEngineStruct(Namespace, Name);
-        }
+	public bool IsEngineStruct()
+	{
+		return MonoUtils.IsEngineStruct(Namespace, Name);
+	}
 
-        public bool IsEnginePointer()
-        {
-                return MonoUtils.IsObject(Namespace, Name) || MonoUtils.IsMonoPrime(Namespace, Name);
-        }
+	public bool IsEnginePointer()
+	{
+		return MonoUtils.IsObject(Namespace, Name) || MonoUtils.IsMonoPrime(Namespace, Name);
+	}
 
-        public override string ToString() => FullName;
+	public override string ToString() => FullName;
 
-        public string FullName => string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";
+	public string FullName => string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";
 
-        public string? Namespace { get; }
-        public PrimitiveType Type { get; }
-        public string Name { get; }
-        public IReadOnlyList<Field> Fields { get; protected set; } = [];
-        public virtual int Version => 1;
-        public virtual bool FlowMappedInYaml => false;
-        /// <summary>
-        /// The maximum depth of the structure.
-        /// </summary>
-        /// <remarks>
-        /// A type with no fields has a depth of 0, such as a primitive type, including strings.<br/>
-        /// A type with a single field has a depth of 1 + the depth of that field.<br/>
-        /// Arrays do not increase depth. For example, a type with a string[] field has a depth of 1, not 2.<br/>
-        /// Despite technically having two numeric fields, PPtrs are treated as primitive types with a depth of 0.<br/>
-        /// A negative value means that the depth is not yet known.
-        /// </remarks>
-        public int MaxDepth { get; protected set; } = -1;
-        public bool IsMaxDepthKnown => MaxDepth >= 0;
-        public bool HasSerializeReference { get; protected set; }
-        private HashSet<SerializableType>? _cyclicReferences;
+	public string? Namespace { get; }
+	public PrimitiveType Type { get; }
+	public string Name { get; }
+	public IReadOnlyList<Field> Fields { get; protected set; } = [];
+	public virtual int Version => 1;
+	public virtual bool FlowMappedInYaml => false;
+	/// <summary>
+	/// The maximum depth of the structure.
+	/// </summary>
+	/// <remarks>
+	/// A type with no fields has a depth of 0, such as a primitive type, including strings.<br/>
+	/// A type with a single field has a depth of 1 + the depth of that field.<br/>
+	/// Arrays do not increase depth. For example, a type with a string[] field has a depth of 1, not 2.<br/>
+	/// Despite technically having two numeric fields, PPtrs are treated as primitive types with a depth of 0.<br/>
+	/// A negative value means that the depth is not yet known.
+	/// </remarks>
+	public int MaxDepth { get; protected set; } = -1;
+	public bool IsMaxDepthKnown => MaxDepth >= 0;
+	public bool HasSerializeReference { get; protected set; }
+	private HashSet<SerializableType>? _cyclicReferences;
 
-        internal protected void AddCyclicReference(SerializableType other)
-        {
-                _cyclicReferences ??= [];
-                _cyclicReferences.Add(other);
-        }
+	internal protected void AddCyclicReference(SerializableType other)
+	{
+		_cyclicReferences ??= [];
+		_cyclicReferences.Add(other);
+	}
 
-        internal protected bool IsCyclicReference(SerializableType other)
-        {
-                return _cyclicReferences is not null && _cyclicReferences.Contains(other);
-        }
+	internal protected bool IsCyclicReference(SerializableType other)
+	{
+		return _cyclicReferences is not null && _cyclicReferences.Contains(other);
+	}
 }

--- a/Source/AssetRipper.SerializationLogic/SerializableType.cs
+++ b/Source/AssetRipper.SerializationLogic/SerializableType.cs
@@ -1,4 +1,4 @@
-﻿namespace AssetRipper.SerializationLogic;
+namespace AssetRipper.SerializationLogic;
 
 public abstract class SerializableType
 {

--- a/Source/AssetRipper.Tests/SerializableStructureTests.cs
+++ b/Source/AssetRipper.Tests/SerializableStructureTests.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Import.Structure.Assembly.Serializable;
+using AssetRipper.Import.Structure.Assembly.Serializable;
 using AssetRipper.IO.Endian;
 using AssetRipper.Primitives;
 using AssetRipper.SerializationLogic;
@@ -17,7 +17,7 @@ internal class SerializableStructureTests
 		SerializableStructure structure = serializableType.CreateSerializableStructure();
 		byte[] data = new byte[27 * sizeof(float)];
 		EndianSpanReader reader = new(data, EndianType.LittleEndian);
-		structure.Read(ref reader, new UnityVersion(6000), default);
+		structure.Read(ref reader, new UnityVersion(6000), default, ITypeResolver.Null);
 		Assert.That(reader.Position, Is.EqualTo(data.Length));
 	}
 

--- a/Source/AssetRipper.Tools.JsonSerializer/JsonAssetFactory.cs
+++ b/Source/AssetRipper.Tools.JsonSerializer/JsonAssetFactory.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets;
+using AssetRipper.Assets;
 using AssetRipper.Assets.Exceptions;
 using AssetRipper.Assets.Generics;
 using AssetRipper.Assets.IO;
@@ -10,7 +10,7 @@ namespace AssetRipper.Tools.JsonSerializer;
 
 public sealed class JsonAssetFactory : AssetFactoryBase
 {
-	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType)
+	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedTypeReference> refTypes)
 	{
 		if (assetType?.OldType.Nodes.Count > 0)
 		{

--- a/Source/AssetRipper.Tools.JsonSerializer/JsonAssetFactory.cs
+++ b/Source/AssetRipper.Tools.JsonSerializer/JsonAssetFactory.cs
@@ -10,7 +10,7 @@ namespace AssetRipper.Tools.JsonSerializer;
 
 public sealed class JsonAssetFactory : AssetFactoryBase
 {
-	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedTypeReference> refTypes)
+	public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, IReadOnlyList<SerializedTypeReference> refTypes)
 	{
 		if (assetType?.OldType.Nodes.Count > 0)
 		{

--- a/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
+++ b/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
@@ -157,7 +157,7 @@ internal static class Program
 
 	private sealed class TextureAssetFactory : AssetFactoryBase
 	{
-		public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedTypeReference> refTypes)
+		public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, IReadOnlyList<SerializedTypeReference> refTypes)
 		{
 			IUnityObjectBase? asset = CreateAsset(assetInfo);
 			if (asset is not null)

--- a/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
+++ b/Source/AssetRipper.Tools.RawTextureExtractor/Program.cs
@@ -1,4 +1,4 @@
-﻿using AssetRipper.Assets;
+using AssetRipper.Assets;
 using AssetRipper.Assets.Bundles;
 using AssetRipper.Assets.Collections;
 using AssetRipper.Assets.Generics;
@@ -157,7 +157,7 @@ internal static class Program
 
 	private sealed class TextureAssetFactory : AssetFactoryBase
 	{
-		public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType)
+		public override IUnityObjectBase? ReadAsset(AssetInfo assetInfo, ReadOnlyArraySegment<byte> assetData, SerializedType? assetType, ReadOnlySpan<SerializedTypeReference> refTypes)
 		{
 			IUnityObjectBase? asset = CreateAsset(assetInfo);
 			if (asset is not null)


### PR DESCRIPTION
Reads and decompiles [SerializeReference] fields in mono behaviors 
- I noticed this when I was decompiling a game, it appears to skip it ("MonoBehaviour has a field with the [SerializeReference] attribute, which is not currently supported.") so I just added support for it. 
-Commit one: Added the base support for it
-Commit two: Added back the previous message where it alerts the user that there isn't support for it (commented out)
-Commit three: Moved the code/changed the structure a little bit for easier code editing.
