### PR TITLE
Detect modern Linux players with extensionless executables

### DIFF
--- a/Source/AssetRipper.Import/Platforms/LinuxGameStructure.cs
+++ b/Source/AssetRipper.Import/Platforms/LinuxGameStructure.cs
@@ -85,7 +85,8 @@ internal sealed class LinuxGameStructure : PlatformGameStructure
 		string x86Path = fileSystem.Path.Join(rootPath, gameName + x86Extension);
 		string x64Path = fileSystem.Path.Join(rootPath, gameName + x64Extension);
 		string x86_64Path = fileSystem.Path.Join(rootPath, gameName + x86_64Extension);
-		if (fileSystem.File.Exists(x86Path) || fileSystem.File.Exists(x64Path) || fileSystem.File.Exists(x86_64Path))
+		string unsuffixedPath = fileSystem.Path.Join(rootPath, gameName);
+		if (fileSystem.File.Exists(x86Path) || fileSystem.File.Exists(x64Path) || fileSystem.File.Exists(x86_64Path) || fileSystem.File.Exists(unsuffixedPath))
 		{
 			return true;
 		}
@@ -129,7 +130,7 @@ internal sealed class LinuxGameStructure : PlatformGameStructure
 		foreach (string file in fileSystem.Directory.EnumerateFiles(rootDiectory))
 		{
 			string extension = fileSystem.Path.GetExtension(file);
-			if (extension is x86Extension or x64Extension or x86_64Extension)
+			if (extension is x86Extension or x64Extension or x86_64Extension or "")
 			{
 				name = fileSystem.Path.GetFileNameWithoutExtension(file);
 				string dataFolder = $"{name}_{DataFolderName}";

--- a/Source/AssetRipper.Tests/LinuxGameStructureTests.cs
+++ b/Source/AssetRipper.Tests/LinuxGameStructureTests.cs
@@ -1,0 +1,74 @@
+using AssetRipper.Import.Platforms;
+using AssetRipper.Import.Structure.Platforms;
+using AssetRipper.IO.Files;
+
+namespace AssetRipper.Tests;
+
+public class LinuxGameStructureTests
+{
+	private const string GameName = "Some Game";
+	private const string DataFolder = $"{GameName}_Data";
+
+	private static VirtualFileSystem CreateFileSystem(string root, string executableName)
+	{
+		VirtualFileSystem fs = new();
+		fs.Directory.Create(root);
+		string dataPath = fs.Path.Join(root, DataFolder);
+		fs.Directory.Create(dataPath);
+		fs.File.WriteAllBytes(fs.Path.Join(root, "UnityPlayer.so"), [0]);
+		fs.File.WriteAllBytes(fs.Path.Join(root, executableName), [0]);
+		return fs;
+	}
+
+	private static PlatformGameStructure? Detect(VirtualFileSystem fs, string inputPath)
+	{
+		List<string> paths = [inputPath];
+		PlatformChecker.CheckPlatform(paths, fs, out PlatformGameStructure? platform, out _);
+		return platform;
+	}
+
+	[Test]
+	public void ExtensionlessExecutableIsDetectedAsLinux()
+	{
+		const string root = "/game";
+		VirtualFileSystem fs = CreateFileSystem(root, GameName); // no extension
+		PlatformGameStructure? platform = Detect(fs, root);
+
+		using (Assert.EnterMultipleScope())
+		{
+			Assert.That(platform, Is.Not.Null);
+			Assert.That(platform!.GetType().Name, Is.EqualTo("LinuxGameStructure"));
+			Assert.That(platform.StreamingAssetsPath, Is.EqualTo(fs.Path.Join(root, DataFolder, "StreamingAssets")));
+		}
+	}
+
+	[Test]
+	public void OldX86_64ExecutableIsDetectedAsLinux()
+	{
+		const string root = "/game";
+		VirtualFileSystem fs = CreateFileSystem(root, $"{GameName}.x86_64");
+		PlatformGameStructure? platform = Detect(fs, root);
+
+		using (Assert.EnterMultipleScope())
+		{
+			Assert.That(platform, Is.Not.Null);
+			Assert.That(platform!.GetType().Name, Is.EqualTo("LinuxGameStructure"));
+			Assert.That(platform.StreamingAssetsPath, Is.EqualTo(fs.Path.Join(root, DataFolder, "StreamingAssets")));
+		}
+	}
+
+	[Test]
+	public void DataDirectoryGivenDirectlyIsDetectedAsLinux()
+	{
+		const string root = "/game";
+		VirtualFileSystem fs = CreateFileSystem(root, GameName); // no extension
+		PlatformGameStructure? platform = Detect(fs, fs.Path.Join(root, DataFolder));
+
+		using (Assert.EnterMultipleScope())
+		{
+			Assert.That(platform, Is.Not.Null);
+			Assert.That(platform!.GetType().Name, Is.EqualTo("LinuxGameStructure"));
+			Assert.That(platform.StreamingAssetsPath, Is.EqualTo(fs.Path.Join(root, DataFolder, "StreamingAssets")));
+		}
+	}
+}


### PR DESCRIPTION
Seems like modern unity versions (I tested 6000.0.50) generate linux executables without the `.x86_64` extension, for example
```
Hollow Knight Silksong # binary
Hollow Knight Silksong_Data # data dir
```


This resulted in StreamingAssets/ not being copied in the game export.