### PR TITLE
Fix negative integer YAML hex encoding

### DIFF
--- a/Source/AssetRipper.Yaml.Tests/YamlScalarNodeTests.cs
+++ b/Source/AssetRipper.Yaml.Tests/YamlScalarNodeTests.cs
@@ -56,7 +56,13 @@ public class YamlScalarNodeTests
 	public void UInt32ListTest() => NumericListTest<uint>([ 0x01020304, 0x05060708 ], "0403020108070605");
 
 	[Test]
+	public void Int32ListTest() => NumericListTest<int>([-1, unchecked((int)0xB0000000), int.MinValue], "ffffffff000000b000000080");
+
+	[Test]
 	public void UInt64ListTest() => NumericListTest<ulong>([ 0x0102030405060708, 0x090A0B0C0D0E0F10 ], "0807060504030201100f0e0d0c0b0a09");
+
+	[Test]
+	public void Int64ListTest() => NumericListTest<long>([-1L, long.MinValue], "ffffffffffffffff0000000000000080");
 
 	private static void NumericListTest<T>(IReadOnlyList<T> list, string expected) where T : unmanaged, INumber<T>
 	{

--- a/Source/AssetRipper.Yaml/Extensions/ReverseHexString.cs
+++ b/Source/AssetRipper.Yaml/Extensions/ReverseHexString.cs
@@ -26,19 +26,19 @@ internal static class ReverseHexString
 		}
 		else if (typeof(T) == typeof(int) || typeof(T) == typeof(uint))
 		{
-			int x = Unsafe.As<T, int>(ref value);
+			uint x = Unsafe.As<T, uint>(ref value);
 			buffer[0] = NybbleToLowercaseHexCharacter((x >> 4) & 0x0F);
 			buffer[1] = NybbleToLowercaseHexCharacter(x & 0x0F);
 			buffer[2] = NybbleToLowercaseHexCharacter((x >> 12) & 0x0F);
 			buffer[3] = NybbleToLowercaseHexCharacter((x >> 8) & 0x0F);
 			buffer[4] = NybbleToLowercaseHexCharacter((x >> 20) & 0x0F);
 			buffer[5] = NybbleToLowercaseHexCharacter((x >> 16) & 0x0F);
-			buffer[6] = NybbleToLowercaseHexCharacter((x >> 28) & 0x0F);
+			buffer[6] = NybbleToLowercaseHexCharacter(x >> 28);
 			buffer[7] = NybbleToLowercaseHexCharacter((x >> 24) & 0x0F);
 		}
 		else if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
 		{
-			long x = Unsafe.As<T, long>(ref value);
+			ulong x = Unsafe.As<T, ulong>(ref value);
 			buffer[0] = NybbleToLowercaseHexCharacter((x >> 4) & 0x0F);
 			buffer[1] = NybbleToLowercaseHexCharacter(x & 0x0F);
 			buffer[2] = NybbleToLowercaseHexCharacter((x >> 12) & 0x0F);
@@ -53,7 +53,7 @@ internal static class ReverseHexString
 			buffer[11] = NybbleToLowercaseHexCharacter((x >> 40) & 0x0F);
 			buffer[12] = NybbleToLowercaseHexCharacter((x >> 52) & 0x0F);
 			buffer[13] = NybbleToLowercaseHexCharacter((x >> 48) & 0x0F);
-			buffer[14] = NybbleToLowercaseHexCharacter((x >> 60) & 0x0F);
+			buffer[14] = NybbleToLowercaseHexCharacter(x >> 60);
 			buffer[15] = NybbleToLowercaseHexCharacter((x >> 56) & 0x0F);
 		}
 		else if (typeof(T) == typeof(float))

--- a/Source/AssetRipper.Yaml/Extensions/ReverseHexString.cs
+++ b/Source/AssetRipper.Yaml/Extensions/ReverseHexString.cs
@@ -77,4 +77,5 @@ internal static class ReverseHexString
 		return unchecked((char)(x + Zero + ((9 - x) >> 31 & Offset)));
 	}
 	private static char NybbleToLowercaseHexCharacter(long x) => NybbleToLowercaseHexCharacter(unchecked((int)x));
+	private static char NybbleToLowercaseHexCharacter(ulong x) => NybbleToLowercaseHexCharacter(unchecked((int)x));
 }

--- a/Source/AssetRipper.Yaml/Extensions/ReverseHexString.cs
+++ b/Source/AssetRipper.Yaml/Extensions/ReverseHexString.cs
@@ -33,7 +33,7 @@ internal static class ReverseHexString
 			buffer[3] = NybbleToLowercaseHexCharacter((x >> 8) & 0x0F);
 			buffer[4] = NybbleToLowercaseHexCharacter((x >> 20) & 0x0F);
 			buffer[5] = NybbleToLowercaseHexCharacter((x >> 16) & 0x0F);
-			buffer[6] = NybbleToLowercaseHexCharacter(x >> 28);
+			buffer[6] = NybbleToLowercaseHexCharacter((x >> 28) & 0x0F);
 			buffer[7] = NybbleToLowercaseHexCharacter((x >> 24) & 0x0F);
 		}
 		else if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
@@ -53,7 +53,7 @@ internal static class ReverseHexString
 			buffer[11] = NybbleToLowercaseHexCharacter((x >> 40) & 0x0F);
 			buffer[12] = NybbleToLowercaseHexCharacter((x >> 52) & 0x0F);
 			buffer[13] = NybbleToLowercaseHexCharacter((x >> 48) & 0x0F);
-			buffer[14] = NybbleToLowercaseHexCharacter(x >> 60);
+			buffer[14] = NybbleToLowercaseHexCharacter((x >> 60) & 0x0F);
 			buffer[15] = NybbleToLowercaseHexCharacter((x >> 56) & 0x0F);
 		}
 		else if (typeof(T) == typeof(float))

--- a/Source/AssetRipper.Yaml/Extensions/ReverseHexString.cs
+++ b/Source/AssetRipper.Yaml/Extensions/ReverseHexString.cs
@@ -76,6 +76,5 @@ internal static class ReverseHexString
 		const int Offset = (int)'a' - Zero - 0x0A;
 		return unchecked((char)(x + Zero + ((9 - x) >> 31 & Offset)));
 	}
-	private static char NybbleToLowercaseHexCharacter(long x) => NybbleToLowercaseHexCharacter(unchecked((int)x));
 	private static char NybbleToLowercaseHexCharacter(ulong x) => NybbleToLowercaseHexCharacter(unchecked((int)x));
 }


### PR DESCRIPTION
Negative integer values were written with non-hex characters in serialized YAML byte arrays because the most significant nibble was sign-extended.

This corrupted Avatar humanoid index tables containing sentinel values such as `-1`, producing values such as `ffffff/f`.

Mask the most significant nibble for 32-bit and 64-bit values and add regression coverage for negative values.

Tests: `dotnet test Source/AssetRipper.Yaml.Tests/AssetRipper.Yaml.Tests.csproj`