### PR TITLE
Small bugfixes for AnimationClip and AnimatorController

### DIFF
--- a/Source/AssetRipper.Processing/AnimationClips/PathChecksumCache.cs
+++ b/Source/AssetRipper.Processing/AnimationClips/PathChecksumCache.cs
@@ -40,7 +40,6 @@ public readonly struct PathChecksumCache
 		if (avatar != null)
 		{
 			AddAvatarTOS(avatar);
-			return;
 		}
 
 		if (animator.Has_HasTransformHierarchy() && !animator.HasTransformHierarchy)

--- a/Source/AssetRipper.Processing/AnimatorControllers/AnimatorControllerProcessor.cs
+++ b/Source/AssetRipper.Processing/AnimatorControllers/AnimatorControllerProcessor.cs
@@ -76,8 +76,11 @@ public sealed class AnimatorControllerProcessor : IAssetProcessor
 
 			foreach (IUnityObjectBase asset in controller.FetchEditorHierarchy().WhereNotNull())
 			{
-				Debug.Assert(asset.MainAsset is null);
-				asset.MainAsset = controller;
+				if (asset.MainAsset != controller)
+				{
+					Debug.Assert(asset.MainAsset is null);
+					asset.MainAsset = controller;
+				}
 			}
 		}
 	}

--- a/Source/AssetRipper.Processing/AnimatorControllers/AnimatorControllerProcessor.cs
+++ b/Source/AssetRipper.Processing/AnimatorControllers/AnimatorControllerProcessor.cs
@@ -68,8 +68,10 @@ public sealed class AnimatorControllerProcessor : IAssetProcessor
 					MultipleReplacementAssetResolver resolver = new(cloneMap);
 					foreach (IUnityObjectBase originalAsset in claimedAssets)
 					{
-						IUnityObjectBase targetAsset = cloneMap.TryGetValue(originalAsset, out IUnityObjectBase? clonedAsset) ? clonedAsset : originalAsset;
-						targetAsset.CopyValues(originalAsset, new PPtrConverter(originalAsset.Collection, targetAsset.Collection, resolver));
+						if (cloneMap.TryGetValue(originalAsset, out IUnityObjectBase? clonedAsset))
+						{
+							clonedAsset.CopyValues(originalAsset, new PPtrConverter(originalAsset.Collection, clonedAsset.Collection, resolver));
+						}
 					}
 				}
 			}


### PR DESCRIPTION
1) **Allow Animator using Avatar to also cache its GameObject hierarchy paths, for AnimationClip path resolution**.
The Avatar asset used in a character's Animator Component only contains GameObject paths of its original hierarchy, it doesn't include new GameObjects added to the character on the Unity Editor.

2) **Assert and assign a sub-asset's MainAsset only if not correctly set before**.
When arriving to the assertion, I found StateMachineBehaviours (IMonoBehaviours) have already been set their correct MainAsset (couldn't find where this happened in code), and so the assertion would incorrectly raise an error.

3) **Prevent asset copying values from itself (asset wasn't cloned)**.